### PR TITLE
Fix, dynamodb should retry with exponential backoff.

### DIFF
--- a/archaius-aws/src/main/java/com/netflix/config/sources/AbstractDynamoDbConfigurationSource.java
+++ b/archaius-aws/src/main/java/com/netflix/config/sources/AbstractDynamoDbConfigurationSource.java
@@ -56,7 +56,7 @@ public abstract class AbstractDynamoDbConfigurationSource <T> {
     static final String defaultEndpoint = "dynamodb.us-east-1.amazonaws.com";
     static final Long defaultMaxBackOffMs = 5 * 1000L;
     static final Long defaultMinBackOffMs = 500L;
-    static final Long defaultMaxRetryCount = 100;
+    static final Long defaultMaxRetryCount = 100L;
 
     //Dynamic Properties
     protected DynamicStringProperty tableName = DynamicPropertyFactory.getInstance()
@@ -113,7 +113,7 @@ public abstract class AbstractDynamoDbConfigurationSource <T> {
 
     protected ScanResult dbScanWithThroughputBackOff(ScanRequest scanRequest) {
         Long currentBackOffMs = minBackOffMs.get();
-        Long retryCount = 0;
+        Long retryCount = 0L;
         while (true) {
             try {
                 return dbClient.scan(scanRequest);

--- a/archaius-aws/src/main/java/com/netflix/config/sources/DynamoDbConfigurationSource.java
+++ b/archaius-aws/src/main/java/com/netflix/config/sources/DynamoDbConfigurationSource.java
@@ -78,7 +78,7 @@ public class DynamoDbConfigurationSource extends AbstractDynamoDbConfigurationSo
             ScanRequest scanRequest = new ScanRequest()
                     .withTableName(table)
                     .withExclusiveStartKey(lastKeysEvaluated);
-            ScanResult result = dbClient.scan(scanRequest);
+            ScanResult result = dbScanWithThroughputBackOff(scanRequest);
             for (Map<String, AttributeValue> item : result.getItems()) {
                 propertyMap.put(item.get(keyAttributeName.get()).getS(), item.get(valueAttributeName.get()).getS());
             }

--- a/archaius-aws/src/main/java/com/netflix/config/sources/DynamoDbDeploymentContextTableCache.java
+++ b/archaius-aws/src/main/java/com/netflix/config/sources/DynamoDbDeploymentContextTableCache.java
@@ -261,7 +261,7 @@ public class DynamoDbDeploymentContextTableCache extends AbstractDynamoDbConfigu
             ScanRequest scanRequest = new ScanRequest()
                     .withTableName(table)
                     .withExclusiveStartKey(lastKeysEvaluated);
-            ScanResult result = dbClient.scan(scanRequest);
+            ScanResult result = dbScanWithThroughputBackOff(scanRequest);
             for (Map<String, AttributeValue> item : result.getItems()) {
                 String keyVal = item.get(keyAttributeName.get()).getS();
 


### PR DESCRIPTION
If requests fails, retry with exponential backoff.

That prevents from cascading failures.

Best practices, according to AWS:
http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ErrorHandling.html#APIRetries