### PR TITLE
Fix configuration mapping when there is no prefix

### DIFF
--- a/archaius-core/src/main/java/com/netflix/archaius/DefaultAppConfig.java
+++ b/archaius-core/src/main/java/com/netflix/archaius/DefaultAppConfig.java
@@ -89,6 +89,10 @@ public class DefaultAppConfig extends CascadingCompositeConfig implements AppCon
         private Decoder                   decoder;
 
         public Builder withStrInterpolator(StrInterpolatorFactory interpolator) {
+            if (interpolator == null) {
+                throw new IllegalArgumentException("StrInterpolatorFactory cannot be null or empty");
+            }
+
             this.interpolator = interpolator;
             return this;
         }
@@ -123,7 +127,9 @@ public class DefaultAppConfig extends CascadingCompositeConfig implements AppCon
          * will use PropertiesConfigLoader.
          */
         public Builder withConfigReader(ConfigReader loader) {
-            this.loaders.add(loader);
+            if (loader != null) {   
+                this.loaders.add(loader);
+            }
             return this;
         }
 
@@ -132,7 +138,9 @@ public class DefaultAppConfig extends CascadingCompositeConfig implements AppCon
          * Library cascade strategies may be configured on the loader returned by newLoader.
          */
         public Builder withDefaultCascadingStrategy(CascadeStrategy strategy) {
-            this.defaultStrategy = strategy;
+            this.defaultStrategy = strategy == null 
+                                 ? DEFAULT_CASCADE_STRATEGY 
+                                 : strategy;
             return this;
         }
 
@@ -157,6 +165,10 @@ public class DefaultAppConfig extends CascadingCompositeConfig implements AppCon
          * Name of application configuration to load at startup.  Default is 'config'.
          */
         public Builder withApplicationConfigName(String name) {
+            if (name == null || name.isEmpty()) {
+                throw new IllegalArgumentException("Name cannot be null or empty");
+            }
+            
             this.configName = name;
             return this;
         }
@@ -165,6 +177,9 @@ public class DefaultAppConfig extends CascadingCompositeConfig implements AppCon
          * Decoder used to decode properties to arbitrary types.
          */
         public Builder withDecoder(Decoder decoder) {
+            if (decoder == null) {
+                throw new IllegalArgumentException("Decoder cannot be null");
+            }
             this.decoder = decoder;
             return this;
         }

--- a/archaius-core/src/main/java/com/netflix/archaius/annotations/Configuration.java
+++ b/archaius-core/src/main/java/com/netflix/archaius/annotations/Configuration.java
@@ -14,7 +14,7 @@
  *    limitations under the License.
  */
 
-package com.netflix.archaius.mapper.annotations;
+package com.netflix.archaius.annotations;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;

--- a/archaius-core/src/main/java/com/netflix/archaius/annotations/ConfigurationSource.java
+++ b/archaius-core/src/main/java/com/netflix/archaius/annotations/ConfigurationSource.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.archaius.mapper.annotations;
+package com.netflix.archaius.annotations;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/archaius-core/src/main/java/com/netflix/archaius/annotations/DefaultValue.java
+++ b/archaius-core/src/main/java/com/netflix/archaius/annotations/DefaultValue.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.archaius.mapper.annotations;
+package com.netflix.archaius.annotations;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -23,6 +23,6 @@ import java.lang.annotation.Target;
 @Documented
 @Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD, ElementType.METHOD})
-public @interface Value {
-    String name();
+public @interface DefaultValue {
+    String value();
 }

--- a/archaius-core/src/main/java/com/netflix/archaius/annotations/Embedded.java
+++ b/archaius-core/src/main/java/com/netflix/archaius/annotations/Embedded.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.archaius.mapper.annotations;
+package com.netflix.archaius.annotations;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;

--- a/archaius-core/src/main/java/com/netflix/archaius/annotations/Value.java
+++ b/archaius-core/src/main/java/com/netflix/archaius/annotations/Value.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.archaius.mapper.annotations;
+package com.netflix.archaius.annotations;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -23,6 +23,6 @@ import java.lang.annotation.Target;
 @Documented
 @Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD, ElementType.METHOD})
-public @interface DefaultValue {
-    String value();
+public @interface Value {
+    String name();
 }

--- a/archaius-core/src/main/java/com/netflix/archaius/mapper/DefaultConfigMapper.java
+++ b/archaius-core/src/main/java/com/netflix/archaius/mapper/DefaultConfigMapper.java
@@ -30,9 +30,9 @@ import com.netflix.archaius.Decoder;
 import com.netflix.archaius.DefaultDecoder;
 import com.netflix.archaius.Property;
 import com.netflix.archaius.PropertyFactory;
+import com.netflix.archaius.annotations.Configuration;
+import com.netflix.archaius.annotations.DefaultValue;
 import com.netflix.archaius.exceptions.MappingException;
-import com.netflix.archaius.mapper.annotations.Configuration;
-import com.netflix.archaius.mapper.annotations.DefaultValue;
 
 public class DefaultConfigMapper implements ConfigMapper {
     private static final IoCContainer NULL_IOC_CONTAINER = new IoCContainer() {
@@ -98,7 +98,7 @@ public class DefaultConfigMapper implements ConfigMapper {
         
         // Interpolate using any replacements loaded into the configuration
         prefix = config.getStrInterpolator().resolve(prefix).toString();
-        if (!prefix.isEmpty() || !prefix.endsWith("."))
+        if (!prefix.isEmpty() && !prefix.endsWith("."))
             prefix += ".";
         
         // Iterate and set fields

--- a/archaius-core/src/test/java/com/netflix/archaius/mapper/DefaultConfigMapperTest.java
+++ b/archaius-core/src/test/java/com/netflix/archaius/mapper/DefaultConfigMapperTest.java
@@ -21,8 +21,8 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.netflix.archaius.DefaultAppConfig;
+import com.netflix.archaius.annotations.DefaultValue;
 import com.netflix.archaius.mapper.DefaultConfigMapper;
-import com.netflix.archaius.mapper.annotations.DefaultValue;
 import com.netflix.archaius.property.PrefixedObservablePropertyFactory;
 
 public class DefaultConfigMapperTest {

--- a/archaius-guice/src/main/java/com/netflix/archaius/guice/ArchaiusModule.java
+++ b/archaius-guice/src/main/java/com/netflix/archaius/guice/ArchaiusModule.java
@@ -36,13 +36,13 @@ import com.netflix.archaius.CascadeStrategy;
 import com.netflix.archaius.Config;
 import com.netflix.archaius.DefaultAppConfig;
 import com.netflix.archaius.PropertyFactory;
+import com.netflix.archaius.annotations.Configuration;
+import com.netflix.archaius.annotations.ConfigurationSource;
 import com.netflix.archaius.config.CompositeConfig;
 import com.netflix.archaius.exceptions.ConfigException;
 import com.netflix.archaius.mapper.ConfigMapper;
 import com.netflix.archaius.mapper.DefaultConfigMapper;
 import com.netflix.archaius.mapper.IoCContainer;
-import com.netflix.archaius.mapper.annotations.Configuration;
-import com.netflix.archaius.mapper.annotations.ConfigurationSource;
 
 public class ArchaiusModule extends AbstractModule {
     

--- a/archaius-guice/src/test/java/com/netflix/archaius/guice/ArchaiusModuleTest.java
+++ b/archaius-guice/src/test/java/com/netflix/archaius/guice/ArchaiusModuleTest.java
@@ -30,14 +30,14 @@ import com.netflix.archaius.AppConfig;
 import com.netflix.archaius.Config;
 import com.netflix.archaius.DefaultAppConfig;
 import com.netflix.archaius.Property;
+import com.netflix.archaius.annotations.Configuration;
+import com.netflix.archaius.annotations.ConfigurationSource;
+import com.netflix.archaius.annotations.DefaultValue;
 import com.netflix.archaius.cascade.ConcatCascadeStrategy;
 import com.netflix.archaius.config.MapConfig;
 import com.netflix.archaius.exceptions.MappingException;
 import com.netflix.archaius.guice.ArchaiusModule;
 import com.netflix.archaius.mapper.DefaultConfigMapper;
-import com.netflix.archaius.mapper.annotations.Configuration;
-import com.netflix.archaius.mapper.annotations.ConfigurationSource;
-import com.netflix.archaius.mapper.annotations.DefaultValue;
 
 public class ArchaiusModuleTest {
     


### PR DESCRIPTION
Additional cleanup
* Argument validation in DefaultAppConfig
* Move annotations to a better package