### PR TITLE
Remove usage of Guava method removed in future versions

### DIFF
--- a/archaius-zookeeper/src/main/java/com/netflix/config/source/ZooKeeperConfigurationSource.java
+++ b/archaius-zookeeper/src/main/java/com/netflix/config/source/ZooKeeperConfigurationSource.java
@@ -227,7 +227,7 @@ public class ZooKeeperConfigurationSource implements WatchedConfigurationSource,
         try {
             Closeables.close(pathChildrenCache, true);
         } catch (IOException exc) {
-            logger.warn("IOException should not have been thrown.", exc);
+            logger.error("IOException should not have been thrown.", exc);
         }
     }
 }

--- a/archaius-zookeeper/src/main/java/com/netflix/config/source/ZooKeeperConfigurationSource.java
+++ b/archaius-zookeeper/src/main/java/com/netflix/config/source/ZooKeeperConfigurationSource.java
@@ -16,6 +16,7 @@
 package com.netflix.config.source;
 
 import java.io.Closeable;
+import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.List;
@@ -223,6 +224,10 @@ public class ZooKeeperConfigurationSource implements WatchedConfigurationSource,
     }
     
     public void close() {
-    	Closeables.closeQuietly(pathChildrenCache);
+        try {
+            Closeables.close(pathChildrenCache, true);
+        } catch (IOException exc) {
+            logger.warn("IOException should not have been thrown.", exc);
+        }
     }
 }


### PR DESCRIPTION
This commit removes usage of Closeables#closeQuietly(Closeable).
It is removed in future versions of Guava and prevents Archaius
from otherwise being able to run with the latest Guava.

It keeps the same behavior as before and logs the same statement.