### PR TITLE
Changing the PropertyChangeValidator interface to throw ValidationException instead of return boolean so that the message can be more descriptive and ease handling of validation failures.

### DIFF
--- a/archaius-core/src/main/java/com/netflix/config/AbstractPollingScheduler.java
+++ b/archaius-core/src/main/java/com/netflix/config/AbstractPollingScheduler.java
@@ -166,7 +166,7 @@ public abstract class AbstractPollingScheduler {
                 }
             }
         } catch (ValidationException e) {
-            log.error("Validation failed for property " + name, e);
+            log.warn("Validation failed for property " + name, e);
         }
     }
     

--- a/archaius-core/src/main/java/com/netflix/config/DynamicProperty.java
+++ b/archaius-core/src/main/java/com/netflix/config/DynamicProperty.java
@@ -506,12 +506,11 @@ public class DynamicProperty {
     private void validate(String newValue) {
         for (PropertyChangeValidator v: validators) {
             try {
-                if (!v.validate(newValue)) {
-                    throw new ValidationException("Validation failed from validator " 
-                            + v.getClass().getName() + " for value " + newValue);
-                }
+                v.validate(newValue);
+            } catch (ValidationException e) {
+                throw e;
             } catch (Throwable e) {
-                throw new ValidationException("Unexpected exception from validator " + v.getClass().getName(), e);
+                throw new ValidationException("Unexpected exception during validation", e);
             }
         }
     }

--- a/archaius-core/src/main/java/com/netflix/config/PropertyWrapper.java
+++ b/archaius-core/src/main/java/com/netflix/config/PropertyWrapper.java
@@ -75,8 +75,8 @@ public abstract class PropertyWrapper<V> {
             });
             this.prop.addValidator(new PropertyChangeValidator() {                
                 @Override
-                public boolean validate(String newValue) {
-                    return PropertyWrapper.this.validate(newValue);
+                public void validate(String newValue) {
+                    PropertyWrapper.this.validate(newValue);
                 }
             });
         }
@@ -110,8 +110,7 @@ public abstract class PropertyWrapper<V> {
         // by default, do nothing
     }
 
-    protected boolean validate(String newValue) {
-        return true;
+    protected void validate(String newValue) {
     }
     
     /**

--- a/archaius-core/src/main/java/com/netflix/config/validation/PropertyChangeValidator.java
+++ b/archaius-core/src/main/java/com/netflix/config/validation/PropertyChangeValidator.java
@@ -2,5 +2,5 @@ package com.netflix.config.validation;
 
 public interface PropertyChangeValidator {
     
-    public boolean validate(String newValue);
+    public void validate(String newValue) throws ValidationException;
 }

--- a/archaius-core/src/test/java/com/netflix/config/DynamicFileConfigurationTest.java
+++ b/archaius-core/src/test/java/com/netflix/config/DynamicFileConfigurationTest.java
@@ -29,6 +29,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.netflix.config.sources.URLConfigurationSource;
+import com.netflix.config.validation.ValidationException;
 
 import static org.junit.Assert.*;
 
@@ -103,11 +104,10 @@ public class DynamicFileConfigurationTest {
 
         DynamicIntProperty validatedProp = new DynamicIntProperty("abc", 0) {
             @Override
-            public boolean validate(String newValue) {
-                if (Integer.parseInt(newValue) >= 0) {
-                    return true;
+            public void validate(String newValue) {
+                if (Integer.parseInt(newValue) < 0) {
+                    throw new ValidationException("Cannot be negative");
                 }
-                return false;
             }
         };
         assertEquals(0, validatedProp.get());

--- a/archaius-core/src/test/java/com/netflix/config/sources/ValidationTest.java
+++ b/archaius-core/src/test/java/com/netflix/config/sources/ValidationTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.*;
 
 import org.junit.Test;
 
-import com.netflix.config.ConcurrentCompositeConfiguration;
 import com.netflix.config.ConfigurationManager;
 import com.netflix.config.DynamicStringProperty;
 import com.netflix.config.validation.ValidationException;
@@ -14,8 +13,8 @@ public class ValidationTest {
     @Test
     public void testValidation() {
         DynamicStringProperty prop = new DynamicStringProperty("abc", "default") {
-            public boolean validate(String newValue) {
-                return false;
+            public void validate(String newValue) {
+                throw new ValidationException("failed");
             }
         };
         try {


### PR DESCRIPTION
...ion instead of return boolean so that the message can be more descriptive and ease handling of validation failures.
