### PR TITLE
Better synchronization for multiple initialization from different threads. Add logging when ConcurrentModificationException is thrown from ConcurrentCompositeConfiguration.getKeys(). 

### DIFF
--- a/archaius-core/src/main/java/com/netflix/config/ConfigurationBackedDynamicPropertySupportImpl.java
+++ b/archaius-core/src/main/java/com/netflix/config/ConfigurationBackedDynamicPropertySupportImpl.java
@@ -24,6 +24,9 @@ public class ConfigurationBackedDynamicPropertySupportImpl implements DynamicPro
     private final AbstractConfiguration config;
         
     public ConfigurationBackedDynamicPropertySupportImpl(AbstractConfiguration config) {
+        if (config == null) {
+            throw new NullPointerException("config is null");
+        }
         this.config = config;
     }
     

--- a/archaius-core/src/main/java/com/netflix/config/DynamicProperty.java
+++ b/archaius-core/src/main/java/com/netflix/config/DynamicProperty.java
@@ -501,6 +501,7 @@ public class DynamicProperty {
                 return false;
             }
         } catch (Exception e) {
+            e.printStackTrace();
             logger.error("Unable to update property: " + propName, e);
             return false;
         }

--- a/archaius-core/src/test/java/com/netflix/config/InitWithNullConfigTest.java
+++ b/archaius-core/src/test/java/com/netflix/config/InitWithNullConfigTest.java
@@ -1,0 +1,31 @@
+package com.netflix.config;
+
+import static org.junit.Assert.*;
+
+import org.apache.commons.configuration.AbstractConfiguration;
+import org.apache.commons.configuration.BaseConfiguration;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class InitWithNullConfigTest {
+    
+    @BeforeClass
+    public static void init() {
+        System.setProperty(DynamicPropertyFactory.DISABLE_DEFAULT_CONFIG, "true");
+    }
+    
+    @Test
+    public void testCreateProperty() {
+        try {
+            DynamicPropertyFactory.initWithConfigurationSource((AbstractConfiguration) null);
+            fail("NPE expected");
+        } catch (NullPointerException e) {
+            assertNotNull(e);
+        }
+        DynamicBooleanProperty prop = DynamicPropertyFactory.getInstance().getBooleanProperty("abc", false);
+        BaseConfiguration baseConfig = new BaseConfiguration();
+        DynamicPropertyFactory.initWithConfigurationSource(baseConfig);
+        baseConfig.setProperty("abc", "true");
+        assertTrue(prop.get());
+    }
+}

--- a/archaius-core/src/test/java/com/netflix/config/MultiThreadedInit.java
+++ b/archaius-core/src/test/java/com/netflix/config/MultiThreadedInit.java
@@ -1,0 +1,39 @@
+package com.netflix.config;
+
+import static org.junit.Assert.*;
+
+import java.util.Random;
+
+import org.apache.commons.configuration.BaseConfiguration;
+import org.junit.Test;
+
+public class MultiThreadedInit {
+
+
+    @Test
+    public void test() {
+        final BaseConfiguration baseConfig = new BaseConfiguration();
+        baseConfig.setProperty("abc", 1);
+        (new Thread() {
+            public void run() {
+                Random r = new Random();
+                while (DynamicPropertyFactory.getBackingConfigurationSource() != baseConfig) {
+                    try {
+                        Thread.sleep(r.nextInt(100) + 1);
+                    } catch (InterruptedException e) {} 
+                    System.setProperty(DynamicPropertyFactory.DISABLE_DEFAULT_CONFIG, "true");
+                    ConfigurationManager.install(baseConfig);
+                }
+            }
+        }).start();
+        Object config = null;
+        DynamicIntProperty prop = DynamicPropertyFactory.getInstance().getIntProperty("abc", 0);
+        while ((config = DynamicPropertyFactory.getBackingConfigurationSource()) != baseConfig && prop.get() != 1) {            
+            // prop = DynamicPropertyFactory.getInstance().getIntProperty("abc", 0);
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException e) {}
+        }
+        
+    }
+}

--- a/archaius-core/src/test/java/com/netflix/config/PropertyListenerTest.java
+++ b/archaius-core/src/test/java/com/netflix/config/PropertyListenerTest.java
@@ -1,0 +1,32 @@
+package com.netflix.config;
+
+import static org.junit.Assert.*;
+
+import org.apache.commons.configuration.AbstractConfiguration;
+import org.junit.Test;
+
+public class PropertyListenerTest {
+    
+    @Test
+    public void testAddPropertyListener() {
+        AbstractConfiguration config = ConfigurationManager.getConfigInstance();
+        config.addConfigurationListener(new ExpandedConfigurationListenerAdapter(new MyListener()));
+        config.addConfigurationListener(new MyListener());
+        config.setProperty("xyz", "abcc");
+        assertEquals(2, MyListener.count);
+    }
+
+}
+
+class MyListener extends AbstractDynamicPropertyListener {
+    static int count = 0;
+
+    @Override
+    public void handlePropertyEvent(String arg0, Object arg1, EventType arg2) {
+        incrementCount();
+    }   
+    
+    private void incrementCount() {
+        count++;
+    }
+}


### PR DESCRIPTION
...s. Add logging when ConcurrentModificationException is thrown from ConcurrentCompositeConfiguration.getKeys().
