### PR TITLE
DefaultAppConfig simplification

### DIFF
--- a/archaius2-core/src/main/java/com/netflix/archaius/AppConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/AppConfig.java
@@ -15,6 +15,9 @@
  */
 package com.netflix.archaius;
 
+import java.util.Collection;
+
+import com.netflix.archaius.config.CompositeConfig;
 import com.netflix.archaius.config.SettableConfig;
 import com.netflix.archaius.exceptions.ConfigException;
 
@@ -24,22 +27,27 @@ import com.netflix.archaius.exceptions.ConfigException;
  * @author elandau
  */
 public interface AppConfig extends PropertyFactory, SettableConfig, ConfigLoader {
-
     /**
-     * Add config into the top level override layer.  Override properties take
-     * precedence of previously added override properties
+     * Return a child layer
      * 
-     * @param child
-     * @throws ConfigException
+     * @param name
+     * @return
      */
-    void addOverrideConfig(Config child) throws ConfigException;
+    Config getLayer(String name);
     
     /**
-     * Add config into the library layer.  Override properties take
-     * precedence of previously added override properties
+     * Return a child layer into which other configurations may be loaded.
      * 
-     * @param child
-     * @throws ConfigException
+     * TODO: Throw an exception if not composite
+     * 
+     * @param name
+     * @return
+     * @throws ConfigException 
      */
-    void addLibraryConfig(Config child) throws ConfigException;
+    CompositeConfig getCompositeLayer(String name) throws ConfigException;
+    
+    /**
+     * @return List of layer names in order of override priority
+     */
+    Collection<String> getLayerNames();
 }

--- a/archaius2-core/src/main/java/com/netflix/archaius/ConfigLoader.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/ConfigLoader.java
@@ -71,13 +71,6 @@ public interface ConfigLoader {
         Loader withOverrides(Properties props);
         
         /**
-         * Once loaded add all the properties to System.setProperty()
-         * @param toSystem
-         * @return
-         */
-        Loader withLoadToSystem(boolean toSystem);
-        
-        /**
          * Load configuration by cascade resource name.
          * @param resourceName
          * @return

--- a/archaius2-core/src/main/java/com/netflix/archaius/DefaultConfigLoader.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/DefaultConfigLoader.java
@@ -25,12 +25,13 @@ import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.CopyOnWriteArraySet;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.netflix.archaius.cascade.SimpleCascadeStrategy;
 import com.netflix.archaius.config.CascadingCompositeConfig;
 import com.netflix.archaius.config.MapConfig;
 import com.netflix.archaius.exceptions.ConfigException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * DefaultConfigLoader provides a DSL to load configurations.
@@ -152,13 +153,7 @@ public class DefaultConfigLoader implements ConfigLoader {
             }
 
             @Override
-            public Loader withLoadToSystem(boolean toSystem) {
-                loadToSystem = toSystem;
-                return this;
-            }
-
-            @Override
-            public Config load(String resourceName) {
+            public Config load(String resourceName) throws ConfigException {
                 if (name == null) {
                     name = resourceName;
                 }
@@ -191,7 +186,7 @@ public class DefaultConfigLoader implements ConfigLoader {
                     
                     if (failIfNotLoaded == true) {
                         if (configs.isEmpty())
-                            throw new RuntimeException("Failed to load configuration resource '" + resourceName + "'");
+                            throw new ConfigException("Failed to load configuration resource '" + resourceName + "'");
                         failIfNotLoaded = false;
                     }
                 }

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/CascadingCompositeConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/CascadingCompositeConfig.java
@@ -193,8 +193,7 @@ public class CascadingCompositeConfig extends DelegatingConfig implements Compos
     }
 
     @Override
-    public synchronized void setStrInterpolator(StrInterpolator interpolator)
-    {
+    public synchronized void setStrInterpolator(StrInterpolator interpolator) {
         super.setStrInterpolator(interpolator);
         for (Config config : children) {
             postConfigUpdate(config);
@@ -202,8 +201,7 @@ public class CascadingCompositeConfig extends DelegatingConfig implements Compos
     }
 
     @Override
-    public synchronized void addListener(ConfigListener listener)
-    {
+    public synchronized void addListener(ConfigListener listener) {
         super.addListener(listener);
         for (Config config : children) {
             postConfigUpdate(config);
@@ -211,11 +209,15 @@ public class CascadingCompositeConfig extends DelegatingConfig implements Compos
     }
 
     @Override
-    public synchronized void removeListener(ConfigListener listener)
-    {
+    public synchronized void removeListener(ConfigListener listener) {
         super.removeListener(listener);
         for (Config config : children) {
             postConfigUpdate(config);
         }
+    }
+
+    @Override
+    public Config getConfig(String name) {
+        return lookup.get(name);
     }
 }

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/CompositeConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/CompositeConfig.java
@@ -31,6 +31,8 @@ public interface CompositeConfig extends Config {
         void visit(Config child);
     }
 
+    Config getConfig(String name);
+    
     void addConfig(Config child) throws ConfigException;
 
     void addConfigs(Collection<Config> config) throws ConfigException;

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/DelegatingConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/DelegatingConfig.java
@@ -47,7 +47,7 @@ public abstract class DelegatingConfig extends AbstractConfig {
         Config config = getConfigWithProperty(key, false);
         if (config == null)
             return defaultValue;
-        return config.getLong(key);
+        return config.getLong(key, defaultValue);
     }
 
     @Override
@@ -60,7 +60,7 @@ public abstract class DelegatingConfig extends AbstractConfig {
         Config config = getConfigWithProperty(key, false);
         if (config == null)
             return defaultValue;
-        return config.getString(key);
+        return config.getString(key, defaultValue);
     }
 
     @Override
@@ -73,7 +73,7 @@ public abstract class DelegatingConfig extends AbstractConfig {
         Config config = getConfigWithProperty(key, false);
         if (config == null)
             return defaultValue;
-        return config.getDouble(key);
+        return config.getDouble(key, defaultValue);
     }
 
     @Override
@@ -86,7 +86,7 @@ public abstract class DelegatingConfig extends AbstractConfig {
         Config config = getConfigWithProperty(key, false);
         if (config == null)
             return defaultValue;
-        return config.getInteger(key);
+        return config.getInteger(key, defaultValue);
     }
 
     @Override
@@ -99,7 +99,7 @@ public abstract class DelegatingConfig extends AbstractConfig {
         Config config = getConfigWithProperty(key, false);
         if (config == null)
             return defaultValue;
-        return config.getBoolean(key);
+        return config.getBoolean(key, defaultValue);
     }
 
     @Override
@@ -112,7 +112,7 @@ public abstract class DelegatingConfig extends AbstractConfig {
         Config config = getConfigWithProperty(key, false);
         if (config == null)
             return defaultValue;
-        return config.getShort(key);
+        return config.getShort(key, defaultValue);
     }
 
     @Override
@@ -125,7 +125,7 @@ public abstract class DelegatingConfig extends AbstractConfig {
         Config config = getConfigWithProperty(key, false);
         if (config == null)
             return defaultValue;
-        return config.getBigInteger(key);
+        return config.getBigInteger(key, defaultValue);
     }
 
     @Override
@@ -138,7 +138,7 @@ public abstract class DelegatingConfig extends AbstractConfig {
         Config config = getConfigWithProperty(key, false);
         if (config == null)
             return defaultValue;
-        return config.getBigDecimal(key);
+        return config.getBigDecimal(key, defaultValue);
     }
 
     @Override
@@ -151,7 +151,7 @@ public abstract class DelegatingConfig extends AbstractConfig {
         Config config = getConfigWithProperty(key, false);
         if (config == null)
             return defaultValue;
-        return config.getFloat(key);
+        return config.getFloat(key, defaultValue);
     }
 
     @Override
@@ -164,7 +164,7 @@ public abstract class DelegatingConfig extends AbstractConfig {
         Config config = getConfigWithProperty(key, false);
         if (config == null)
             return defaultValue;
-        return config.getByte(key);
+        return config.getByte(key, defaultValue);
     }
 
     @Override
@@ -177,7 +177,7 @@ public abstract class DelegatingConfig extends AbstractConfig {
         Config config = getConfigWithProperty(key, false);
         if (config == null)
             return defaultValue;
-        return config.getList(key);
+        return config.getList(key, defaultValue);
     }
 
     @Override
@@ -190,7 +190,7 @@ public abstract class DelegatingConfig extends AbstractConfig {
         Config config = getConfigWithProperty(key, false);
         if (config == null)
             return defaultValue;
-        return config.get(type, key);
+        return config.get(type, key, defaultValue);
     }
 
     @Override

--- a/archaius2-core/src/test/java/com/netflix/archaius/ConfigManagerTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/ConfigManagerTest.java
@@ -19,10 +19,8 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.netflix.archaius.cascade.ConcatCascadeStrategy;
-import com.netflix.archaius.config.EnvironmentConfig;
 import com.netflix.archaius.config.MapConfig;
 import com.netflix.archaius.config.SimpleDynamicConfig;
-import com.netflix.archaius.config.SystemConfig;
 import com.netflix.archaius.exceptions.ConfigException;
 import com.netflix.archaius.loaders.PropertiesConfigReader;
 import com.netflix.archaius.property.DefaultPropertyListener;
@@ -36,8 +34,8 @@ public class ConfigManagerTest {
                 .withApplicationConfigName("application")
                 .build();
         
-        config.addConfig(dyn);
-        config.addConfig(MapConfig.builder("test")
+        config.getCompositeLayer(DefaultAppConfig.LIBRARY_LAYER).addConfig(dyn);
+        config.getCompositeLayer(DefaultAppConfig.LIBRARY_LAYER).addConfig(MapConfig.builder("test")
                         .put("env",    "prod")
                         .put("region", "us-east")
                         .put("c",      123)
@@ -66,7 +64,7 @@ public class ConfigManagerTest {
                 .withConfigReader(new PropertiesConfigReader())
                 .build();
                 
-        config.addConfig(MapConfig.builder("test")
+        config.getCompositeLayer(DefaultAppConfig.LIBRARY_LAYER).addConfig(MapConfig.builder("test")
                     .put("env",    "prod")
                     .put("region", "us-east")
                     .build());

--- a/archaius2-core/src/test/java/com/netflix/archaius/DefaultAppConfigTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/DefaultAppConfigTest.java
@@ -108,7 +108,7 @@ public class DefaultAppConfigTest {
     public void shouldNotFailWithNoApplicationConfig() throws ConfigException {
         DefaultAppConfig.builder()
             .withApplicationConfigName("non-existant")
-            .withFailOnFirst(false)
+            .withFailOnFirstCascadeLoad(false)
             .build();
     }
 }

--- a/archaius2-core/src/test/java/com/netflix/archaius/mapper/DefaultConfigMapperTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/mapper/DefaultConfigMapperTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 
 import com.netflix.archaius.DefaultAppConfig;
 import com.netflix.archaius.annotations.DefaultValue;
+import com.netflix.archaius.exceptions.ConfigException;
 import com.netflix.archaius.mapper.DefaultConfigMapper;
 import com.netflix.archaius.property.PrefixedObservablePropertyFactory;
 
@@ -62,7 +63,7 @@ public class DefaultConfigMapperTest {
     }
     
     @Test
-    public void testProxy() {
+    public void testProxy() throws ConfigException {
         Properties props = new Properties();
         props.put("prefix.string",   "loaded");
         props.put("prefix.integer",  1);
@@ -103,7 +104,7 @@ public class DefaultConfigMapperTest {
     }
     
     @Test
-    public void testProxyWithDefaults() {
+    public void testProxyWithDefaults() throws ConfigException{
         DefaultAppConfig config = DefaultAppConfig.builder()
                 .withApplicationConfigName("application")
                 .build();

--- a/archaius2-core/src/test/java/com/netflix/archaius/property/PropertyTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/property/PropertyTest.java
@@ -42,7 +42,7 @@ public class PropertyTest {
     public void test() throws ConfigException {
         DefaultAppConfig config = DefaultAppConfig.builder().withApplicationConfigName("application").build();
         
-        System.out.println("Configs: " + config.getConfigNames());
+        System.out.println("Configs: " + config.getLayerNames());
         
         MyService service = new MyService(config);
 
@@ -59,7 +59,7 @@ public class PropertyTest {
     public void testPropertyIsCached() throws ConfigException {
         DefaultAppConfig config = DefaultAppConfig.builder().withApplicationConfigName("application").build();
         
-        System.out.println("Configs: " + config.getConfigNames());
+        System.out.println("Configs: " + config.getLayerNames());
         
         Property<Integer> intProp1 = config.getProperty("foo").asInteger(1);
         Property<Integer> intProp2 = config.getProperty("foo").asInteger(2);
@@ -80,7 +80,7 @@ public class PropertyTest {
         SimpleDynamicConfig dynamic = new SimpleDynamicConfig("dyn");
         
         DefaultAppConfig config = DefaultAppConfig.builder().withApplicationConfigName("application").build();
-        config.addOverrideConfig(dynamic);
+        config.getCompositeLayer(DefaultAppConfig.DYNAMIC_LAYER).addConfig(dynamic);
         
         System.out.println("Configs: " + config.toString());
         

--- a/archaius2-core/src/test/java/com/netflix/archaius/property/PropertyTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/property/PropertyTest.java
@@ -80,7 +80,7 @@ public class PropertyTest {
         SimpleDynamicConfig dynamic = new SimpleDynamicConfig("dyn");
         
         DefaultAppConfig config = DefaultAppConfig.builder().withApplicationConfigName("application").build();
-        config.getCompositeLayer(DefaultAppConfig.DYNAMIC_LAYER).addConfig(dynamic);
+        config.getCompositeLayer(DefaultAppConfig.OVERRIDE_LAYER).addConfig(dynamic);
         
         System.out.println("Configs: " + config.toString());
         

--- a/archaius2-guice/src/main/java/com/netflix/archaius/guice/ArchaiusModule.java
+++ b/archaius2-guice/src/main/java/com/netflix/archaius/guice/ArchaiusModule.java
@@ -175,7 +175,6 @@ public final class ArchaiusModule extends AbstractModule {
     final AppConfig getAppConfig(CascadeStrategy defaultStrategy) throws ConfigException {
         return DefaultAppConfig.builder()
                 .withDefaultCascadingStrategy(defaultStrategy)
-                .withApplicationConfigName(DefaultAppConfig.DEFAULT_APP_CONFIG_NAME)
                 .build();
     }
 

--- a/archaius2-guice/src/main/java/com/netflix/archaius/guice/ArchaiusModule.java
+++ b/archaius2-guice/src/main/java/com/netflix/archaius/guice/ArchaiusModule.java
@@ -126,7 +126,8 @@ public final class ArchaiusModule extends AbstractModule {
                         if (source != null) {
                             for (String value : source.value()) {
                                 try {
-                                    appConfig.addLibraryConfig(appConfig.newLoader().withCascadeStrategy(strategy).load(value));
+                                    appConfig.getCompositeLayer(DefaultAppConfig.LIBRARY_LAYER)
+                                             .addConfig(appConfig.newLoader().withCascadeStrategy(strategy).load(value));
                                 } catch (ConfigException e) {
                                     throw new ProvisionException("Unable to load configuration for " + value + " at source " + injectee.getClass(), e);
                                 }
@@ -171,13 +172,22 @@ public final class ArchaiusModule extends AbstractModule {
     
     @Provides
     @Singleton
-    final AppConfig getAppConfig() {
-        return DefaultAppConfig.createDefault();
+    final AppConfig getAppConfig(CascadeStrategy defaultStrategy) throws ConfigException {
+        return DefaultAppConfig.builder()
+                .withDefaultCascadingStrategy(defaultStrategy)
+                .withApplicationConfigName(DefaultAppConfig.DEFAULT_APP_CONFIG_NAME)
+                .build();
     }
 
     @Provides
     @Singleton
     final Config getConfig(AppConfig config) {
         return config;
+    }
+    
+    @Provides
+    @Singleton
+    final CascadeStrategy getDefaultCascadeStrategy() {
+        return DefaultAppConfig.DEFAULT_CASCADE_STRATEGY;
     }
 }

--- a/archaius2-guice/src/test/java/com/netflix/archaius/guice/ArchaiusModuleTest.java
+++ b/archaius2-guice/src/test/java/com/netflix/archaius/guice/ArchaiusModuleTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.google.inject.name.Names;
 import com.google.inject.util.Modules;
@@ -37,6 +38,7 @@ import com.netflix.archaius.annotations.ConfigurationSource;
 import com.netflix.archaius.annotations.DefaultValue;
 import com.netflix.archaius.cascade.ConcatCascadeStrategy;
 import com.netflix.archaius.config.MapConfig;
+import com.netflix.archaius.exceptions.ConfigException;
 import com.netflix.archaius.exceptions.MappingException;
 import com.netflix.archaius.mapper.DefaultConfigMapper;
 
@@ -106,7 +108,7 @@ public class ArchaiusModuleTest {
     }
     
     @Test
-    public void test() {
+    public void test() throws ConfigException {
         final Properties props = new Properties();
         props.setProperty("prefix-prod.str_value", "str_value");
         props.setProperty("prefix-prod.int_value", "123");
@@ -119,8 +121,14 @@ public class ArchaiusModuleTest {
                    .with(new AbstractModule() {
                        @Override
                        protected void configure() {
-                           bind(AppConfig.class).toInstance(DefaultAppConfig.builder().withProperties(props).build());
                        }
+                       
+                       @Provides
+                       @Singleton
+                       public AppConfig getAppConfig() throws ConfigException {
+                           return DefaultAppConfig.builder().withProperties(props).build();
+                       }
+
                    })
         );
         
@@ -143,7 +151,7 @@ public class ArchaiusModuleTest {
     }
     
     @Test
-    public void testNamedInjection() {
+    public void testNamedInjection() throws ConfigException {
         final Properties props = new Properties();
         props.setProperty("prefix-prod.named", "name1");
         props.setProperty("env", "prod");
@@ -153,7 +161,12 @@ public class ArchaiusModuleTest {
                    .with(new AbstractModule() {
                         @Override
                         protected void configure() {
-                            bind(AppConfig.class).toInstance(DefaultAppConfig.builder().withProperties(props).build());
+                        }
+                        
+                        @Provides
+                        @Singleton
+                        public AppConfig getAppConfig() throws ConfigException {
+                            return DefaultAppConfig.builder().withProperties(props).build();
                         }
                    })
             ,

--- a/archaius2-persisted2/src/main/java/com/netflix/archaius/persisted2/JsonPersistedV2Reader.java
+++ b/archaius2-persisted2/src/main/java/com/netflix/archaius/persisted2/JsonPersistedV2Reader.java
@@ -14,11 +14,11 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 
 import org.apache.commons.lang3.StringUtils;
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.archaius.config.polling.PollingResponse;
 
 /**

--- a/archaius2-persisted2/src/main/java/com/netflix/archaius/persisted2/JsonPersistedV2Reader.java
+++ b/archaius2-persisted2/src/main/java/com/netflix/archaius/persisted2/JsonPersistedV2Reader.java
@@ -13,9 +13,9 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.Callable;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.StringUtils;
+import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.map.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/archaius2-typesafe/src/test/java/com/netflix/archaius/typesafe/TypesafeConfigLoaderTest.java
+++ b/archaius2-typesafe/src/test/java/com/netflix/archaius/typesafe/TypesafeConfigLoaderTest.java
@@ -37,12 +37,12 @@ public class TypesafeConfigLoaderTest {
                 .withStrInterpolator(config.getStrInterpolator())
                 .build();
         
-        config.addConfig(MapConfig.builder("test")
+        config.getCompositeLayer(DefaultAppConfig.LIBRARY_LAYER).addConfig(MapConfig.builder("test")
                         .put("env",    "prod")
                         .put("region", "us-east")
                         .build());
         
-        config.addConfig(loader.newLoader()
+        config.getCompositeLayer(DefaultAppConfig.LIBRARY_LAYER).addConfig(loader.newLoader()
               .withCascadeStrategy(ConcatCascadeStrategy.from("${env}", "${region}"))
               .load("foo"));
         


### PR DESCRIPTION
Modify DefaultAppConfig to be a DelegatingConfig instead of a CascadingCompositeConfig to avoid exposing all of the CascadingCompositeConfig functionality.
Remove withLoadSystem from ConfigLoader
Expose getting any layer from AppConfig