### PR TITLE
fix javadoc for specifying defaults with Property

### DIFF
--- a/archaius-core/src/main/java/com/netflix/archaius/Property.java
+++ b/archaius-core/src/main/java/com/netflix/archaius/Property.java
@@ -27,12 +27,12 @@ import java.util.concurrent.TimeUnit;
  *     private final Property<String> prop;
  *     
  *     MyService(PropertyFactroy config) {
- *        prop = config.connectProperty("foo.prop").asString("defaultValue");
+ *        prop = config.connectProperty("foo.prop").asString();
  *     }
  *     
  *     void doSomething() {
  *         // Will print out the most up to date value for the property
- *         System.out.println(prop.get());
+ *         System.out.println(prop.get("defaultValue"));
  *     }
  * }
  * }


### PR DESCRIPTION
I find having to specify the default for every access a bit
cumbersome. In general it means that you have to have a constant
somewhere for the default and pass it in on every access.

I tend to favor the DRY principle in regards to specifying defaults,
more similar to the reasoning in:

https://github.com/typesafehub/config#how-to-handle-defaults

Further, forcing properties to be specified as part of the config
files is quite useful for debugging because it means the value you
see in views like the karyon admin are the full set of properties
used. With the defaults all over the place you essentially have to
read the code if a value is missing to find out what value would
get used.