### PR TITLE
Merged contextKey and contextValue into one field.

### DIFF
--- a/archaius-aws/src/main/java/com/netflix/config/sources/DynamoDbDeploymentContextTableCache.java
+++ b/archaius-aws/src/main/java/com/netflix/config/sources/DynamoDbDeploymentContextTableCache.java
@@ -35,7 +35,7 @@ import com.netflix.config.sources.AbstractDynamoDbConfigurationSource;
  * having to load the table separately.
  */
 public class DynamoDbDeploymentContextTableCache extends AbstractDynamoDbConfigurationSource<PropertyWithDeploymentContext> {
-    private static Logger log = LoggerFactory.getLogger(AbstractPollingScheduler.class);
+    private static Logger log = LoggerFactory.getLogger(DynamoDbDeploymentContextTableCache.class);
 
     //Property names
     static final String contextKeyAttributePropertyName = "com.netflix.config.dynamo.contextAttributeName";
@@ -195,7 +195,7 @@ public class DynamoDbDeploymentContextTableCache extends AbstractDynamoDbConfigu
         executor = Executors.newScheduledThreadPool(1, new ThreadFactory() {
             @Override
             public Thread newThread(Runnable r) {
-                Thread t = new Thread(r, "pollingConfigurationSource");
+                Thread t = new Thread(r, "pollingDynamoTableCache");
                 t.setDaemon(true);
                 return t;
             }
@@ -221,7 +221,7 @@ public class DynamoDbDeploymentContextTableCache extends AbstractDynamoDbConfigu
     private Runnable getPollingRunnable() {
         return new Runnable() {
             public void run() {
-                log.debug("Polling started");
+                log.debug("Dynamo cached polling started");
                 try {
                     Map<String, PropertyWithDeploymentContext> newMap = loadPropertiesFromTable(tableName.get());
                     cachedTable = newMap;


### PR DESCRIPTION
This is related to issue #97 and issue #98 that I reported recently. Changing the structure of the DynamoDB table so that contextKey and contextValue are stored in the same field should fix the problem of issue #98.

Fixing the problem with global attributes (as mentioned in issue #97) was just a byproduct.
