### PR TITLE
Fast property update optimization

### DIFF
--- a/archaius2-core/src/main/java/com/netflix/archaius/PropertyContainer.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/PropertyContainer.java
@@ -19,12 +19,6 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 
 public interface PropertyContainer {
-    
-    /**
-     * Notify the container that it should fetch the latest property value
-     */
-    void update();
-    
     /**
      * Parse the property as a string 
      */

--- a/archaius2-core/src/main/java/com/netflix/archaius/property/ListenerManager.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/property/ListenerManager.java
@@ -1,0 +1,43 @@
+package com.netflix.archaius.property;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import com.netflix.archaius.PropertyListener;
+
+/**
+ * Globally managed list of listeners.  Listeners are tracked globally as 
+ * an optimization so it is not necessary to iterate through all property
+ * containers when the listeners need to be invoked since the expectation
+ * is to have far less listeners than property containers.
+ * 
+ * @author elandau
+ */
+public class ListenerManager {
+    public static interface ListenerUpdater {
+        public void update();
+    }
+
+    private final ConcurrentMap<PropertyListener<?>, ListenerUpdater> lookup = new ConcurrentHashMap<>();
+    private final CopyOnWriteArrayList<ListenerUpdater> updaters = new CopyOnWriteArrayList<>();
+
+    public void add(PropertyListener<?> listener, ListenerUpdater updater) {
+        lookup.put(listener, updater);
+        updaters.add(updater);
+        updater.update();
+    }
+
+    public void remove(PropertyListener<?> listener) {
+        ListenerUpdater updater = lookup.remove(listener);
+        if (updater != null) {
+            updaters.remove(updater);
+        }
+    }
+
+    public void updateAll() {
+        for (ListenerUpdater updater : updaters) {
+            updater.update();
+        }
+    }
+}

--- a/archaius2-core/src/test/java/com/netflix/archaius/config/CompositeConfigTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/CompositeConfigTest.java
@@ -13,22 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.archaius;
+package com.netflix.archaius.config;
 
 import java.util.Properties;
 
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.netflix.archaius.DefaultConfigLoader;
 import com.netflix.archaius.cascade.ConcatCascadeStrategy;
-import com.netflix.archaius.config.CompositeConfig;
-import com.netflix.archaius.config.MapConfig;
 import com.netflix.archaius.exceptions.ConfigException;
 import com.netflix.archaius.visitor.PrintStreamVisitor;
 
-public class DefaultAppConfigTest {
+public class CompositeConfigTest {
     @Test
-    public void testAppAndLibraryLoading() throws ConfigException {
+    public void basicTest() throws ConfigException {
         Properties props = new Properties();
         props.setProperty("env", "prod");
         
@@ -70,52 +69,5 @@ public class DefaultAppConfigTest {
         Assert.assertEquals("libA", config.getString("libA.overrideA"));
         
         config.accept(new PrintStreamVisitor());
-    }
-    
-    @Test
-    public void interpolationShouldWork() throws ConfigException {
-        Config config = MapConfig.builder()
-                .put("env",         "prod")
-                .put("replacement", "${env}")
-                .build();
-        
-        Assert.assertEquals("prod", config.getString("replacement"));
-    }
-    
-    @Test(expected=IllegalStateException.class)
-    public void infiniteInterpolationRecursionShouldFail() throws ConfigException  {
-        Config config = MapConfig.builder()
-                .put("env", "${env}")
-                .put("replacement.env", "${env}")
-                .build();
-        
-        Assert.assertEquals("prod", config.getString("replacement.env"));
-    }
-    
-    @Test
-    public void numericInterpolationShouldWork() throws ConfigException  {
-        Config config = MapConfig.builder()
-                .put("default",     "123")
-                .put("value",       "${default}")
-                .build();
-        
-        Assert.assertEquals((long)123L, (long)config.getLong("value"));
-    }
-    
-    @Test(expected=ConfigException.class)
-    public void shouldFailWithNoApplicationConfig() throws ConfigException {
-        DefaultConfigLoader loader = DefaultConfigLoader.builder()
-                .build();
-        
-        loader.newLoader().load("non-existant");
-    }
-    
-    @Test
-    public void shouldNotFailWithNoApplicationConfig() throws ConfigException {
-        DefaultConfigLoader loader = DefaultConfigLoader.builder()
-                .withFailOnFirst(false)
-                .build();
-        
-        loader.newLoader().load("non-existant");
     }
 }

--- a/archaius2-core/src/test/java/com/netflix/archaius/config/ConfigLoaderTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/ConfigLoaderTest.java
@@ -1,0 +1,27 @@
+package com.netflix.archaius.config;
+
+import org.junit.Test;
+
+import com.netflix.archaius.DefaultConfigLoader;
+import com.netflix.archaius.exceptions.ConfigException;
+
+public class ConfigLoaderTest {
+    
+    @Test(expected=ConfigException.class)
+    public void shouldFailWithNoApplicationConfig() throws ConfigException {
+        DefaultConfigLoader loader = DefaultConfigLoader.builder()
+                .build();
+        
+        loader.newLoader().load("non-existant");
+    }
+    
+    @Test
+    public void shouldNotFailWithNoApplicationConfig() throws ConfigException {
+        DefaultConfigLoader loader = DefaultConfigLoader.builder()
+                .withFailOnFirst(false)
+                .build();
+        
+        loader.newLoader().load("non-existant");
+    }
+
+}

--- a/archaius2-core/src/test/java/com/netflix/archaius/config/MapConfigTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/MapConfigTest.java
@@ -17,9 +17,12 @@ package com.netflix.archaius.config;
 
 import java.util.NoSuchElementException;
 
+import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import com.netflix.archaius.Config;
+import com.netflix.archaius.exceptions.ConfigException;
 import com.netflix.archaius.exceptions.ParseException;
 
 public class MapConfigTest {
@@ -134,4 +137,36 @@ public class MapConfigTest {
     public void invalidShort() {
         config.getShort("badnumber");
     }
+    
+    @Test
+    public void interpolationShouldWork() throws ConfigException {
+        Config config = MapConfig.builder()
+                .put("env",         "prod")
+                .put("replacement", "${env}")
+                .build();
+        
+        Assert.assertEquals("prod", config.getString("replacement"));
+    }
+    
+    @Test(expected=IllegalStateException.class)
+    public void infiniteInterpolationRecursionShouldFail() throws ConfigException  {
+        Config config = MapConfig.builder()
+                .put("env", "${env}")
+                .put("replacement.env", "${env}")
+                .build();
+        
+        Assert.assertEquals("prod", config.getString("replacement.env"));
+    }
+    
+    @Test
+    public void numericInterpolationShouldWork() throws ConfigException  {
+        Config config = MapConfig.builder()
+                .put("default",     "123")
+                .put("value",       "${default}")
+                .build();
+        
+        Assert.assertEquals((long)123L, (long)config.getLong("value"));
+    }
+    
+
 }


### PR DESCRIPTION
Optimize fast property behavior to use a global dirty flag instead of updating each property individually.  With this change updating ALL fast properties is just a matter of incrementing a single AtomicInteger.  Calling get() on each property will now update the value inline if the global flag has been set.  Listener notification is still done at the time of update but only for the listeners and not for each property.  The assumption here is that there could be 1000's of fast properties but only a handful of listeners.  