### PR TITLE
Fix issue with IAM role credentials and default constructor for DynamoDBConfigurationSource

### DIFF
--- a/archaius-aws/src/main/java/com/netflix/config/sources/DynamoDbConfigurationSource.java
+++ b/archaius-aws/src/main/java/com/netflix/config/sources/DynamoDbConfigurationSource.java
@@ -17,7 +17,9 @@
  */
 package com.netflix.config.sources;
 
+import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.services.dynamodb.AmazonDynamoDB;
 import com.amazonaws.services.dynamodb.AmazonDynamoDBClient;
@@ -64,11 +66,27 @@ public class DynamoDbConfigurationSource implements PolledConfigurationSource {
     private AmazonDynamoDB dbClient;
 
     public DynamoDbConfigurationSource() {
-        this(new DefaultAWSCredentialsProviderChain().getCredentials());
+        this(new AmazonDynamoDBClient());
     }
 
-    public DynamoDbConfigurationSource(AWSCredentials credentials) {
-        this(new AmazonDynamoDBClient(credentials));
+    public DynamoDbConfigurationSource(ClientConfiguration clientConfiguration) {
+        this(new AmazonDynamoDBClient(clientConfiguration));
+    }
+
+    public DynamoDbConfigurationSource(AWSCredentials awsCredentials) {
+        this(new AmazonDynamoDBClient(awsCredentials));
+    }
+
+    public DynamoDbConfigurationSource(AWSCredentials awsCredentials, ClientConfiguration clientConfiguration) {
+        this(new AmazonDynamoDBClient(awsCredentials, clientConfiguration));
+    }
+
+    public DynamoDbConfigurationSource(AWSCredentialsProvider awsCredentialsProvider) {
+        this(new AmazonDynamoDBClient(awsCredentialsProvider));
+    }
+
+    public DynamoDbConfigurationSource(AWSCredentialsProvider awsCredentialsProvider, ClientConfiguration clientConfiguration) {
+        this(new AmazonDynamoDBClient(awsCredentialsProvider, clientConfiguration));
     }
 
     public DynamoDbConfigurationSource(AmazonDynamoDB dbClient) {


### PR DESCRIPTION
The DynamoDbConfigurationSource's default constructor will getCredentials from DefaultAWSCredentialsProviderChain, which is fine if the credentials are in environment variables or system properties. Unfortunately with IAM roles, the credentials will expire, and since the credentials rather than the credentials provider was used to create the AmazonDynamoDBClient, eventually there will be an issue.

This pull request instead uses the the credentials provider instead of just the credentials. In addition, new constructors have been added DynamoDbConfigurationSource to mirror the constructors of AmazonDynamoDBClient, so end users can specify AWSCredentialsProviders and ClientConfigurations if they so desire.
