### PR TITLE
Config loading cleanup

### DIFF
--- a/archaius2-core/src/main/java/com/netflix/archaius/ConfigLoader.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/ConfigLoader.java
@@ -17,6 +17,7 @@ package com.netflix.archaius;
 
 import java.io.File;
 import java.net.URL;
+import java.util.LinkedHashMap;
 import java.util.Properties;
 
 import com.netflix.archaius.exceptions.ConfigException;
@@ -69,7 +70,7 @@ public interface ConfigLoader {
          * @param resourceName
          * @return
          */
-        Config load(String resourceName) throws ConfigException;
+        LinkedHashMap<String, Config> load(String resourceName) throws ConfigException;
         
         /**
          * Load configuration from a specific URL

--- a/archaius2-core/src/test/java/com/netflix/archaius/config/CompositeConfigTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/CompositeConfigTest.java
@@ -45,14 +45,14 @@ public class CompositeConfigTest {
             .withDefaultCascadingStrategy(ConcatCascadeStrategy.from("${env}"))
             .build();
         
-        application.addConfig("app", loader.newLoader().load("application"));
+        application.replaceConfigs(loader.newLoader().load("application"));
         
         Assert.assertTrue(config.getBoolean("application.loaded"));
         Assert.assertTrue(config.getBoolean("application-prod.loaded", false));
         
         Assert.assertFalse(config.getBoolean("libA.loaded", false));
         
-        libraries.addConfig("libA", loader.newLoader().load("libA"));
+        libraries.replaceConfigs(loader.newLoader().load("libA"));
         libraries.accept(new PrintStreamVisitor());
         
         config.accept(new PrintStreamVisitor());
@@ -61,7 +61,7 @@ public class CompositeConfigTest {
         Assert.assertFalse(config.getBoolean("libB.loaded", false));
         Assert.assertEquals("libA", config.getString("libA.overrideA"));
         
-        libraries.addConfig("libB", loader.newLoader().load("libB"));
+        libraries.replaceConfigs(loader.newLoader().load("libB"));
         
         System.out.println(config.toString());
         Assert.assertTrue(config.getBoolean("libA.loaded"));
@@ -90,14 +90,14 @@ public class CompositeConfigTest {
             .withDefaultCascadingStrategy(ConcatCascadeStrategy.from("${env}"))
             .build();
         
-        application.addConfig("app", loader.newLoader().load("application"));
+        application.replaceConfigs(loader.newLoader().load("application"));
         
         Assert.assertTrue(config.getBoolean("application.loaded"));
         Assert.assertTrue(config.getBoolean("application-prod.loaded", false));
         
         Assert.assertFalse(config.getBoolean("libA.loaded", false));
         
-        libraries.addConfig("libA", loader.newLoader().load("libA"));
+        libraries.replaceConfigs(loader.newLoader().load("libA"));
         libraries.accept(new PrintStreamVisitor());
         
         config.accept(new PrintStreamVisitor());
@@ -106,7 +106,7 @@ public class CompositeConfigTest {
         Assert.assertFalse(config.getBoolean("libB.loaded", false));
         Assert.assertEquals("libA", config.getString("libA.overrideA"));
         
-        libraries.addConfig("libB", loader.newLoader().load("libB"));
+        libraries.replaceConfigs(loader.newLoader().load("libB"));
         
         System.out.println(config.toString());
         Assert.assertTrue(config.getBoolean("libA.loaded"));

--- a/archaius2-core/src/test/java/com/netflix/archaius/loaders/PropertyConfigReaderTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/loaders/PropertyConfigReaderTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 
 import com.netflix.archaius.Config;
 import com.netflix.archaius.exceptions.ConfigException;
+import com.netflix.archaius.readers.PropertiesConfigReader;
 
 public class PropertyConfigReaderTest {
     @Test

--- a/archaius2-guice/src/main/java/com/netflix/archaius/guice/ConfigurationInjectingListener.java
+++ b/archaius2-guice/src/main/java/com/netflix/archaius/guice/ConfigurationInjectingListener.java
@@ -66,7 +66,7 @@ public class ConfigurationInjectingListener implements TypeListener, IoCContaine
                     if (source != null) {
                         for (String resourceName : source.value()) {
                             try {
-                                librariesConfig.addConfig(resourceName, loader.newLoader().withCascadeStrategy(strategy).load(resourceName));
+                                librariesConfig.replaceConfigs(loader.newLoader().withCascadeStrategy(strategy).load(resourceName));
                             } 
                             catch (ConfigException e) {
                                 throw new ProvisionException("Unable to load configuration for " + resourceName + " at source " + injectee.getClass(), e);

--- a/archaius2-typesafe/src/test/java/com/netflix/archaius/typesafe/TypesafeConfigLoaderTest.java
+++ b/archaius2-typesafe/src/test/java/com/netflix/archaius/typesafe/TypesafeConfigLoaderTest.java
@@ -38,7 +38,7 @@ public class TypesafeConfigLoaderTest {
                 .withStrLookup(config)
                 .build();
         
-        config.addConfig("foo", loader.newLoader()
+        config.addConfigs(loader.newLoader()
               .withCascadeStrategy(ConcatCascadeStrategy.from("${env}", "${region}"))
               .load("foo"));
         


### PR DESCRIPTION
* Modify config loader to load resources as a LinkedHashMap<String, Config> instead of being inconsistent with merging Configs when multiple resources are loaded
* Move @next processing to PropertiesConfigReader instead of forcing it on all ConfigReader's since doing so breaks Typesafe's loading
* Add addConfigs and replaceConfigs to CompositeConfig
* Fix bug where application cascade loading wasn't done correctly