### PR TITLE
fix #286, easier to customize AppConfig

### DIFF
--- a/archaius-guice/README.md
+++ b/archaius-guice/README.md
@@ -9,12 +9,24 @@ To enable create Guice bindings for Config and AppConfig and install a single gu
 
 ```java
 Injector injector = Guice.createInjector(
+    new DefaultArchaiusModule()
+    );
+```
+
+For users that need to customize the `AppConfig` object, the `AchaiusModule` can be used
+instead. The user is responsible for providing bindings for the `ConfigMapper` and `AppConfig`
+instances to use.
+
+```java
+Injector injector = Guice.createInjector(
     new AbstractModule() {
         @Override
         protected void configure() {
-            AppConfig config = AppConfig.createDefaultConfig();
-            bind(Config.class).toInstance(config);
+            final AppConfig config = DefaultAppConfig.builder()
+                .withApplicationConfigName("application")
+                .build();
             bind(AppConfig.class).toInstance(config);
+            bind(ConfigMapper.class).toInstance(new DefaultConfigMapper());
         }
     },
     new ArchaiusModule()

--- a/archaius-guice/src/main/java/com/netflix/archaius/guice/ArchaiusModule.java
+++ b/archaius-guice/src/main/java/com/netflix/archaius/guice/ArchaiusModule.java
@@ -44,6 +44,12 @@ import com.netflix.archaius.mapper.ConfigMapper;
 import com.netflix.archaius.mapper.DefaultConfigMapper;
 import com.netflix.archaius.mapper.IoCContainer;
 
+/**
+ * Module to setup DI features of archaius with guice. The user must specify bindings for
+ * {@link AppConfig} and {@link ConfigMapper}.
+ *
+ * @see DefaultArchaiusModule
+ */
 public class ArchaiusModule extends AbstractModule {
     
     public static class ConfigProvider<T> implements Provider<T> {
@@ -146,18 +152,6 @@ public class ArchaiusModule extends AbstractModule {
         requestInjection(listener);
         
         bindListener(Matchers.any(), listener);
-    }
-    
-    @Provides
-    @Singleton
-    protected ConfigMapper createConfigMapper() {
-        return new DefaultConfigMapper();
-    }
-    
-    @Provides
-    @Singleton
-    protected AppConfig createAppConfig() {
-        return DefaultAppConfig.builder().build();
     }
     
     @Provides

--- a/archaius-guice/src/main/java/com/netflix/archaius/guice/DefaultArchaiusModule.java
+++ b/archaius-guice/src/main/java/com/netflix/archaius/guice/DefaultArchaiusModule.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.archaius.guice;
+
+import com.google.inject.Provides;
+import com.netflix.archaius.AppConfig;
+import com.netflix.archaius.DefaultAppConfig;
+import com.netflix.archaius.mapper.ConfigMapper;
+import com.netflix.archaius.mapper.DefaultConfigMapper;
+
+import javax.inject.Singleton;
+
+/**
+ * Standalone module that gets archaius ready to use with the default bindings for
+ * {@link ConfigMapper} and {@link AppConfig}.
+ */
+public class DefaultArchaiusModule extends ArchaiusModule {
+
+    @Provides
+    @Singleton
+    protected ConfigMapper createConfigMapper() {
+        return new DefaultConfigMapper();
+    }
+
+    @Provides
+    @Singleton
+    protected AppConfig createAppConfig() {
+        return DefaultAppConfig.builder().build();
+    }
+}

--- a/archaius-guice/src/test/java/com/netflix/archaius/guice/ArchaiusModuleTest.java
+++ b/archaius-guice/src/test/java/com/netflix/archaius/guice/ArchaiusModuleTest.java
@@ -19,6 +19,9 @@ import java.util.Properties;
 
 import javax.inject.Inject;
 
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.netflix.archaius.mapper.ConfigMapper;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -107,7 +110,13 @@ public class ArchaiusModuleTest {
     @Test
     public void test() {
         Injector injector = Guice.createInjector(
-            new ArchaiusModule() {
+            new AbstractModule() {
+                protected void configure() {
+                    bind(ConfigMapper.class).toInstance(new DefaultConfigMapper());
+                }
+
+                @Provides
+                @Singleton
                 protected AppConfig createAppConfig() {
                     Properties props = new Properties();
                     props.setProperty("prefix-prod.str_value", "str_value");
@@ -118,7 +127,8 @@ public class ArchaiusModuleTest {
                     
                     return DefaultAppConfig.builder().withProperties(props).build();
                 }
-            }
+            },
+            new ArchaiusModule()
         );
         
         MyService service = injector.getInstance(MyService.class);
@@ -139,14 +149,15 @@ public class ArchaiusModuleTest {
     @Test
     public void testNamedInjection() {
         Injector injector = Guice.createInjector(
-            new ArchaiusModule() {
+            new AbstractModule() {
                 protected void configure() {
-                    super.configure();
-                    
+                    bind(ConfigMapper.class).toInstance(new DefaultConfigMapper());
                     bind(Named.class).annotatedWith(Names.named("name1")).to(Named1.class);
                     bind(Named.class).annotatedWith(Names.named("name2")).to(Named2.class);
                 }
-                
+
+                @Provides
+                @Singleton
                 protected AppConfig createAppConfig() {
                     Properties props = new Properties();
                     props.setProperty("prefix-prod.named", "name1");
@@ -154,7 +165,8 @@ public class ArchaiusModuleTest {
                     
                     return DefaultAppConfig.builder().withProperties(props).build();
                 }
-            }
+            },
+            new ArchaiusModule()
             );
             
         MyService service = injector.getInstance(MyService.class);
@@ -198,7 +210,7 @@ public class ArchaiusModuleTest {
     @Test
     public void testProxy() {
         Injector injector = Guice.createInjector(
-                new ArchaiusModule(),
+                new DefaultArchaiusModule(),
                 ArchaiusModule.forProxy(TestProxyConfig.class)
             );
         


### PR DESCRIPTION
This change splits out the two `@Provides` methods for the
`ConfigMapper` and `AppConfig` into a `DefaultArchaiusModule`.
The base `ArchaiusModule` expects something else to provide
those bindings.

The other advantage to this over expecting a sub-class to
override is that the user is free to inject whatever they need
into their `@Provides` for the `AppConfig`.

README has been updated to show the usage for both `ArchaiusModule`
and `DefaultArchaiusModule`.