### PR TITLE
Add getName() to DynamicListProperty, to be consistent with PropertyWrapper & DynamicSetProperty.

### DIFF
--- a/archaius-core/src/main/java/com/netflix/config/DynamicListProperty.java
+++ b/archaius-core/src/main/java/com/netflix/config/DynamicListProperty.java
@@ -165,4 +165,11 @@ public abstract class DynamicListProperty<T> {
      * 
      */
     protected abstract T from(String value);
+    
+    /**
+     * Getter for the property name
+     */
+    public String getName() {
+        return delegate.getName();
+    }
 }

--- a/archaius-core/src/test/java/com/netflix/config/DynamicStringCollectionTest.java
+++ b/archaius-core/src/test/java/com/netflix/config/DynamicStringCollectionTest.java
@@ -136,4 +136,18 @@ public class DynamicStringCollectionTest {
         }
         assertEquals(extMap, map);
     }
+    
+    @Test
+    public void testStringListGetName() {
+    	String propName = "testGetName";
+    	DynamicStringListProperty prop = new DynamicStringListProperty(propName, "1,2");
+    	assertEquals(propName, prop.getName());
+    }
+    
+    @Test
+    public void testStringMapGetName() {
+    	String propName = "testGetName";
+    	DynamicStringMapProperty prop = new DynamicStringMapProperty(propName, "key1=1,key2=2,key3=3");
+    	assertEquals(propName, prop.getName());
+    }
 }


### PR DESCRIPTION
Add accessor for the property name in DynamicListProperty. This will make DynamicListProperty consistent with the getName() accessor in PropertyWrapper and DynamicSetProperty.
