### PR TITLE
Properly set decoder when using DefaultAppConfig

### DIFF
--- a/archaius-core/src/main/java/com/netflix/archaius/DefaultAppConfig.java
+++ b/archaius-core/src/main/java/com/netflix/archaius/DefaultAppConfig.java
@@ -199,6 +199,12 @@ public class DefaultAppConfig extends CascadingCompositeConfig implements AppCon
         super(NAME);
         
         try {
+            if (builder.decoder != null) {
+                setDecoder(builder.decoder);
+            }
+
+            this.setStrInterpolator(builder.interpolator.create(this));
+
             // The following are added first, before application configuration
             // to allow for replacements in the application configuration cascade
             // loading.
@@ -219,12 +225,6 @@ public class DefaultAppConfig extends CascadingCompositeConfig implements AppCon
             if (builder.enableEnvironmentLayer) {
                 super.addConfig(new EnvironmentConfig());
             }
-
-            if (builder.decoder != null) {
-                setDecoder(builder.decoder);
-            }
-
-            this.setStrInterpolator(builder.interpolator.create(this));
             
             loader = DefaultConfigLoader.builder()
                     .withConfigReader(builder.loaders)


### PR DESCRIPTION
This pull request resolves issue #274.

When using the DefaultAppConfig with a custom decoder or custom string interpolator, only some of the configurations would receive the decoder or interpolator. 