### PR TITLE
upgrade Guava to 16.0 to comply with Netflix applications

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ project(':archaius-core') {
     dependencies {
         compile 'commons-configuration:commons-configuration:1.8'
         compile 'org.slf4j:slf4j-api:1.6.4'
-        compile 'com.google.guava:guava:11.0.2'    
+        compile 'com.google.guava:guava:16.0'
         compile 'com.fasterxml.jackson.core:jackson-annotations:2.4.3'
         compile 'com.fasterxml.jackson.core:jackson-core:2.4.3'
         compile 'com.fasterxml.jackson.core:jackson-databind:2.4.3'


### PR DESCRIPTION
Need to upgrade Guava to 16.0 since all Netflix apps are going to upgrade to Guava 16.0