### PR TITLE
archaius-scala: ChainedProperty.map

### DIFF
--- a/archaius-scala/src/main/scala/com/netflix/config/scala/ChainMakers.scala
+++ b/archaius-scala/src/main/scala/com/netflix/config/scala/ChainMakers.scala
@@ -74,7 +74,7 @@ protected[scala] object ChainMakers {
      * be null.
      * @return the value derived from the chain of properties.
      */
-    def apply: Option[TYPE] = Option(convert(chain.get()))
+    def apply(): Option[TYPE] = Option(convert(chain.get()))
 
     /**
      * Produce the most-appropriate current value of the chain of properties.  Where the Scala type allows
@@ -83,6 +83,29 @@ protected[scala] object ChainMakers {
      * @return the value derived from the chain of properties.
      */
     def get: TYPE = convert(nonNull(chain.get()))
+  }
+
+  class BoxConverter[B, TYPE](chainBox: ChainBox[TYPE,_], fn: (TYPE) => B, mapType: Manifest[B])
+  extends ChainBox[B, TYPE]
+  {
+    override protected lazy val typeName = mapType.runtimeClass.getName
+
+    // all calls in some way divert to the provided chainBox
+    override protected val chain : ChainLink[TYPE] = null
+
+    protected def convert(cv: TYPE): B = fn(cv)
+
+    override def apply(): Option[B] = chainBox().map(fn)
+
+    override def get: B = fn(chainBox.get)
+
+    override def addCallback(callback: Runnable) {
+      chainBox.addCallback(callback)
+    }
+
+    override def propertyName: String = chainBox.propertyName
+
+    override def defaultValue: B = convert(chainBox.defaultValue)
   }
 
   /**

--- a/archaius-scala/src/main/scala/com/netflix/config/scala/ChainedProperty.scala
+++ b/archaius-scala/src/main/scala/com/netflix/config/scala/ChainedProperty.scala
@@ -15,7 +15,7 @@
  */
 package com.netflix.config.scala
 
-import com.netflix.config.scala.ChainMakers.ChainBox
+import com.netflix.config.scala.ChainMakers.{BoxConverter, ChainBox}
 
 /**
  * Base functionality of a [[com.netflix.config.ChainedDynamicProperty]], in Scala terms.
@@ -45,7 +45,22 @@ trait ChainedProperty[TYPE] {
    * be null.
    * @return the value derived from the chain of properties.
    */
-  def apply: Option[TYPE] = chainBox.apply
+  def apply(): Option[TYPE] = chainBox()
+
+  /**
+   * Allow derivation of a new type of ChainedProperty by mapping the type of this one.
+   * @param fn the transformation function which produces the new type.
+   * @return a new ChainedProperty for the target type.
+   */
+  def map[B](fn: (TYPE) => B)(implicit mapType: Manifest[B]): ChainedProperty[B] = new MapBy(chainBox, fn, mapType)
+
+  class MapBy[B, TYPE](unmappedBox: ChainBox[TYPE, _], fn: (TYPE) => B, mapType: Manifest[B])
+  extends ChainedProperty[B]
+  {
+    override protected val chainBox = new BoxConverter[B, TYPE](unmappedBox, fn, mapType)
+
+    override def propertyNames: Iterable[String] = propertyNames
+  }
 
   /**
    * Get the name of the property.

--- a/archaius-scala/src/test/scala/com/netflix/config/scala/ChainedPropertyBehaviors.scala
+++ b/archaius-scala/src/test/scala/com/netflix/config/scala/ChainedPropertyBehaviors.scala
@@ -19,81 +19,92 @@ import org.scalatest.matchers.ShouldMatchers
 
 trait ChainedPropertyBehaviors[TYPE] { this: PropertiesTestHelp with ShouldMatchers =>
 
-  def fixture( pre: Option[String], mid: String, post: Option[String]):ChainedProperty[TYPE]
+  def fixture(pre: Option[String], mid: String, post: Option[String]): ChainedProperty[TYPE]
 
   def chainedPropertyWithOnePart(defaultValue: TYPE, configuredValue: TYPE) {
+    chainedPropertyWithOnePart(defaultValue, configuredValue, defaultValue, configuredValue)
+  }
+
+  def chainedPropertyWithOnePart(defaultValue: Any, configuredValue: Any, expectedDefaultValue: TYPE, expectedConfiguredValue: TYPE) {
     "understand a name with one part" in {
       clearProperty("test.part")
       clearProperty("test.one.part")
       val chainOfTwo = fixture(Some("test"), "one", Some("part"))
-      withClue(markProperty("")) { chainOfTwo.get should equal( defaultValue ) }
+      withClue(markProperty("")) { chainOfTwo.get should equal( expectedDefaultValue ) }
     }
     "retrieve configured base value for a name with one part" in {
       setProperty("test.part", configuredValue)
       val chainOfTwo = fixture(Some("test"), "one", Some("part"))
-      withClue(markProperty("test.part")) { chainOfTwo.get should equal( configuredValue ) }
+      withClue(markProperty("test.part")) { chainOfTwo.get should equal( expectedConfiguredValue ) }
     }
     "retrieve configured specific value for a name with one part" in {
       clearProperty("test.part")
       setProperty("test.one.part", configuredValue)
       val chainOfTwo = fixture(Some("test"), "one", Some("part"))
-      withClue(markProperty("test.one.part")) { chainOfTwo.get should equal( configuredValue ) }
+      withClue(markProperty("test.one.part")) { chainOfTwo.get should equal( expectedConfiguredValue ) }
     }
-
   }
 
   def chainedPropertyWithTwoParts(defaultValue: TYPE, configuredValue: TYPE) {
+    chainedPropertyWithTwoParts(defaultValue, configuredValue, defaultValue, configuredValue)
+  }
+
+  def chainedPropertyWithTwoParts(defaultValue: Any, configuredValue: Any, expectedDefaultValue: TYPE, expectedConfiguredValue: TYPE) {
     "understand a name with two parts" in {
       clearProperty("test.parts")
       clearProperty("test.one.parts")
       clearProperty("test.one.two.parts")
       val chainOfThree = fixture(Some("test"), "one.two", Some("parts"))
-      withClue(markProperty("")) { chainOfThree.get should equal( defaultValue ) }
+      withClue(markProperty("")) { chainOfThree.get should equal( expectedDefaultValue ) }
     }
     "retrieve configured most-specific value for a name with two parts" in {
       clearProperty("test.parts")
       clearProperty("test.one.parts")
       setProperty("test.one.two.parts", configuredValue)
       val chainOfThree = fixture(Some("test"), "one.two", Some("parts"))
-      withClue(markProperty("test.one.two.parts")) { chainOfThree.get should equal( configuredValue ) }
+      withClue(markProperty("test.one.two.parts")) { chainOfThree.get should equal( expectedConfiguredValue ) }
     }
     "retrieve configured next-general value for a name with two parts" in {
       clearProperty("test.parts")
       setProperty("test.one.parts", configuredValue)
       clearProperty("test.one.two.parts")
       val chainOfThree = fixture(Some("test"), "one.two", Some("parts"))
-      withClue(markProperty("test.one.parts")) { chainOfThree.get should equal( configuredValue ) }
+      withClue(markProperty("test.one.parts")) { chainOfThree.get should equal( expectedConfiguredValue ) }
     }
   }
 
   def chainedPropertyWithManyParts(defaultValue: TYPE, bottomValue: TYPE, middleValue: TYPE, topValue: TYPE) {
+    chainedPropertyWithManyParts(defaultValue, bottomValue, middleValue, topValue, defaultValue, bottomValue, middleValue, topValue)
+  }
+
+  def chainedPropertyWithManyParts(defaultValue: Any, bottomValue: Any, middleValue: Any, topValue: Any, expectedDefaultValue: TYPE, expectedBottomValue: TYPE, expectedMiddleValue: TYPE, expectedTopValue: TYPE) {
     "retrieve configured most-specific value from a multi-part chain" in {
       setProperty("test.parts", bottomValue)
       setProperty("test.one.parts", middleValue)
       setProperty("test.one.two.parts", topValue)
       val chainOfThree = fixture(Some("test"), "one.two", Some("parts"))
-      withClue(markProperty("test.one.two.parts")) { chainOfThree.get should equal( topValue ) }
+      withClue(markProperty("test.one.two.parts")) { chainOfThree.get should equal( expectedTopValue ) }
     }
     "retrieve configured next-general value from a multi-part chain" in {
       setProperty("test.parts", bottomValue)
       setProperty("test.one.parts", middleValue)
       clearProperty("test.one.two.parts")
       val chainOfThree = fixture(Some("test"), "one.two", Some("parts"))
-      withClue(markProperty("test.one.parts")) { chainOfThree.get should equal( middleValue ) }
+      withClue(markProperty("test.one.parts")) { chainOfThree.get should equal( expectedMiddleValue ) }
     }
     "retrieve configured most-general value from a multi-part chain" in {
       setProperty("test.parts", bottomValue)
       clearProperty("test.one.parts")
       clearProperty("test.one.two.parts")
       val chainOfThree = fixture(Some("test"), "one.two", Some("parts"))
-      withClue(markProperty("test.parts")) { chainOfThree.get should equal( bottomValue ) }
+      withClue(markProperty("test.parts")) { chainOfThree.get should equal( expectedBottomValue ) }
     }
     "retrieve default value from a multi-part chain" in {
       clearProperty("test.parts")
       clearProperty("test.one.parts")
       clearProperty("test.one.two.parts")
       val chainOfThree = fixture(Some("test"), "one.two", Some("parts"))
-      withClue(markProperty("")) { chainOfThree.get should equal( defaultValue ) }
+      withClue(markProperty("")) { chainOfThree.get should equal( expectedDefaultValue ) }
     }
   }
 }

--- a/archaius-scala/src/test/scala/com/netflix/config/scala/ChainedPropertyTest.scala
+++ b/archaius-scala/src/test/scala/com/netflix/config/scala/ChainedPropertyTest.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.config.scala
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.matchers.ShouldMatchers
+import scala.concurrent.duration._
+
+@RunWith(classOf[JUnitRunner])
+class ChainedPropertyTest extends PropertiesTestHelp with ShouldMatchers with ChainedPropertyBehaviors[Duration] {
+
+  val defaultUnmappedValue = -1L
+  val defaultMappedValue = defaultUnmappedValue.millis
+
+  def fixture(pre: Option[String], mid: String, post: Option[String]) = {
+    new ChainedLongProperty(pre, mid, post, defaultUnmappedValue).map( v => v.millis )
+  }
+
+  "ChainedProperty.map to another type" should {
+    behave like chainedPropertyWithOnePart(defaultUnmappedValue, 1L, defaultMappedValue, 1L.milli)
+    behave like chainedPropertyWithTwoParts(defaultUnmappedValue, 1L, defaultMappedValue, 1L.milli)
+    behave like chainedPropertyWithManyParts(defaultUnmappedValue, 0L, 1L, 2L, defaultMappedValue, 0L.millis, 1L.milli, 2L.millis)
+  }
+}


### PR DESCRIPTION
scala ChainedProperty bindings:
- correct apply() definition to be scala-y.
- provide a map implementation which takes a conversion function, allowing ChainedProperty implementations of arbitrary type to be created.
