### PR TITLE
Cleanup ArchaiusModule

### DIFF
--- a/archaius-guice/src/main/java/com/netflix/archaius/guice/ArchaiusModule.java
+++ b/archaius-guice/src/main/java/com/netflix/archaius/guice/ArchaiusModule.java
@@ -16,12 +16,12 @@
 package com.netflix.archaius.guice;
 
 import javax.inject.Inject;
-import javax.inject.Provider;
 import javax.inject.Singleton;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
 import com.google.inject.Key;
+import com.google.inject.Provider;
 import com.google.inject.Provides;
 import com.google.inject.ProvisionException;
 import com.google.inject.Scopes;
@@ -43,6 +43,28 @@ import com.netflix.archaius.mapper.ConfigMapper;
 import com.netflix.archaius.mapper.DefaultConfigMapper;
 import com.netflix.archaius.mapper.IoCContainer;
 
+/**
+ * Guice module with default bindings to enable AppConfig injection and 
+ * configuration mapping/binding in a Guice based application.
+ * 
+ * To override the AppConfig binding use Guice's Modules.override()
+ * 
+ * <pre>
+ * ```java
+ * Modules
+ *     .override(new ArchaiusModule())
+ *     .with(new AbstractModule() {
+ *         @Override
+ *         protected void configure() {
+ *             bind(AppConfig.class).toInstance(DefaultAppConfig.builder().withProperties(props).build());
+ *         }
+ *     })
+ * ```
+ * </pre>
+ * 
+ * @author elandau
+ *
+ */
 public final class ArchaiusModule extends AbstractModule {
     
     public static class ConfigProvider<T> implements Provider<T> {
@@ -139,35 +161,20 @@ public final class ArchaiusModule extends AbstractModule {
         }
     }
 
-    private final AppConfig appConfig;
-    
-    public ArchaiusModule() {
-        this(null);
-    }
-    
-    public ArchaiusModule(AppConfig appConfig) {
-        this.appConfig = appConfig;
-    }
-    
-    public static ArchaiusModule fromAppConfig(final AppConfig config) {
-        return new ArchaiusModule(config);
-    }
-    
     @Override
     final protected void configure() {
         ConfigurationInjectingListener listener = new ConfigurationInjectingListener();
         requestInjection(listener);
         bindListener(Matchers.any(), listener);
-        
         bind(ConfigMapper.class).to(DefaultConfigMapper.class).in(Scopes.SINGLETON);
     }
     
     @Provides
     @Singleton
-    final AppConfig createAppConfig() {
-        return appConfig != null ? appConfig : DefaultAppConfig.createDefault();
+    final AppConfig getAppConfig() {
+        return DefaultAppConfig.createDefault();
     }
-    
+
     @Provides
     @Singleton
     final Config getConfig(AppConfig config) {

--- a/archaius-guice/src/main/java/com/netflix/archaius/guice/ArchaiusModule.java
+++ b/archaius-guice/src/main/java/com/netflix/archaius/guice/ArchaiusModule.java
@@ -56,7 +56,7 @@ import com.netflix.archaius.mapper.IoCContainer;
  *     .with(new AbstractModule() {
  *         @Override
  *         protected void configure() {
- *             bind(AppConfig.class).toInstance(DefaultAppConfig.builder().withProperties(props).build());
+ *             bind(AppConfig.class).toInstance(DefaultAppConfig.builder().withApplicationConfigName("mayapp").build());
  *         }
  *     })
  * ```

--- a/archaius-guice/src/test/java/com/netflix/archaius/guice/ArchaiusModuleTest.java
+++ b/archaius-guice/src/test/java/com/netflix/archaius/guice/ArchaiusModuleTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
-import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.google.inject.name.Names;
 import com.google.inject.util.Modules;

--- a/archaius-guice/src/test/java/com/netflix/archaius/guice/ArchaiusModuleTest.java
+++ b/archaius-guice/src/test/java/com/netflix/archaius/guice/ArchaiusModuleTest.java
@@ -25,8 +25,10 @@ import org.junit.Test;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.google.inject.name.Names;
+import com.google.inject.util.Modules;
 import com.netflix.archaius.AppConfig;
 import com.netflix.archaius.Config;
 import com.netflix.archaius.DefaultAppConfig;
@@ -106,7 +108,7 @@ public class ArchaiusModuleTest {
     
     @Test
     public void test() {
-        Properties props = new Properties();
+        final Properties props = new Properties();
         props.setProperty("prefix-prod.str_value", "str_value");
         props.setProperty("prefix-prod.int_value", "123");
         props.setProperty("prefix-prod.bool_value", "true");
@@ -114,7 +116,13 @@ public class ArchaiusModuleTest {
         props.setProperty("env", "prod");
         
         Injector injector = Guice.createInjector(
-            new ArchaiusModule(DefaultAppConfig.builder().withProperties(props).build())
+            Modules.override(new ArchaiusModule())
+                   .with(new AbstractModule() {
+                       @Override
+                       protected void configure() {
+                           bind(AppConfig.class).toInstance(DefaultAppConfig.builder().withProperties(props).build());
+                       }
+                   })
         );
         
         MyService service = injector.getInstance(MyService.class);
@@ -137,12 +145,19 @@ public class ArchaiusModuleTest {
     
     @Test
     public void testNamedInjection() {
-        Properties props = new Properties();
+        final Properties props = new Properties();
         props.setProperty("prefix-prod.named", "name1");
         props.setProperty("env", "prod");
         
         Injector injector = Guice.createInjector(
-            new ArchaiusModule(DefaultAppConfig.builder().withProperties(props).build()),
+            Modules.override(new ArchaiusModule())
+                   .with(new AbstractModule() {
+                        @Override
+                        protected void configure() {
+                            bind(AppConfig.class).toInstance(DefaultAppConfig.builder().withProperties(props).build());
+                        }
+                   })
+            ,
             new AbstractModule() {
                 protected void configure() {
                     bind(Named.class).annotatedWith(Names.named("name1")).to(Named1.class);


### PR DESCRIPTION
Simplify bindings in ArchaiusModule and support an externally provided A
ppConfig implementation instead of allowing ArcahiusModule to be inherited.