### PR TITLE
Revert Gradle version to 1.7 to bypass OSS build issue with Gradle 1.11.

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.7-all.zip


### PR DESCRIPTION
Revert Gradle version back to 1.7 to bypass OSS build issue with Gradle 1.11.
