### PR TITLE
Revert Gradle version to 1.6 to bypass OSS build issue with Gradle 1.11.

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.7-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-bin.zip


### PR DESCRIPTION
1.7 won't work either. Moving to 1.6 instead.
