### PR TITLE
Add the functionality of dynamic properties change validation

### DIFF
--- a/archaius-core/src/main/java/com/netflix/config/AbstractPollingScheduler.java
+++ b/archaius-core/src/main/java/com/netflix/config/AbstractPollingScheduler.java
@@ -31,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.netflix.config.PollListener.EventType;
+import com.netflix.config.validation.ValidationException;
 
 
 /**
@@ -150,17 +151,22 @@ public abstract class AbstractPollingScheduler {
     }
     
     private void addOrChangeProperty(String name, Object newValue, final Configuration config) {
-        if (!config.containsKey(name)) {
-            config.addProperty(name, newValue);
-        } else {
-            Object oldValue = config.getProperty(name);
-            if (newValue != null) {
-                if (!newValue.equals(oldValue)) {
-                    config.setProperty(name, newValue);
+        // We do not want to abort the operation due to failed validation on one property
+        try {
+            if (!config.containsKey(name)) {
+                config.addProperty(name, newValue);
+            } else {
+                Object oldValue = config.getProperty(name);
+                if (newValue != null) {
+                    if (!newValue.equals(oldValue)) {
+                        config.setProperty(name, newValue);
+                    }
+                } else if (oldValue != null) {
+                    config.setProperty(name, null);                
                 }
-            } else if (oldValue != null) {
-                config.setProperty(name, null);                
             }
+        } catch (ValidationException e) {
+            log.error("Validation failed for property " + name, e);
         }
     }
     

--- a/archaius-core/src/main/java/com/netflix/config/DynamicBooleanProperty.java
+++ b/archaius-core/src/main/java/com/netflix/config/DynamicBooleanProperty.java
@@ -25,7 +25,7 @@ package com.netflix.config;
  *
  */
 public class DynamicBooleanProperty extends PropertyWrapper<Boolean> {
-    DynamicBooleanProperty(String propName, boolean defaultValue) {
+    protected DynamicBooleanProperty(String propName, boolean defaultValue) {
         super(propName, Boolean.valueOf(defaultValue));
     }
     /**

--- a/archaius-core/src/main/java/com/netflix/config/DynamicDoubleProperty.java
+++ b/archaius-core/src/main/java/com/netflix/config/DynamicDoubleProperty.java
@@ -26,7 +26,7 @@ package com.netflix.config;
  *
  */
 public class DynamicDoubleProperty extends PropertyWrapper<Double> {
-    DynamicDoubleProperty(String propName, double defaultValue) {
+    protected DynamicDoubleProperty(String propName, double defaultValue) {
         super(propName, Double.valueOf(defaultValue));
     }
         

--- a/archaius-core/src/main/java/com/netflix/config/DynamicFloatProperty.java
+++ b/archaius-core/src/main/java/com/netflix/config/DynamicFloatProperty.java
@@ -23,8 +23,9 @@ package com.netflix.config;
  * 
  * @author awang
  *
- */public class DynamicFloatProperty extends PropertyWrapper<Float> {
-    DynamicFloatProperty(String propName, float defaultValue) {
+ */
+public class DynamicFloatProperty extends PropertyWrapper<Float> {
+    protected DynamicFloatProperty(String propName, float defaultValue) {
         super(propName, Float.valueOf(defaultValue));
     }
     /**

--- a/archaius-core/src/main/java/com/netflix/config/DynamicIntProperty.java
+++ b/archaius-core/src/main/java/com/netflix/config/DynamicIntProperty.java
@@ -27,7 +27,7 @@ import com.netflix.config.PropertyWrapper;
  *
  */
 public class DynamicIntProperty extends PropertyWrapper<Integer> {
-    DynamicIntProperty(String propName, int defaultValue) {
+    protected DynamicIntProperty(String propName, int defaultValue) {
         super(propName, Integer.valueOf(defaultValue));
     }
         

--- a/archaius-core/src/main/java/com/netflix/config/DynamicLongProperty.java
+++ b/archaius-core/src/main/java/com/netflix/config/DynamicLongProperty.java
@@ -25,7 +25,7 @@ package com.netflix.config;
  *
  */
 public class DynamicLongProperty extends PropertyWrapper<Long> {
-    DynamicLongProperty(String propName, long defaultValue) {
+    protected DynamicLongProperty(String propName, long defaultValue) {
         super(propName, Long.valueOf(defaultValue));
     }
         

--- a/archaius-core/src/main/java/com/netflix/config/DynamicStringProperty.java
+++ b/archaius-core/src/main/java/com/netflix/config/DynamicStringProperty.java
@@ -26,7 +26,7 @@ package com.netflix.config;
  */
 public class DynamicStringProperty extends PropertyWrapper<String> {
 
-    DynamicStringProperty(String propName, String defaultValue) {
+    protected DynamicStringProperty(String propName, String defaultValue) {
         super(propName, defaultValue);
     }
 

--- a/archaius-core/src/main/java/com/netflix/config/validation/PropertyChangeValidator.java
+++ b/archaius-core/src/main/java/com/netflix/config/validation/PropertyChangeValidator.java
@@ -1,0 +1,6 @@
+package com.netflix.config.validation;
+
+public interface PropertyChangeValidator {
+    
+    public boolean validate(String newValue);
+}

--- a/archaius-core/src/main/java/com/netflix/config/validation/ValidationException.java
+++ b/archaius-core/src/main/java/com/netflix/config/validation/ValidationException.java
@@ -1,0 +1,27 @@
+package com.netflix.config.validation;
+
+public class ValidationException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public ValidationException() {
+        super();
+        // TODO Auto-generated constructor stub
+    }
+
+    public ValidationException(String arg0, Throwable arg1) {
+        super(arg0, arg1);
+        // TODO Auto-generated constructor stub
+    }
+
+    public ValidationException(String arg0) {
+        super(arg0);
+        // TODO Auto-generated constructor stub
+    }
+
+    public ValidationException(Throwable arg0) {
+        super(arg0);
+        // TODO Auto-generated constructor stub
+    }
+
+}

--- a/archaius-core/src/test/java/com/netflix/config/sources/ValidationTest.java
+++ b/archaius-core/src/test/java/com/netflix/config/sources/ValidationTest.java
@@ -1,0 +1,39 @@
+package com.netflix.config.sources;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import com.netflix.config.ConcurrentCompositeConfiguration;
+import com.netflix.config.ConfigurationManager;
+import com.netflix.config.DynamicStringProperty;
+import com.netflix.config.validation.ValidationException;
+
+public class ValidationTest {
+    
+    @Test
+    public void testValidation() {
+        DynamicStringProperty prop = new DynamicStringProperty("abc", "default") {
+            public boolean validate(String newValue) {
+                return false;
+            }
+        };
+        try {
+            ConfigurationManager.getConfigInstance().setProperty("abc", "new");
+            fail("ValidationException expected");
+        } catch (ValidationException e) {
+            assertNotNull(e);
+        }
+        assertEquals("default", prop.get());
+        assertNull(ConfigurationManager.getConfigInstance().getProperty("abc"));
+        
+        try {
+            ConfigurationManager.getConfigInstance().addProperty("abc", "new");
+            fail("ValidationException expected");
+        } catch (ValidationException e) {
+            assertNotNull(e);
+        }
+        assertEquals("default", prop.get());
+        assertNull(ConfigurationManager.getConfigInstance().getProperty("abc"));
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 // Establish version and status
-ext.releaseVersion = '0.5.1'
+ext.releaseVersion = '0.5.2'
 ext.githubProjectName = 'archaius'
 //group = 'com.netflix.archaius'
 


### PR DESCRIPTION
Dynamic properties should be able to validate property change and reject invalid changes. The rejection will cause the underlying configuration to also reject property change. This can be done by overriding PropertyWrapper.validate() or add validator callback when dynamic properties are created, for example:

DynamicStringProperty prop = new DynamicStringProperty("abc", "default") {
            public boolean validate(String newValue) {
                // carry out validation logic
            }
        };

The implementation of validation is done through the configuration's "beforeUpdate" notification. If false is returned from validation, ConcurrentMapConfiguration.setProperty or addProperty will stop continuing setting the property.
