### PR TITLE
quote keys for typesafe config

### DIFF
--- a/archaius2-typesafe/src/main/java/com/netflix/archaius/typesafe/TypesafeConfig.java
+++ b/archaius2-typesafe/src/main/java/com/netflix/archaius/typesafe/TypesafeConfig.java
@@ -33,7 +33,7 @@ public class TypesafeConfig extends AbstractConfig {
 
     @Override
     public boolean containsKey(String key) {
-        return config.hasPath(key);
+        return config.hasPath(quoteKey(key));
     }
 
     @Override
@@ -44,11 +44,16 @@ public class TypesafeConfig extends AbstractConfig {
     @Override
     public Object getRawProperty(String key) {
         // TODO: Handle lists
-        return config.getValue(key).unwrapped().toString();
+        return config.getValue(quoteKey(key)).unwrapped().toString();
     }
 
     public List getList(String key) {
         throw new UnsupportedOperationException("Not supported yet");
+    }
+
+    private String quoteKey(String key) {
+        final String escaped = key.replace("\\", "\\\\").replace("\"", "\\\"");
+        return "\"" + escaped + "\"";
     }
 
     @Override

--- a/archaius2-typesafe/src/main/java/com/netflix/archaius/typesafe/TypesafeConfig.java
+++ b/archaius2-typesafe/src/main/java/com/netflix/archaius/typesafe/TypesafeConfig.java
@@ -21,6 +21,7 @@ import java.util.Map.Entry;
 
 import com.netflix.archaius.config.AbstractConfig;
 import com.typesafe.config.Config;
+import com.typesafe.config.ConfigUtil;
 import com.typesafe.config.ConfigValue;
 
 public class TypesafeConfig extends AbstractConfig {
@@ -52,8 +53,18 @@ public class TypesafeConfig extends AbstractConfig {
     }
 
     private String quoteKey(String key) {
-        final String escaped = key.replace("\\", "\\\\").replace("\"", "\\\"");
-        return "\"" + escaped + "\"";
+        final String[] path = key.split("\\.");
+        return ConfigUtil.joinPath(path);
+    }
+
+    private String unquoteKey(String key) {
+        final List<String> path = ConfigUtil.splitPath(key);
+        StringBuilder buf = new StringBuilder();
+        buf.append(path.get(0));
+        for (String p : path.subList(1, path.size())) {
+            buf.append('.').append(p);
+        }
+        return buf.toString();
     }
 
     @Override
@@ -68,7 +79,7 @@ public class TypesafeConfig extends AbstractConfig {
 
             @Override
             public String next() {
-                return iter.next().getKey();
+                return unquoteKey(iter.next().getKey());
             }
 
             @Override

--- a/archaius2-typesafe/src/test/java/com/netflix/archaius/typesafe/TypesafeConfigLoaderTest.java
+++ b/archaius2-typesafe/src/test/java/com/netflix/archaius/typesafe/TypesafeConfigLoaderTest.java
@@ -24,6 +24,8 @@ import com.netflix.archaius.config.CompositeConfig;
 import com.netflix.archaius.config.MapConfig;
 import com.netflix.archaius.exceptions.ConfigException;
 
+import java.util.Iterator;
+
 public class TypesafeConfigLoaderTest {
     @Test
     public void test() throws ConfigException {
@@ -41,9 +43,10 @@ public class TypesafeConfigLoaderTest {
         config.addConfig("foo", loader.newLoader()
               .withCascadeStrategy(ConcatCascadeStrategy.from("${env}", "${region}"))
               .load("foo"));
-        
-        
+
+        Assert.assertEquals("prod", config.getString("@environment"));
         Assert.assertEquals("foo-prod", config.getString("foo.prop1"));
         Assert.assertEquals("foo", config.getString("foo.prop2"));
-    }   
+    }
+
 }

--- a/archaius2-typesafe/src/test/java/com/netflix/archaius/typesafe/TypesafeConfigLoaderTest.java
+++ b/archaius2-typesafe/src/test/java/com/netflix/archaius/typesafe/TypesafeConfigLoaderTest.java
@@ -24,8 +24,6 @@ import com.netflix.archaius.config.CompositeConfig;
 import com.netflix.archaius.config.MapConfig;
 import com.netflix.archaius.exceptions.ConfigException;
 
-import java.util.Iterator;
-
 public class TypesafeConfigLoaderTest {
     @Test
     public void test() throws ConfigException {

--- a/archaius2-typesafe/src/test/java/com/netflix/archaius/typesafe/TypesafeConfigTest.java
+++ b/archaius2-typesafe/src/test/java/com/netflix/archaius/typesafe/TypesafeConfigTest.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.archaius.typesafe;
+
+import com.netflix.archaius.Config;
+import com.typesafe.config.ConfigFactory;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.netflix.archaius.DefaultConfigLoader;
+import com.netflix.archaius.cascade.ConcatCascadeStrategy;
+import com.netflix.archaius.config.CompositeConfig;
+import com.netflix.archaius.config.MapConfig;
+import com.netflix.archaius.exceptions.ConfigException;
+
+public class TypesafeConfigTest {
+    @Test
+    public void simple() throws ConfigException {
+        Config config = new TypesafeConfig(ConfigFactory.parseString("a=b"));
+        Assert.assertEquals("b", config.getString("a"));
+    }
+
+    @Test
+    public void keyWithAt() throws ConfigException {
+        Config config = new TypesafeConfig(ConfigFactory.parseString("\"@a\"=b"));
+        Assert.assertEquals("b", config.getString("@a"));
+    }
+
+    @Test
+    public void specialChars() throws ConfigException {
+        for (char c = '!'; c <= '~'; ++c) {
+            String k = c + "a";
+            String escaped = k.replace("\\", "\\\\").replace("\"", "\\\"");
+            Config mc = MapConfig.builder().put(k, "b").build();
+            Config tc = new TypesafeConfig(ConfigFactory.parseString("\"" + escaped + "\"=b"));
+            Assert.assertEquals(mc.getString(k), tc.getString(k));
+            Assert.assertEquals(mc.containsKey(k), tc.containsKey(k));
+        }
+    }
+}

--- a/archaius2-typesafe/src/test/resources/foo-prod.properties
+++ b/archaius2-typesafe/src/test/resources/foo-prod.properties
@@ -15,3 +15,4 @@
 #
 
 foo.prop1=foo-prod
+@environment=prod


### PR DESCRIPTION
Certain characters such as `!`, `@`, and `"` need to be
in quotes or escaped to avoid errors:

```
1) Error injecting method, com.typesafe.config.ConfigException$BadPath: path parameter: Invalid path '@environment': Token not allowed in path expression: '@' (Reserved character '@' is not allowed outside quotes) (you can double-quote this token if you really want it here)
  at com.netflix.archaius.bridge.StaticAbstractConfiguration.intialize(StaticAbstractConfiguration.java:24)
Caused by: com.typesafe.config.ConfigException$BadPath: path parameter: Invalid path '@environment': Token not allowed in path expression: '@' (Reserved character '@' is not allowed outside quotes) (you can double-quote this token if you really want it here)
        at com.typesafe.config.impl.Parser.parsePathExpression(Parser.java:1095)
        at com.typesafe.config.impl.Parser.parsePath(Parser.java:1135)
        at com.typesafe.config.impl.Path.newPath(Path.java:224)
        at com.typesafe.config.impl.SimpleConfig.hasPath(SimpleConfig.java:80)
        at com.netflix.archaius.typesafe.TypesafeConfig.containsKey(TypesafeConfig.java:36)
        at com.netflix.archaius.config.CompositeConfig.containsKey(CompositeConfig.java:225)
        at com.netflix.archaius.bridge.AbstractConfigurationBridge.containsKey(AbstractConfigurationBridge.java:56)
        at com.netflix.config.ConfigurationManager.setDirect(ConfigurationManager.java:201)
        at com.netflix.config.ConfigurationManager.install(ConfigurationManager.java:124)
        at com.netflix.archaius.bridge.StaticAbstractConfiguration.intialize(StaticAbstractConfiguration.java:25)
```

A test case has been added to check that the quoting works
to get the same results as MapConfig.