### PR TITLE
Add DI named configuration mapping support. Support variable replacements from fields and methods.

### DIFF
--- a/archaius-core/src/main/java/netflix/archaius/StrInterpolatorFactory.java
+++ b/archaius-core/src/main/java/netflix/archaius/StrInterpolatorFactory.java
@@ -1,5 +1,6 @@
 package netflix.archaius;
 
+
 /**
  * SPI for specifying the {@link StrInterpolator} type used by ConfigManager.
  * This factory exists since the root config doesn't exist yet when the 

--- a/archaius-core/src/main/java/netflix/archaius/mapper/ConfigBinder.java
+++ b/archaius-core/src/main/java/netflix/archaius/mapper/ConfigBinder.java
@@ -4,6 +4,8 @@ import netflix.archaius.exceptions.MappingException;
 
 public interface ConfigBinder {
 
-    void bindConfig(Object injectee) throws MappingException;
+    <T> void bindConfig(T injectee, IoCContainer ioc) throws MappingException;
+    
+    <T> void bindConfig(T injectee) throws MappingException;
 
 }

--- a/archaius-core/src/main/java/netflix/archaius/mapper/DefaultConfigBinder.java
+++ b/archaius-core/src/main/java/netflix/archaius/mapper/DefaultConfigBinder.java
@@ -2,73 +2,152 @@ package netflix.archaius.mapper;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
 
 import netflix.archaius.Config;
 import netflix.archaius.exceptions.MappingException;
 import netflix.archaius.mapper.annotations.Configuration;
 
+import org.apache.commons.lang3.text.StrSubstitutor;
+
 public class DefaultConfigBinder implements ConfigBinder {
     private final Config config;
-
+    private static final IoCContainer NULL_IOC_CONTAINER = new IoCContainer() {
+        @Override
+        public <T> T getInstance(String name, Class<T> type) {
+            return null;
+        }
+    };
+    
     public DefaultConfigBinder(Config config) {
         this.config = config;
     }
     
     @Override
-    public void bindConfig(Object injectee) throws MappingException {
-        Configuration configAnnot = injectee.getClass().getAnnotation(Configuration.class);
-        if (configAnnot != null) {
-            String prefix = config.getStrInterpolator().resolve(configAnnot.prefix()).toString();
-            if (!prefix.isEmpty() || !prefix.endsWith("."))
-                prefix += ".";
-            
-            for (Field field : injectee.getClass().getDeclaredFields()) {
-                String name = field.getName();
-                Class<?> type = field.getType();
-                Object value = config.get(type, prefix + name, null);
-                if (value != null) {
-                    try {
-                        field.setAccessible(true);
-                        field.set(injectee, value);
-                    } catch (Exception e) {
-                        throw new MappingException("Unable to inject field " + injectee.getClass() + "." + name + " with value " + value, e);
-                    }
-                }
-            }
-            
-            for (Method method : injectee.getClass().getDeclaredMethods()) {
-                // Only support methods with one parameter 
-                //  Ex.  setTimeout(int timeout);
-                if (method.getParameterTypes().length != 1) {
-                    continue;
-                }
-                
-                // Extract field name from method name
-                //  Ex.  setTimeout => timeout
-                String name = method.getName();
-                if (name.startsWith("set") && name.length() > 3) {
-                    name = name.substring(3,4).toLowerCase() + name.substring(4);
-                }
-                // Or from builder
-                //  Ex.  withTimeout => timeout
-                else if (name.startsWith("with") && name.length() > 4) {
-                    name = name.substring(4,1).toLowerCase() + name.substring(5);
-                }
-                else {
-                    continue;
-                }
+    public <T> void bindConfig(T injectee) throws MappingException {
+        bindConfig(injectee, NULL_IOC_CONTAINER);
+    }
 
-                method.setAccessible(true);
-                Class<?> type = method.getParameterTypes()[0];
-                Object value = config.get(type, prefix + name, null);
-                if (value != null) {
+    @Override
+    public <T> void bindConfig(T injectee, IoCContainer ioc) throws MappingException {
+        Configuration configAnnot = injectee.getClass().getAnnotation(Configuration.class);
+        if (configAnnot == null) {
+            return;
+        }
+        
+        Class<T> injecteeType = (Class<T>) injectee.getClass();
+        
+        String prefix = configAnnot.prefix();
+        
+        // Extract parameters from the object.  For each parameter
+        // look for either file 'paramname' or method 'getParamnam'
+        String[] params = configAnnot.params();
+        if (params.length > 0) {
+            Map<String, String> map = new HashMap<String, String>();
+            for (String param : params) {
+                try {
+                    Field f = injecteeType.getDeclaredField(param);
+                    f.setAccessible(true);
+                    map.put(param, f.get(injectee).toString());
+                } catch (NoSuchFieldException e) {
                     try {
-                        method.invoke(injectee, value);
-                    } catch (Exception e) {
-                        throw new MappingException("Unable to inject field " + injectee.getClass() + "." + name + " with value " + value, e);
+                        Method method = injecteeType.getDeclaredMethod(
+                                "get" + Character.toUpperCase(param.charAt(0)) + param.substring(1));
+                        method.setAccessible(true);
+                        map.put(param, method.invoke(injectee).toString());
+                    } catch (Exception e1) {
+                        throw new MappingException(e1);
                     }
+                } catch (Exception e) {
+                    throw new MappingException(e);
                 }
             }
-        }                        
+            
+            prefix = StrSubstitutor.replace(prefix, map, "${", "}");
+        }
+        
+        // Interpolate using any replacements loaded into the configuration
+        prefix = config.getStrInterpolator().resolve(prefix).toString();
+        if (!prefix.isEmpty() || !prefix.endsWith("."))
+            prefix += ".";
+        
+        // Iterate and set fiels
+        for (Field field : injecteeType.getDeclaredFields()) {
+            if (   Modifier.isFinal(field.getModifiers())
+                || Modifier.isTransient(field.getModifiers())
+                || Modifier.isStatic(field.getModifiers())) {
+                continue;
+            }
+            
+            String name = field.getName();
+            Class<?> type = field.getType();
+            Object value = null;
+            if (type.isInterface()) {
+                String objName = config.getString(prefix + name, null);
+                if (objName != null) {
+                    value = ioc.getInstance(objName, type);
+                }
+            }
+            else {
+                value = config.get(type, prefix + name, null);
+            }
+            
+            if (value != null) {
+                try {
+                    field.setAccessible(true);
+                    field.set(injectee, value);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    throw new MappingException("Unable to inject field " + injectee.getClass() + "." + name + " with value " + value, e);
+                }
+            }
+        }
+        
+        // map to setter methods
+        for (Method method : injectee.getClass().getDeclaredMethods()) {
+            // Only support methods with one parameter 
+            //  Ex.  setTimeout(int timeout);
+            if (method.getParameterTypes().length != 1) {
+                continue;
+            }
+            
+            // Extract field name from method name
+            //  Ex.  setTimeout => timeout
+            String name = method.getName();
+            if (name.startsWith("set") && name.length() > 3) {
+                name = name.substring(3,4).toLowerCase() + name.substring(4);
+            }
+            // Or from builder
+            //  Ex.  withTimeout => timeout
+            else if (name.startsWith("with") && name.length() > 4) {
+                name = name.substring(4,1).toLowerCase() + name.substring(5);
+            }
+            else {
+                continue;
+            }
+
+            method.setAccessible(true);
+            Class<?> type = method.getParameterTypes()[0];
+            Object value = null;
+            if (type.isInterface()) {
+                String objName = config.getString(prefix + name, null);
+                if (objName != null) {
+                    value = ioc.getInstance(objName, type);
+                }
+            }
+            else {
+                value = config.get(type, prefix + name, null);
+            }
+            
+            if (value != null) {
+                try {
+                    method.invoke(injectee, value);
+                } catch (Exception e) {
+                    throw new MappingException("Unable to inject field " + injectee.getClass() + "." + name + " with value " + value, e);
+                }
+            }
+        }
     }
 }

--- a/archaius-core/src/main/java/netflix/archaius/mapper/IoCContainer.java
+++ b/archaius-core/src/main/java/netflix/archaius/mapper/IoCContainer.java
@@ -1,0 +1,18 @@
+package netflix.archaius.mapper;
+
+/**
+ * Interface used by ConfigBinder to integrate with a DI framework that 
+ * allows for named injection.  This integration enables binding a string
+ * value for a type to a DI bound instance.
+ * 
+ * @author elandau
+ *
+ */
+public interface IoCContainer {
+    /**
+     * @param name
+     * @param type
+     * @return Return the instance for type T bound to 'name'
+     */
+    public <T> T getInstance(String name, Class<T> type);
+}

--- a/archaius-core/src/main/java/netflix/archaius/mapper/annotations/Configuration.java
+++ b/archaius-core/src/main/java/netflix/archaius/mapper/annotations/Configuration.java
@@ -36,6 +36,11 @@ public @interface Configuration
     String      prefix() default "";
 
     /**
+     * @return field names to use for replacement
+     */
+    String[]      params() default {};
+    
+    /**
      * @return user displayable description of this configuration
      */
     String      documentation() default "";

--- a/archaius-guice/src/main/java/netflix/archaius/guice/ArchaiusModule.java
+++ b/archaius-guice/src/main/java/netflix/archaius/guice/ArchaiusModule.java
@@ -8,21 +8,24 @@ import netflix.archaius.Config;
 import netflix.archaius.exceptions.ConfigException;
 import netflix.archaius.mapper.ConfigBinder;
 import netflix.archaius.mapper.DefaultConfigBinder;
+import netflix.archaius.mapper.IoCContainer;
 import netflix.archaius.mapper.annotations.Configuration;
 import netflix.archaius.mapper.annotations.ConfigurationSource;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
+import com.google.inject.Key;
 import com.google.inject.Provides;
 import com.google.inject.ProvisionException;
 import com.google.inject.TypeLiteral;
 import com.google.inject.matcher.Matchers;
+import com.google.inject.name.Names;
 import com.google.inject.spi.InjectionListener;
 import com.google.inject.spi.TypeEncounter;
 import com.google.inject.spi.TypeListener;
 
 public class ArchaiusModule extends AbstractModule {
-    public static class ConfigurationInjectingListener implements TypeListener {
+    public static class ConfigurationInjectingListener implements TypeListener, IoCContainer {
         @Inject
         private AppConfig appConfig;
         
@@ -70,14 +73,20 @@ public class ArchaiusModule extends AbstractModule {
                     @Override
                     public void afterInjection(I injectee) {
                         try {
-                            binder.bindConfig(injectee);
+                            binder.bindConfig(injectee, ConfigurationInjectingListener.this);
                         }
                         catch (Exception e) {
-                            throw new ProvisionException("Unable to bind configuration to " + injectee.getClass());
+                            e.printStackTrace();
+                            throw new ProvisionException("Unable to bind configuration to " + injectee.getClass(), e);
                         }
                     }
                 });
             }        
+        }
+
+        @Override
+        public <T> T getInstance(String name, Class<T> type) {
+            return injector.getInstance(Key.get(type, Names.named(name)));
         }
     }
     


### PR DESCRIPTION
DI Mapping example,

```java
@Configuration(prefix="foo")
class Foo {
    public void setBar(Bar bar);
}
```

```properties
foo.bar=bartype1
```

```java
bind(Bar.class).annotatedWith(Names.named("bartype1")).to(Bar1Impl.class);
```

@Configuration variable replacement example,

```java
@Configuration(prefix="foo.${name}", parameters={"name"})
public Foo {
    private final String name; // match parameter "name"
    private int timeout;
    public Foo(String name) {
        this.name = name;
    }
}
```

```properties
foo.abc.timeout=1000
```

```java
Foo foo = new Foo("123");
binder.bindConfig(foo);
```