### PR TITLE
#51. Provide mechanism for Dynamic Property users to un-subscribe callba...

### DIFF
--- a/archaius-core/src/main/java/com/netflix/config/ChainedDynamicProperty.java
+++ b/archaius-core/src/main/java/com/netflix/config/ChainedDynamicProperty.java
@@ -165,6 +165,14 @@ public class ChainedDynamicProperty {
         }
 
         /**
+         * Remove callback from callbacks list
+         */
+        @Override
+        public void removeAllCallbacks() {
+            callbacks.clear();
+        }
+
+        /**
          * @return String 
          */
         @Override
@@ -213,7 +221,8 @@ public class ChainedDynamicProperty {
         }
 
         @Override
-        public void unSubscribe() {
+        public void removeAllCallbacks() {
+            super.removeAllCallbacks();
             sProp.prop.removeCallback(callback);
         }
     }
@@ -258,7 +267,8 @@ public class ChainedDynamicProperty {
         }
 
         @Override
-        public void unSubscribe() {
+        public void removeAllCallbacks() {
+            super.removeAllCallbacks();
             sProp.prop.removeCallback(callback);
         }
     }
@@ -302,7 +312,8 @@ public class ChainedDynamicProperty {
         }
 
         @Override
-        public void unSubscribe() {
+        public void removeAllCallbacks() {
+            super.removeAllCallbacks();
             sProp.prop.removeCallback(callback);
         }
     }
@@ -347,7 +358,8 @@ public class ChainedDynamicProperty {
         }
 
         @Override
-        public void unSubscribe() {
+        public void removeAllCallbacks() {
+            super.removeAllCallbacks();
             sProp.prop.removeCallback(callback);
         }
     }

--- a/archaius-core/src/main/java/com/netflix/config/DerivedStringProperty.java
+++ b/archaius-core/src/main/java/com/netflix/config/DerivedStringProperty.java
@@ -89,7 +89,7 @@ public abstract class DerivedStringProperty<D> implements Property<D> {
      * Remove all callbacks registered through this instance of property
      */
     @Override
-    public void unSubscribe() {
+    public void removeAllCallbacks() {
         for (Runnable callback: callbackList) {
             delegate.prop.removeCallback(callback);
         }

--- a/archaius-core/src/main/java/com/netflix/config/DynamicListProperty.java
+++ b/archaius-core/src/main/java/com/netflix/config/DynamicListProperty.java
@@ -42,8 +42,6 @@ public abstract class DynamicListProperty<T> implements Property<List<T>> {
 
     public static final String DEFAULT_DELIMITER = ",";
 
-    private final List<Runnable> callbackList = Lists.newArrayList();
-
     /**
      * Create the dynamic list property using default delimiter regex ",". The guava Splitter used is created as
      * <code>Splitter.onPattern(delimiterRegex).omitEmptyStrings().trimResults()</code>. The default
@@ -107,7 +105,6 @@ public abstract class DynamicListProperty<T> implements Property<List<T>> {
             }
         };
         delegate.addCallback(callback);
-        callbackList.add(callback);
     }
 
     private void propertyChangedInternal() {
@@ -179,7 +176,6 @@ public abstract class DynamicListProperty<T> implements Property<List<T>> {
     public void addCallback(Runnable callback) {
         if (callback != null) {
             delegate.addCallback(callback);
-            callbackList.add(callback);
         }
     }
 
@@ -187,10 +183,8 @@ public abstract class DynamicListProperty<T> implements Property<List<T>> {
      * Remove all callbacks registered through this instance of property
      */
     @Override
-    public void unSubscribe() {
-        for (Runnable callback: callbackList) {
-            delegate.prop.removeCallback(callback);
-        }
+    public void removeAllCallbacks() {
+        delegate.removeAllCallbacks();
     }
 
 

--- a/archaius-core/src/main/java/com/netflix/config/DynamicSetProperty.java
+++ b/archaius-core/src/main/java/com/netflix/config/DynamicSetProperty.java
@@ -181,7 +181,7 @@ public abstract class DynamicSetProperty<T> implements Property<Set<T>> {
      * Remove all callbacks registered through this instance of property
      */
     @Override
-    public void unSubscribe() {
+    public void removeAllCallbacks() {
         for (Runnable callback: callbackList) {
             delegate.prop.removeCallback(callback);
         }

--- a/archaius-core/src/main/java/com/netflix/config/Property.java
+++ b/archaius-core/src/main/java/com/netflix/config/Property.java
@@ -63,6 +63,6 @@ public interface Property<T> {
     /**
      * remove all callbacks registered through the instance of property
      */
-    void unSubscribe();
+    void removeAllCallbacks();
 
 }

--- a/archaius-core/src/main/java/com/netflix/config/PropertyWrapper.java
+++ b/archaius-core/src/main/java/com/netflix/config/PropertyWrapper.java
@@ -157,7 +157,7 @@ public abstract class PropertyWrapper<V> implements Property<V> {
      * Remove all callbacks registered through this instance of property
      */
     @Override
-    public void unSubscribe() {
+    public void removeAllCallbacks() {
         for (Runnable callback: callbackList) {
             prop.removeCallback(callback);
         }

--- a/archaius-core/src/test/java/com/netflix/config/DynamicStringPropertyTest.java
+++ b/archaius-core/src/test/java/com/netflix/config/DynamicStringPropertyTest.java
@@ -35,7 +35,7 @@ public class DynamicStringPropertyTest {
         //trigger callback
         ConfigurationManager.getConfigInstance().setProperty("testProperty", "cde");
         assertEquals(AFTERCALLBACK, callbackFlag);
-        dp.unSubscribe();
+        dp.removeAllCallbacks();
         //trigger callback again
         ConfigurationManager.getConfigInstance().setProperty("testProperty", "def");
         assertEquals(AFTERCALLBACK, callbackFlag);


### PR DESCRIPTION
...cks for property value changes. This will free the references by the static DP so GC can reclaim those property wrapper instances in time.
