### PR TITLE
Introduce Property interface to specify methods available across all property implementations

### DIFF
--- a/archaius-core/src/main/java/com/netflix/config/ChainedDynamicProperty.java
+++ b/archaius-core/src/main/java/com/netflix/config/ChainedDynamicProperty.java
@@ -137,14 +137,14 @@ public class ChainedDynamicProperty {
             return getReferencedProperty().getName();
         }
 
-		@Override
-		public long getChangedTimestamp() {
+        @Override
+        public long getChangedTimestamp() {
             if (pReference.get() == this) {
                 return getReferencedProperty().getChangedTimestamp();
             } else {
                 return pReference.get().getChangedTimestamp();
             }
-		}
+        }
 
         /**
          * @param r
@@ -195,10 +195,10 @@ public class ChainedDynamicProperty {
             return (sProp.get() != null);
         }
 
-		@Override
-		protected Property<String> getReferencedProperty() {
-			return sProp;
-		}
+        @Override
+        protected Property<String> getReferencedProperty() {
+            return sProp;
+        }
     }
 
     public static class IntProperty extends ChainLink<Integer> {
@@ -233,10 +233,10 @@ public class ChainedDynamicProperty {
             return (sProp.get() != Integer.MIN_VALUE);
         }
 
-		@Override
-		protected Property<Integer> getReferencedProperty() {
-			return sProp;
-		}
+        @Override
+        protected Property<Integer> getReferencedProperty() {
+            return sProp;
+        }
     }
 
     public static class FloatProperty extends ChainLink<Float> {
@@ -270,10 +270,10 @@ public class ChainedDynamicProperty {
             return Math.abs(sProp.get() - Float.MIN_VALUE) > 0.000001f ;
         }
 
-		@Override
-		protected Property<Float> getReferencedProperty() {
-			return sProp;
-		}
+        @Override
+        protected Property<Float> getReferencedProperty() {
+            return sProp;
+        }
     }
 
     public static class BooleanProperty extends ChainLink<Boolean> {
@@ -310,9 +310,9 @@ public class ChainedDynamicProperty {
         }
 
         @Override
-		protected Property<Boolean> getReferencedProperty() {
-			return sProp;
-		}
+        protected Property<Boolean> getReferencedProperty() {
+            return sProp;
+        }
     }
 
     public static class DynamicBooleanPropertyThatSupportsNull extends PropertyWrapper<Boolean> {

--- a/archaius-core/src/main/java/com/netflix/config/DerivedStringProperty.java
+++ b/archaius-core/src/main/java/com/netflix/config/DerivedStringProperty.java
@@ -53,25 +53,25 @@ public abstract class DerivedStringProperty<D> implements Property<D> {
         return derived.get();
     }
     
-	@Override
-	public D getValue() {
-		return get();
-	}
+    @Override
+    public D getValue() {
+        return get();
+    }
 
-	@Override
-	public String getName() {
-		return delegate.getName();
-	}
+    @Override
+    public String getName() {
+        return delegate.getName();
+    }
 
-	@Override
-	public long getChangedTimestamp() {
-		return delegate.getChangedTimestamp();
-	}
+    @Override
+    public long getChangedTimestamp() {
+        return delegate.getChangedTimestamp();
+    }
 
-	@Override
-	public void addCallback(Runnable callback) {
-		delegate.addCallback(callback);
-	}  
+    @Override
+    public void addCallback(Runnable callback) {
+        delegate.addCallback(callback);
+    }  
 
     /**
      * Invoked when property is updated with a new value.  Should return the new derived value, which may be null.

--- a/archaius-core/src/main/java/com/netflix/config/DynamicListProperty.java
+++ b/archaius-core/src/main/java/com/netflix/config/DynamicListProperty.java
@@ -59,8 +59,8 @@ public abstract class DynamicListProperty<T> implements Property<List<T>> {
      * null, the default list value will be an empty list.
      */
     public DynamicListProperty(String propName, String defaultValue, String delimiterRegex) {
-    	this.splitter = Splitter.onPattern(delimiterRegex).omitEmptyStrings().trimResults();
-    	setup(propName, transform(split(defaultValue)), splitter);
+        this.splitter = Splitter.onPattern(delimiterRegex).omitEmptyStrings().trimResults();
+        setup(propName, transform(split(defaultValue)), splitter);
     }
 
     public DynamicListProperty(String propName, List<T> defaultValue) {
@@ -73,7 +73,7 @@ public abstract class DynamicListProperty<T> implements Property<List<T>> {
      * list value will be taken from the passed in list argument.
      */
     public DynamicListProperty(String propName, List<T> defaultValue, String delimiterRegex) {
-    	setup(propName, defaultValue, delimiterRegex);
+        setup(propName, defaultValue, delimiterRegex);
     }
 
     /**
@@ -81,7 +81,7 @@ public abstract class DynamicListProperty<T> implements Property<List<T>> {
      * from the arguments.
      */
     public DynamicListProperty(String propName, List<T> defaultValue, Splitter splitter) {
-    	setup(propName, defaultValue, splitter);
+        setup(propName, defaultValue, splitter);
     }
 
     
@@ -90,7 +90,7 @@ public abstract class DynamicListProperty<T> implements Property<List<T>> {
     }
 
     private void setup(String propName, List<T> defaultValue, Splitter splitter) {
-    	this.defaultValues = defaultValue;
+        this.defaultValues = defaultValue;
         this.splitter = splitter;
         delegate = DynamicPropertyFactory.getInstance().getStringProperty(propName, null);
         load();
@@ -99,7 +99,7 @@ public abstract class DynamicListProperty<T> implements Property<List<T>> {
             public void run() {
                 propertyChangedInternal();
             }
-        });    	
+        });        
     }
 
     private void propertyChangedInternal() {
@@ -125,11 +125,11 @@ public abstract class DynamicListProperty<T> implements Property<List<T>> {
     
     @Override
     public List<T> getValue() {
-    	return get();
+        return get();
     }
 
-    private List<String> split(String value) {    	
-    	return Lists.newArrayList(splitter.split(Strings.nullToEmpty(value)));
+    private List<String> split(String value) {        
+        return Lists.newArrayList(splitter.split(Strings.nullToEmpty(value)));
     }
     
     protected List<T> transform(List<String> stringValues) {
@@ -137,16 +137,16 @@ public abstract class DynamicListProperty<T> implements Property<List<T>> {
         for (String s : stringValues) {
             list.add(from(s));
         }
-        return Collections.unmodifiableList(list);	
+        return Collections.unmodifiableList(list);    
     }
     
     
     protected void load() {
-    	if (delegate.get() == null) {
-    		values = defaultValues;
-    	} else {
+        if (delegate.get() == null) {
+            values = defaultValues;
+        } else {
             values = transform(split(delegate.get()));
-    	}
+        }
     }
 
     /**

--- a/archaius-core/src/main/java/com/netflix/config/DynamicSetProperty.java
+++ b/archaius-core/src/main/java/com/netflix/config/DynamicSetProperty.java
@@ -51,8 +51,8 @@ public abstract class DynamicSetProperty<T> implements Property<Set<T>> {
      * null, the default set value will be an empty set.
      */
     public DynamicSetProperty(String propName, String defaultValue, String delimiterRegex) {
-    	this.splitter = Splitter.onPattern(delimiterRegex).omitEmptyStrings().trimResults();
-    	setup(propName, transform(split(defaultValue)), splitter);
+        this.splitter = Splitter.onPattern(delimiterRegex).omitEmptyStrings().trimResults();
+        setup(propName, transform(split(defaultValue)), splitter);
     }
 
     public DynamicSetProperty(String propName, Set<T> defaultValue) {
@@ -65,7 +65,7 @@ public abstract class DynamicSetProperty<T> implements Property<Set<T>> {
      * set value will be taken from the passed in set argument.
      */
     public DynamicSetProperty(String propName, Set<T> defaultValue, String delimiterRegex) {
-    	setup(propName, defaultValue, delimiterRegex);
+        setup(propName, defaultValue, delimiterRegex);
     }
 
     /**
@@ -73,7 +73,7 @@ public abstract class DynamicSetProperty<T> implements Property<Set<T>> {
      * from the arguments.
      */
     public DynamicSetProperty(String propName, Set<T> defaultValue, Splitter splitter) {
-    	setup(propName, defaultValue, splitter);
+        setup(propName, defaultValue, splitter);
     }
 
     
@@ -82,7 +82,7 @@ public abstract class DynamicSetProperty<T> implements Property<Set<T>> {
     }
 
     private void setup(String propName, Set<T> defaultValue, Splitter splitter) {
-    	this.defaultValues = defaultValue;
+        this.defaultValues = defaultValue;
         this.splitter = splitter;
         delegate = DynamicPropertyFactory.getInstance().getStringProperty(propName, null);
         load();
@@ -91,7 +91,7 @@ public abstract class DynamicSetProperty<T> implements Property<Set<T>> {
             public void run() {
                 propertyChangedInternal();
             }
-        });    	
+        });        
     }
 
     private void propertyChangedInternal() {
@@ -117,11 +117,11 @@ public abstract class DynamicSetProperty<T> implements Property<Set<T>> {
     
     @Override
     public Set<T> getValue() {
-    	return get();
+        return get();
     }
 
-    private Set<String> split(String value) {    	    	
-    	return Sets.newHashSet(splitter.split(Strings.nullToEmpty(value)));
+    private Set<String> split(String value) {                
+        return Sets.newHashSet(splitter.split(Strings.nullToEmpty(value)));
     }
     
     protected Set<T> transform(Set<String> stringValues) {
@@ -129,16 +129,16 @@ public abstract class DynamicSetProperty<T> implements Property<Set<T>> {
         for (String s : stringValues) {
             set.add(from(s));
         }
-        return Collections.unmodifiableSet(set);	
+        return Collections.unmodifiableSet(set);    
     }
     
     
     protected void load() {
-    	if (delegate.get() == null) {
-    		values = defaultValues;
-    	} else {
+        if (delegate.get() == null) {
+            values = defaultValues;
+        } else {
             values = transform(split(delegate.get()));
-    	}
+        }
     }
 
     /**

--- a/archaius-core/src/main/java/com/netflix/config/Property.java
+++ b/archaius-core/src/main/java/com/netflix/config/Property.java
@@ -18,35 +18,39 @@
 package com.netflix.config;
 
 /**
- * Base interface for Archaius properties. Provides common methods across all property implementations. 
- *
+ * Base interface for Archaius properties. Provides common methods across all
+ * property implementations.
+ * 
  * @param <T> The value type of the property
  */
 public interface Property<T> {
-	
-	/**
-	 * Get the latest value for the given property
-	 * @return the latest property value
-	 */
-	T getValue();
-	
-	/**
-	 * Get the name of the property
-	 * @return the property name
-	 */
-	String getName();
-	
+
     /**
-     * Gets the time (in milliseconds past the epoch) when the property
-     * was last set/changed.
+     * Get the latest value for the given property
+     * 
+     * @return the latest property value
      */
-	long getChangedTimestamp();
-	
+    T getValue();
+
     /**
-     * Add the callback to be triggered when the value of the property is changed
-     *
+     * Get the name of the property
+     * 
+     * @return the property name
+     */
+    String getName();
+
+    /**
+     * Gets the time (in milliseconds past the epoch) when the property was last
+     * set/changed.
+     */
+    long getChangedTimestamp();
+
+    /**
+     * Add the callback to be triggered when the value of the property is
+     * changed
+     * 
      * @param callback
      */
-	void addCallback(Runnable callback);
+    void addCallback(Runnable callback);
 
 }

--- a/archaius-core/src/main/java/com/netflix/config/PropertyWrapper.java
+++ b/archaius-core/src/main/java/com/netflix/config/PropertyWrapper.java
@@ -84,12 +84,12 @@ public abstract class PropertyWrapper<V> implements Property<V> {
                 }
             });
             try {
-            	if (this.prop.getString() != null) {
-            	    this.validate(this.prop.getString());
-            	}
+                if (this.prop.getString() != null) {
+                    this.validate(this.prop.getString());
+                }
             } catch (ValidationException e) {
-            	logger.warn("Error validating property at initialization. Will fallback to default value.", e);
-            	prop.updateValue(defaultValue);
+                logger.warn("Error validating property at initialization. Will fallback to default value.", e);
+                prop.updateValue(defaultValue);
             }
         }
     }


### PR DESCRIPTION
This change set introduces a common interface (Property) for all Archaius properties, to allow for standard handling of property classes. This change introduces the getChangedTimestamp() method to the ChainedDynamicProperty types, and getChangedTimeStamp(), getName(), and addCallback() to DerivedStringProperty.

Note: it's a little confusing having both get() and getValue() present on most of the classes, but is needed for maintaining backwards compatibility. I believe this is not significantly more confusing than the get()/getValue() duality present on the subclasses of PropertyWrapper.
