### PR TITLE
Observable property cache

### DIFF
--- a/archaius-core/src/main/java/netflix/archaius/ObservableProperty.java
+++ b/archaius-core/src/main/java/netflix/archaius/ObservableProperty.java
@@ -35,43 +35,24 @@ public interface ObservableProperty {
      */
     void update();
     
-    Property<String> asString(String defaultValue);
+    Property<String> asString();
     
-    Property<Integer> asInteger(Integer defaultValue);
+    Property<Integer> asInteger();
     
-    Property<Double> asDouble(Double defaultValue);
+    Property<Double> asDouble();
     
-    Property<Float> asFloat(Float defaultValue);
+    Property<Float> asFloat();
     
-    Property<Short> asShort(Short defaultValue);
+    Property<Short> asShort();
     
-    Property<Byte> asByte(Byte defaultValue);
+    Property<Byte> asByte();
     
-    Property<BigDecimal> asBigDecimal(BigDecimal defaultValue);
+    Property<BigDecimal> asBigDecimal();
 
-    Property<Boolean> asBoolean(Boolean defaultValue);
+    Property<Boolean> asBoolean();
 
-    Property<BigInteger> asBigInteger(BigInteger defaultValue);
+    Property<BigInteger> asBigInteger();
     
-    <T> Property<T> asType(Class<T> type, T defaultValue);
+    <T> Property<T> asType(Class<T> type);
 
-    Property<String> asString(String defaultValue, PropertyObserver<String> observer);
-    
-    Property<Integer> asInteger(Integer defaultValue, PropertyObserver<Integer> observer);
-    
-    Property<Double> asDouble(Double defaultValue, PropertyObserver<Double> observer);
-    
-    Property<Float> asFloat(Float defaultValue, PropertyObserver<Float> observer);
-    
-    Property<Short> asShort(Short defaultValue, PropertyObserver<Short> observer);
-    
-    Property<Byte> asByte(Byte defaultValue, PropertyObserver<Byte> observer);
-    
-    Property<BigDecimal> asBigDecimal(BigDecimal defaultValue, PropertyObserver<BigDecimal> observer);
-
-    Property<Boolean> asBoolean(Boolean defaultValue, PropertyObserver<Boolean> observer);
-
-    Property<BigInteger> asBigInteger(BigInteger defaultValue, PropertyObserver<BigInteger> observer);
-    
-    <T> Property<T> asType(Class<T> type, T defaultValue, PropertyObserver<T> observer);
 }

--- a/archaius-core/src/main/java/netflix/archaius/Property.java
+++ b/archaius-core/src/main/java/netflix/archaius/Property.java
@@ -29,12 +29,7 @@ public interface Property<T> {
     /**
      * @return  Most recent value for the property
      */
-    T get();
-    
-    /**
-     * @return  The default value used when the property is not set
-     */
-    T getDefaultValue();
+    T get(T defaultValue);
     
     /**
      * Get the last time the property was updated
@@ -47,4 +42,8 @@ public interface Property<T> {
      * Unsubscribe from property value update notifications.  The property object cannot be resubscribed.
      */
     void unsubscribe();
+
+    void addObserver(PropertyObserver<T> observer);
+
+    void removeObserver(PropertyObserver<T> observer);
 }

--- a/archaius-core/src/main/java/netflix/archaius/property/DefaultObservableProperty.java
+++ b/archaius-core/src/main/java/netflix/archaius/property/DefaultObservableProperty.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Constructor;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.TimeUnit;
 
 import netflix.archaius.Config;
@@ -14,12 +15,38 @@ import netflix.archaius.PropertyObserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Implementation of ObservableProperty which reuses the same object for each
+ * type.  This implementation is assumes that each fast property is mostly accessed
+ * as the same type but allows for additional types to be deserialized.  
+ * Instead of incurring the overhead for caching in a hash map, the objects are 
+ * stored in a CopyOnWriteArrayList and items are retrieved via a linear scan.
+ * 
+ * Once created a fast property cannot be removed.  However, observer may be
+ * aded and removed. 
+ * 
+ * @author elandau
+ *
+ */
 public class DefaultObservableProperty implements ObservableProperty {
     private final Logger LOG = LoggerFactory.getLogger(DefaultObservableProperty.class);
     
+    enum Type {
+        INTEGER,
+        STRING,
+        BYTE,
+        BIG_DECIMAL,
+        BIG_INTEGER,
+        SHORT,
+        DOUBLE,
+        FLOAT,
+        BOOLEAN,
+        CUSTOM, // Must be last
+    }
+
     private final String key;
     private final Config config;
-    private final CopyOnWriteArrayList<AbstractProperty<?>> subscribers = new CopyOnWriteArrayList<AbstractProperty<?>>();
+    private final CopyOnWriteArrayList<AbstractProperty<?>> cache = new CopyOnWriteArrayList<AbstractProperty<?>>();
     private volatile long lastUpdateTimeInMillis = 0;
     
     public DefaultObservableProperty(String key, Config config) {
@@ -29,24 +56,53 @@ public class DefaultObservableProperty implements ObservableProperty {
 
     @Override
     public void update() {
-        for (AbstractProperty<?> subscriber : subscribers) {
-            subscriber.update();
+        for (AbstractProperty<?> property : cache) {
+            property.update();
         }
     }
 
     public abstract class AbstractProperty<T> implements Property<T> {
+        @Override
+        public int hashCode() {
+            return type;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            @SuppressWarnings("rawtypes")
+            AbstractProperty other = (AbstractProperty) obj;
+            if (!getOuterType().equals(other.getOuterType()))
+                return false;
+            return (type == other.type);
+        }
+
         private volatile T existing = null;
-        private PropertyObserver<T> observer;
-        private final T defaultValue;
+        private CopyOnWriteArraySet<PropertyObserver<T>> observers = new CopyOnWriteArraySet<PropertyObserver<T>>();
+        private final int type;
         
-        public AbstractProperty(PropertyObserver<T> observer, T defaultValue) {
-            this.observer = observer;
-            this.defaultValue = defaultValue;
+        AbstractProperty(Type type) {
+            this.type = type.ordinal();
+        }
+        
+        @Override
+        public void addObserver(PropertyObserver<T> observer) {
+            this.observers.add(observer);
+        }
+        
+        @Override
+        public void removeObserver(PropertyObserver<T> observer) {
+            this.observers.remove(observer);
         }
         
         @Override
         public void unsubscribe() {
-            subscribers.remove(this);
+            // Noop - for now let's keep this in the cache.
         }
 
         void update() {
@@ -57,146 +113,216 @@ public class DefaultObservableProperty implements ObservableProperty {
                 }
                 else if (next == null || existing == null || !existing.equals(next)) {
                     existing = next;
-                    if (observer != null) {
-                        lastUpdateTimeInMillis = System.currentTimeMillis();
+                    lastUpdateTimeInMillis = System.currentTimeMillis();
+                    for (PropertyObserver<T> observer : observers) {
                         observer.onChange(existing);
                     }
                 }
             }
             catch (Exception e) {
                 LOG.warn("Unable to get current version of property '{}'. Error: {}", key, e.getMessage());
-                if (observer != null) {
+                for (PropertyObserver<T> observer : observers) {
                     observer.onError(e);
                 }
             }
         }
         
         @Override
-        public T get() {
-            return existing;
+        public T get(T defaultValue) {
+            T ret = existing;
+            if (ret == null) 
+                return defaultValue;
+            return ret;
         }
         
-        @Override
-        public T getDefaultValue() {
-            return defaultValue;
-        }
-
         @Override
         public long getLastUpdateTime(TimeUnit units) {
             return units.convert(lastUpdateTimeInMillis, TimeUnit.MILLISECONDS);
         }
 
+        private DefaultObservableProperty getOuterType() {
+            return DefaultObservableProperty.this;
+        }
+        
         protected abstract T getCurrent() throws Exception;
     }
 
-    private <T> AbstractProperty<T> subscribe(AbstractProperty<T> subscriber) {
-        subscribers.add(subscriber);
-        subscriber.update();
-        return subscriber;
+    /**
+     * Add a new property to the end of the array list but first check
+     * to see if it already exists.
+     * @param newProperty
+     * @return
+     */
+    @SuppressWarnings("unchecked")
+    private <T> AbstractProperty<T> add(AbstractProperty<T> newProperty) {
+        while (!cache.addIfAbsent(newProperty)) {
+            for (AbstractProperty<?> property : cache) {
+                if (property.type == newProperty.type) {
+                    return (AbstractProperty<T>) property;
+                }
+            }
+        }
+        
+        return newProperty;
+    }
+    
+    /**
+     * Retrieve a cached instance of the fast property for the specified
+     * primitive data type
+     * @param type
+     * @return Cached type or null if does not exist
+     */
+    @SuppressWarnings("unchecked")
+    private <T> Property<T> get(int type) {
+        for (AbstractProperty<?> property : cache) {
+            if (property.type == type) {
+                return (AbstractProperty<T>) property;
+            }
+        }
+        return null;
     }
     
     @Override
-    public Property<String> asString(final String defaultValue, PropertyObserver<String> observer) {
-        return subscribe(new AbstractProperty<String>(observer, defaultValue) {
-            @Override
-            protected String getCurrent() throws Exception {
-                return config.getString(key, defaultValue);
-            }
-        });
+    public Property<String> asString() {
+        Property<String> prop = get(Type.STRING.ordinal());
+        if (prop == null) {
+            return add(new AbstractProperty<String>(Type.STRING) {
+                @Override
+                protected String getCurrent() throws Exception {
+                    return config.getString(key, null);
+                }
+            });
+        }
+        return prop;
     }
 
     @Override
-    public Property<Integer> asInteger(final Integer defaultValue, PropertyObserver<Integer> observer) {
-        return subscribe(new AbstractProperty<Integer>(observer, defaultValue) {
-            @Override
-            protected Integer getCurrent() throws Exception {
-                return config.getInteger(key, defaultValue);
-            }
-        });
+    public Property<Integer> asInteger() {
+        Property<Integer> prop = get(Type.INTEGER.ordinal());
+        if (prop == null) {
+            return add(new AbstractProperty<Integer>(Type.INTEGER) {
+                @Override
+                protected Integer getCurrent() throws Exception {
+                    return config.getInteger(key, null);
+                }
+            });
+        }
+        return prop;
     }
 
     @Override
-    public Property<Double> asDouble(final Double defaultValue, PropertyObserver<Double> observer) {
-        return subscribe(new AbstractProperty<Double>(observer, defaultValue) {
-            @Override
-            protected Double getCurrent() throws Exception {
-                return config.getDouble(key, defaultValue);
-            }
-        });
+    public Property<Double> asDouble() {
+        Property<Double> prop = get(Type.DOUBLE.ordinal());
+        if (prop == null) {
+            return add(new AbstractProperty<Double>(Type.DOUBLE) {
+                @Override
+                protected Double getCurrent() throws Exception {
+                    return config.getDouble(key, null);
+                }
+            });
+        }
+        return prop;
     }
 
     @Override
-    public Property<Float> asFloat(final Float defaultValue, PropertyObserver<Float> observer) {
-        return subscribe(new AbstractProperty<Float>(observer, defaultValue) {
-            @Override
-            protected Float getCurrent() throws Exception {
-                return config.getFloat(key, defaultValue);
-            }
-        });
+    public Property<Float> asFloat() {
+        Property<Float> prop = get(Type.FLOAT.ordinal());
+        if (prop == null) {
+            return add(new AbstractProperty<Float>(Type.FLOAT) {
+                @Override
+                protected Float getCurrent() throws Exception {
+                    return config.getFloat(key, null);
+                }
+            });
+        }
+        return prop;
     }
 
     @Override
-    public Property<Short> asShort(final Short defaultValue, PropertyObserver<Short> observer) {
-        return subscribe(new AbstractProperty<Short>(observer, defaultValue) {
-            @Override
-            protected Short getCurrent() throws Exception {
-                return config.getShort(key, defaultValue);
-            }
-        });
+    public Property<Short> asShort() {
+        Property<Short> prop = get(Type.SHORT.ordinal());
+        if (prop == null) {
+            return add(new AbstractProperty<Short>(Type.SHORT) {
+                @Override
+                protected Short getCurrent() throws Exception {
+                    return config.getShort(key, null);
+                }
+            });
+        }
+        return prop;
     }
 
     @Override
-    public Property<Byte> asByte(final Byte defaultValue, PropertyObserver<Byte> observer) {
-        return subscribe(new AbstractProperty<Byte>(observer, defaultValue) {
-            @Override
-            protected Byte getCurrent() throws Exception {
-                return config.getByte(key, defaultValue);
-            }
-        });
+    public Property<Byte> asByte() {
+        Property<Byte> prop = get(Type.BYTE.ordinal());
+        if (prop == null) {
+            return add(new AbstractProperty<Byte>(Type.BYTE) {
+                @Override
+                protected Byte getCurrent() throws Exception {
+                    return config.getByte(key, null);
+                }
+            });
+        }
+        return prop;
     }
 
     @Override
-    public Property<BigDecimal> asBigDecimal(final BigDecimal defaultValue, PropertyObserver<BigDecimal> observer) {
-        return subscribe(new AbstractProperty<BigDecimal>(observer, defaultValue) {
-            @Override
-            protected BigDecimal getCurrent() throws Exception {
-                return config.getBigDecimal(key, defaultValue);
-            }
-        });
+    public Property<BigDecimal> asBigDecimal() {
+        Property<BigDecimal> prop = get(Type.BIG_DECIMAL.ordinal());
+        if (prop == null) {
+            return add(new AbstractProperty<BigDecimal>(Type.BIG_DECIMAL) {
+                @Override
+                protected BigDecimal getCurrent() throws Exception {
+                    return config.getBigDecimal(key, null);
+                }
+            });
+        }
+        return prop;
     }
     
     @Override
-    public Property<Boolean> asBoolean(final Boolean defaultValue, PropertyObserver<Boolean> observer) {
-        return subscribe(new AbstractProperty<Boolean>(observer, defaultValue) {
-            @Override
-            protected Boolean getCurrent() throws Exception {
-                return config.getBoolean(key, defaultValue);
-            }
-        });
+    public Property<Boolean> asBoolean() {
+        Property<Boolean> prop = get(Type.BOOLEAN.ordinal());
+        if (prop == null) {
+            return add(new AbstractProperty<Boolean>(Type.BOOLEAN) {
+                @Override
+                protected Boolean getCurrent() throws Exception {
+                    return config.getBoolean(key, null);
+                }
+            });
+        }
+        return prop;
     }
 
     @Override
-    public Property<BigInteger> asBigInteger(final BigInteger defaultValue, PropertyObserver<BigInteger> observer) {
-        return subscribe(new AbstractProperty<BigInteger>(observer, defaultValue) {
-            @Override
-            protected BigInteger getCurrent() throws Exception {
-                return config.getBigInteger(key, defaultValue);
-            }
-        });
+    public Property<BigInteger> asBigInteger() {
+        Property<BigInteger> prop = get(Type.BIG_INTEGER.ordinal());
+        if (prop == null) {
+            return add(new AbstractProperty<BigInteger>(Type.BIG_INTEGER) {
+                @Override
+                protected BigInteger getCurrent() throws Exception {
+                    return config.getBigInteger(key, null);
+                }
+            });
+        }
+        return prop;
     }
 
+    /**
+     * No caching for custom types.
+     */
     @Override
-    public <T> Property<T> asType(Class<T> type, final T defaultValue, PropertyObserver<T> observer) {
+    public <T> Property<T> asType(Class<T> type) {
         final Constructor<T> constructor;
         try {
             constructor = type.getConstructor(String.class);
             if (constructor != null) {
-                return subscribe(new AbstractProperty<T>(observer, defaultValue) {
+                return add(new AbstractProperty<T>(Type.CUSTOM) {
                     @Override
                     protected T getCurrent() throws Exception {
                         String value = config.getString(key);
                         if (value == null) {
-                            return defaultValue;
+                            return null;
                         }
                         else { 
                             return constructor.newInstance(value);
@@ -206,59 +332,10 @@ public class DefaultObservableProperty implements ObservableProperty {
             }
         } catch (NoSuchMethodException e) {
         } catch (SecurityException e) {
-            throw new UnsupportedOperationException("No parser for type " + type.getName());
+            throw new UnsupportedOperationException("No parser for type " + type.getName(), e);
         }
       
         throw new UnsupportedOperationException("No parser for type " + type.getName());
     }
 
-    @Override
-    public Property<String> asString(String defaultValue) {
-        return asString(defaultValue, null);
-    }
-
-    @Override
-    public Property<Integer> asInteger(Integer defaultValue) {
-        return asInteger(defaultValue, null);
-    }
-
-    @Override
-    public Property<Double> asDouble(Double defaultValue) {
-        return asDouble(defaultValue, null);
-    }
-
-    @Override
-    public Property<Float> asFloat(Float defaultValue) {
-        return asFloat(defaultValue, null);
-    }
-
-    @Override
-    public Property<Short> asShort(Short defaultValue) {
-        return asShort(defaultValue, null);
-    }
-
-    @Override
-    public Property<Byte> asByte(Byte defaultValue) {
-        return asByte(defaultValue, null);
-    }
-
-    @Override
-    public Property<BigDecimal> asBigDecimal(BigDecimal defaultValue) {
-        return asBigDecimal(defaultValue, null);
-    }
-
-    @Override
-    public Property<Boolean> asBoolean(Boolean defaultValue) {
-        return asBoolean(defaultValue, null);
-    }
-
-    @Override
-    public Property<BigInteger> asBigInteger(BigInteger defaultValue) {
-        return asBigInteger(defaultValue, null);
-    }
-
-    @Override
-    public <T> Property<T> asType(Class<T> type, T defaultValue) {
-        return asType(type, defaultValue, null);
-    }
 }

--- a/archaius-core/src/test/java/netflix/archaius/ConfigManagerTest.java
+++ b/archaius-core/src/test/java/netflix/archaius/ConfigManagerTest.java
@@ -29,9 +29,9 @@ public class ConfigManagerTest {
         config.addConfigLast(new EnvironmentConfig());
         config.addConfigLast(new SystemConfig());
         
-        Property<String> prop = config.createProperty("abc").asString("defaultValue");
+        Property<String> prop = config.createProperty("abc").asString();
         
-        config.createProperty("abc").asString("defaultValue", new DefaultPropertyObserver<String>() {
+        prop.addObserver(new DefaultPropertyObserver<String>() {
             @Override
             public void onChange(String next) {
                 System.out.println("Configuration changed : " + next);

--- a/archaius-core/src/test/java/netflix/archaius/property/PropertyTest.java
+++ b/archaius-core/src/test/java/netflix/archaius/property/PropertyTest.java
@@ -13,8 +13,9 @@ public class PropertyTest {
         private Property<Integer> value2;
         
         public MyService(DefaultAppConfig config) {
-            value  = config.createProperty("foo").asInteger(1, new MethodInvoker<Integer>(this, "setValue"));
-            value2 = config.createProperty("foo").asInteger(2);
+            value  = config.createProperty("foo").asInteger();
+            value.addObserver(new MethodInvoker<Integer>(this, "setValue"));
+            value2 = config.createProperty("foo").asInteger();
         }
         
         public void setValue(Integer value) {
@@ -30,13 +31,32 @@ public class PropertyTest {
         
         MyService service = new MyService(config);
 
-        Assert.assertEquals(1, (int)service.value.get());
-        Assert.assertEquals(2, (int)service.value2.get());
+        Assert.assertEquals(1, (int)service.value.get(1));
+        Assert.assertEquals(2, (int)service.value2.get(2));
         
         config.setProperty("foo", "123");
         
-        Assert.assertEquals(123, (int)service.value.get());
-        Assert.assertEquals(123, (int)service.value2.get());
+        Assert.assertEquals(123, (int)service.value.get(1));
+        Assert.assertEquals(123, (int)service.value2.get(2));
+    }
+    
+    @Test
+    public void testPropertyIsCached() throws ConfigException {
+        DefaultAppConfig config = DefaultAppConfig.builder().withApplicationConfigName("application").build();
+        
+        System.out.println("Configs: " + config.getChildConfigNames());
+        
+        Property<Integer> intProp1 = config.createProperty("foo").asInteger();
+        Property<Integer> intProp2 = config.createProperty("foo").asInteger();
+        Property<String>  strProp  = config.createProperty("foo").asString();
+
+        Assert.assertSame(intProp1, intProp2);
+        
+        config.setProperty("foo", "123");
+        
+        Assert.assertEquals("123", strProp.get(null));
+        Assert.assertEquals((Integer)123, intProp1.get(null));
+        Assert.assertEquals((Integer)123, intProp2.get(null));
     }
 
 }


### PR DESCRIPTION
Add caching to DefaultObservableProperty to optimize the case where client code constantly tries to create the property again.

This change optimizes situations where the Property<?> object is not stored in a variable.  For example,

```java
class SomeClass {
   void doSomething() {
      config.createProperty("foo.someproperty").asInteger().get(123);
   }
}
```

as opposed to the preferred 

```java
class SomeClass {
    private Property<Integer> prop;
    SomeClass() { 
        prop = config.createProperty("foo.someproperty").asInteger();
    }

    void doSomething() {
        prop.get(123)
    }
}
```

This PR also moves the default value from asInteger(default) to asInteger().get(default).  This is necessary since caching makes storing the default awkward.