### PR TITLE
fix docs for config proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ When using archaius-guice create a binding for the proxy interface like this (a 
 ```java
 new AbstractModule() {
     protected void configure() {
-        bind(MyConfig.class).toProvider(Providers.guicify(ArchaiusModule.forProxy(MyConfig.class));
+        install(ArchaiusModule.forProxy(MyConfig.class));
     }
 }
 ```

--- a/archaius-guice/README.md
+++ b/archaius-guice/README.md
@@ -34,7 +34,7 @@ For example,
 ```java
 // Class where configuration is load
 @Singleton
-@ConfigurationSource({"serviceA"}
+@ConfigurationSource({"serviceA"})
 public class ServiceAConfiguration {
 }
 


### PR DESCRIPTION
The listed code doesn't work as Provides.guicify expects a
Provider not a Module.