### PR TITLE
archaius-aws: Merged contextKey and contextValue into one field

### DIFF
--- a/archaius-aws/src/main/java/com/netflix/config/PropertyWithDeploymentContext.java
+++ b/archaius-aws/src/main/java/com/netflix/config/PropertyWithDeploymentContext.java
@@ -54,10 +54,11 @@ public class PropertyWithDeploymentContext {
 
     @Override
     public int hashCode() {
-        int result = contextKey.hashCode();
-        result = 31 * result + contextValue.hashCode();
-        result = 31 * result + propertyName.hashCode();
+        int result = propertyName.hashCode();
         result = 31 * result + propertyValue.hashCode();
+        result = 31 * result + (contextKey != null ? contextKey.hashCode() : 0);
+        result = 31 * result + (contextValue != null ? contextValue.hashCode() : 0);
+         
         return result;
     }
 }

--- a/archaius-aws/src/test/java/com/netflix/config/PropertyWithDeploymentContextTest.java
+++ b/archaius-aws/src/test/java/com/netflix/config/PropertyWithDeploymentContextTest.java
@@ -1,0 +1,11 @@
+package com.netflix.config;
+
+import org.junit.Test;
+
+public class PropertyWithDeploymentContextTest {
+	@Test
+	public void verifyHashCodeSucceedsForGlobalProperty() {
+		PropertyWithDeploymentContext property = new PropertyWithDeploymentContext(null, null, "key", "value");
+		property.hashCode();
+	}
+}

--- a/archaius-aws/src/test/java/com/netflix/config/sources/DynamoDbDeploymentContextTableCacheTest.java
+++ b/archaius-aws/src/test/java/com/netflix/config/sources/DynamoDbDeploymentContextTableCacheTest.java
@@ -63,4 +63,30 @@ public class DynamoDbDeploymentContextTableCacheTest {
         assertTrue(props.contains(test5));
         assertTrue(props.contains(test6));
     }
+
+    @Test
+    public void testPollWithNewFormat() throws Exception {
+        AmazonDynamoDB mockContextDbClient = mock(AmazonDynamoDB.class);
+
+        when(mockContextDbClient.scan(any(ScanRequest.class))).thenReturn(DynamoDbMocks.newContextScanResult1,
+                DynamoDbMocks.newContextScanResult2);
+        DynamoDbDeploymentContextTableCache cache = new DynamoDbDeploymentContextTableCache(mockContextDbClient, 100, 100);
+
+        Collection<PropertyWithDeploymentContext> props = cache.getProperties();
+        assertEquals(4, props.size());
+        assertTrue(props.contains(test1));
+        assertTrue(props.contains(test2));
+        assertTrue(props.contains(test5));
+        assertTrue(props.contains(test6));
+
+        Thread.sleep(150);
+
+        props = cache.getProperties();
+        assertEquals(5, props.size());
+        assertTrue(props.contains(test1));
+        assertTrue(props.contains(test3));
+        assertTrue(props.contains(test4));
+        assertTrue(props.contains(test5));
+        assertTrue(props.contains(test6));
+    }
 }

--- a/archaius-aws/src/test/java/com/netflix/config/sources/DynamoDbMocks.java
+++ b/archaius-aws/src/test/java/com/netflix/config/sources/DynamoDbMocks.java
@@ -20,6 +20,7 @@ public class DynamoDbMocks {
     static final String defaultValueAttribute = AbstractDynamoDbConfigurationSource.defaultValueAttribute;
     static final String defaultContextKeyAttribute = DynamoDbDeploymentContextTableCache.defaultContextKeyAttribute;
     static final String defaultContextValueAttribute = DynamoDbDeploymentContextTableCache.defaultContextValueAttribute;
+    static final String defaultContextAttribute = DynamoDbDeploymentContextTableCache.defaultContextAttribute;
 
     public static final Collection<Map<String, AttributeValue>> basicResultValues1 = new LinkedList<Map<String, AttributeValue>>();
     public static final Collection<Map<String, AttributeValue>> basicResultValues2 = new LinkedList<Map<String, AttributeValue>>();
@@ -30,6 +31,11 @@ public class DynamoDbMocks {
     public static final Collection<Map<String, AttributeValue>> contextResultValues2 = new LinkedList<Map<String, AttributeValue>>();
     public static final ScanResult contextScanResult1;
     public static final ScanResult contextScanResult2;
+
+    public static final Collection<Map<String, AttributeValue>> newContextResultValues1 = new LinkedList<Map<String, AttributeValue>>();
+    public static final Collection<Map<String, AttributeValue>> newContextResultValues2 = new LinkedList<Map<String, AttributeValue>>();
+    public static final ScanResult newContextScanResult1;
+    public static final ScanResult newContextScanResult2;    
 
 
     static {
@@ -109,5 +115,58 @@ public class DynamoDbMocks {
         //Create results from initialized values
         contextScanResult1 = new ScanResult().withItems(contextResultValues1);
         contextScanResult2 = new ScanResult().withItems(contextResultValues2);
+
+        //New DeploymentContext results config
+        Map<String, AttributeValue> newContextRow1 = new HashMap<String, AttributeValue>();
+        newContextRow1.put(defaultKeyAttribute, new AttributeValue().withS("foo"));
+        newContextRow1.put(defaultValueAttribute, new AttributeValue().withS("bar"));
+        newContextRow1.put(defaultContextAttribute, new AttributeValue().withS("environment=test"));    
+        newContextResultValues1.add(newContextRow1);
+
+        Map<String, AttributeValue> newContextRow2 = new HashMap<String, AttributeValue>();
+        newContextRow2.put(defaultKeyAttribute, new AttributeValue().withS("goo"));
+        newContextRow2.put(defaultValueAttribute, new AttributeValue().withS("goo"));
+        newContextRow2.put(defaultContextAttribute, new AttributeValue().withS("environment=test"));
+        newContextResultValues1.add(newContextRow2);
+
+        Map<String, AttributeValue> newContextRow3 = new HashMap<String, AttributeValue>();
+        newContextRow3.put(defaultKeyAttribute, new AttributeValue().withS("boo"));
+        newContextRow3.put(defaultValueAttribute, new AttributeValue().withS("who"));
+        newContextRow3.put(defaultContextAttribute, new AttributeValue().withS("environment=test"));
+        newContextResultValues1.add(newContextRow3);    
+
+        Map<String, AttributeValue> newGlobalRow1 = new HashMap<String, AttributeValue>();
+        newGlobalRow1.put(defaultKeyAttribute, new AttributeValue().withS("foo"));
+        newGlobalRow1.put(defaultValueAttribute, new AttributeValue().withS("bar"));
+        newGlobalRow1.put(defaultContextAttribute, new AttributeValue().withS("global"));
+        newContextResultValues1.add(newGlobalRow1);
+
+        //Result2
+        newContextResultValues2.add(contextRow1);
+        newContextResultValues2.add(contextRow3);
+
+        Map<String, AttributeValue> newContextRow4 = new HashMap<String, AttributeValue>();
+        newContextRow4.put(defaultKeyAttribute, new AttributeValue().withS("goo"));
+        newContextRow4.put(defaultValueAttribute, new AttributeValue().withS("foo"));
+        newContextRow4.put(defaultContextAttribute, new AttributeValue().withS("environment=prod"));
+        newContextResultValues2.add(newContextRow4);
+
+        Map<String, AttributeValue> newUpdatedContextRow = new HashMap<String, AttributeValue>();
+        newUpdatedContextRow.put(defaultKeyAttribute, new AttributeValue().withS("goo"));
+        newUpdatedContextRow.put(defaultValueAttribute, new AttributeValue().withS("foo"));
+        newUpdatedContextRow.put(defaultContextAttribute, new AttributeValue().withS("environment=test"));
+        newContextResultValues2.add(newUpdatedContextRow);
+
+        newContextResultValues2.add(newGlobalRow1);
+
+        Map<String, AttributeValue> invalidContextRow = new HashMap<String, AttributeValue>();
+        invalidContextRow.put(defaultKeyAttribute, new AttributeValue().withS("goo"));
+        invalidContextRow.put(defaultValueAttribute, new AttributeValue().withS("foo"));
+        invalidContextRow.put(defaultContextAttribute, new AttributeValue().withS("environment"));
+        newContextResultValues2.add(invalidContextRow);
+
+        //Create results from initialized values
+        newContextScanResult1 = new ScanResult().withItems(newContextResultValues1);
+        newContextScanResult2 = new ScanResult().withItems(newContextResultValues2);
     }
 }


### PR DESCRIPTION
This pull request supersedes pull request #99. It still fixes the issue with the way the rangeKey is currently used when talking to DynamoDB. While the code can handle both the old and the new format (and in theory a mixture of both), it requires a different field to be the rangeKey (context instead of contextKey). In theory it would've been possible to reuse contextKey but I felt this was kinda ugly.

This also fixes an NPE in PropertyWithDeploymentContext#hashCode() that occurred with global properties (those having neither contextKey nor contextValue) .
