### PR TITLE
update jcloud-blobstore version to match Netflix OSS requirement

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ project(':archaius-aws') {
 project(':archaius-jclouds') {
     dependencies {
         compile project(':archaius-core')
-        compile 'org.jclouds:jclouds-blobstore:1.5.3'
+        compile 'org.jclouds:jclouds-blobstore:1.6.0'
         testCompile 'junit:junit:4.11'
         testCompile 'org.slf4j:slf4j-simple:1.6.4'
     }


### PR DESCRIPTION
Update jcloud-blobstore version to 1.6.0 to match Netflix's extlib version
