### PR TITLE
Finish correctly setting Decoder/Interpolator logic

### DIFF
--- a/archaius-core/src/main/java/com/netflix/archaius/DefaultConfigLoader.java
+++ b/archaius-core/src/main/java/com/netflix/archaius/DefaultConfigLoader.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
@@ -205,6 +206,7 @@ public class DefaultConfigLoader implements ConfigLoader {
                 // multiple
                 else {
                     CascadingCompositeConfig cConfig = new CascadingCompositeConfig(name);
+                    Collections.reverse(configs);
                     try {
                         cConfig.addConfigs(configs);
                     } catch (ConfigException e) {
@@ -241,7 +243,7 @@ public class DefaultConfigLoader implements ConfigLoader {
             @Override
             public Config load(File file) throws ConfigException {
                 try {
-                    return load(file.toURL());
+                    return load(file.toURI().toURL());
                 } catch (MalformedURLException e) {
                     throw new ConfigException("Failed to load file " + file, e);
                 }

--- a/archaius-core/src/main/java/com/netflix/archaius/cascade/ConcatCascadeStrategy.java
+++ b/archaius-core/src/main/java/com/netflix/archaius/cascade/ConcatCascadeStrategy.java
@@ -75,9 +75,9 @@ public class ConcatCascadeStrategy implements CascadeStrategy {
         String current = name;
         for (String param : parameters) {
             current += separator + param;
-            result.add(interpolator.resolve(current).toString());
+            result.add(interpolator.resolve(current));
         }
-        
+
         return result;
     }
 

--- a/archaius-core/src/main/java/com/netflix/archaius/config/AbstractConfig.java
+++ b/archaius-core/src/main/java/com/netflix/archaius/config/AbstractConfig.java
@@ -44,32 +44,32 @@ public abstract class AbstractConfig implements Config {
     }
     
     @Override
-    final public void setDecoder(Decoder decoder) {
-        this.decoder = decoder;
-    }
-    
-    @Override
     final public Decoder getDecoder() {
         return this.decoder;
     }
-    
+
+    @Override
+    public void setDecoder(Decoder decoder) {
+        this.decoder = decoder;
+    }
+
     @Override
     final public StrInterpolator getStrInterpolator() {
         return this.interpolator;
     }
-    
+
     @Override
-    final public void setStrInterpolator(StrInterpolator interpolator) {
+    public void setStrInterpolator(StrInterpolator interpolator) {
         this.interpolator = interpolator;
     }
     
     @Override
-    final public void addListener(ConfigListener listener) {
+    public void addListener(ConfigListener listener) {
         listeners.add(listener);
     }
     
     @Override
-    final public void removeListener(ConfigListener listener) {
+    public void removeListener(ConfigListener listener) {
         listeners.remove(listener);
     }
     

--- a/archaius-core/src/main/java/com/netflix/archaius/config/PrefixedViewConfig.java
+++ b/archaius-core/src/main/java/com/netflix/archaius/config/PrefixedViewConfig.java
@@ -20,6 +20,9 @@ import java.util.LinkedHashSet;
 import java.util.NoSuchElementException;
 
 import com.netflix.archaius.Config;
+import com.netflix.archaius.ConfigListener;
+import com.netflix.archaius.Decoder;
+import com.netflix.archaius.StrInterpolator;
 
 /**
  * View into another Config for properties starting with a specified prefix.
@@ -80,4 +83,31 @@ public class PrefixedViewConfig extends DelegatingConfig {
         return null;
     }
 
+    @Override
+    public synchronized void setDecoder(Decoder decoder)
+    {
+        super.setDecoder(decoder);
+        config.setDecoder(decoder);
+    }
+
+    @Override
+    public synchronized void setStrInterpolator(StrInterpolator interpolator)
+    {
+        super.setStrInterpolator(interpolator);
+        config.setStrInterpolator(interpolator);
+    }
+
+    @Override
+    public synchronized void addListener(ConfigListener listener)
+    {
+        super.addListener(listener);
+        config.addListener(listener);
+    }
+
+    @Override
+    public synchronized void removeListener(ConfigListener listener)
+    {
+        super.removeListener(listener);
+        config.removeListener(listener);
+    }
 }

--- a/archaius-core/src/test/java/com/netflix/archaius/AppConfigTest.java
+++ b/archaius-core/src/test/java/com/netflix/archaius/AppConfigTest.java
@@ -55,7 +55,7 @@ public class AppConfigTest {
         System.out.println(config.toString());
         Assert.assertTrue(config.getBoolean("libA.loaded"));
         Assert.assertTrue(config.getBoolean("libB.loaded"));
-        Assert.assertEquals("libB", config.getString("libA.overrideA"));
+        Assert.assertEquals("libA", config.getString("libA.overrideA"));
         
         config.accept(new PrintStreamVisitor());
     }


### PR DESCRIPTION
This pull request is to finish correcting issue #280

Allow the overriding of setDecoder/setStrInterpolator/addListener/removeListener such that configurations that delegate to one or more configurations can assure that those components are properly propagated down to the child(ren) configurations.

I have attempted to make the order of configuration loading be in line with Archaius 1.x as far the configurations sources are handled, but I would greatly appreciate someone taking a second look at the additional library components to make sure that the order is correct. AppConfigTest.testAppAndLibraryLoading() demonstrates the issue that I am speaking of.