### PR TITLE
Fixing Unable to enable JMX support

### DIFF
--- a/archaius-core/src/main/java/com/netflix/config/ConfigurationManager.java
+++ b/archaius-core/src/main/java/com/netflix/config/ConfigurationManager.java
@@ -181,7 +181,7 @@ public class ConfigurationManager {
     }
     
     private static void registerConfigBean() {
-        if (Boolean.getBoolean(DynamicPropertyFactory.ENABLE_JMX)) {
+        if (Boolean.getBoolean(System.getProperty(DynamicPropertyFactory.ENABLE_JMX))) {
             try {
                 configMBean = ConfigJMXManager.registerConfigMbean(instance);
             } catch (Exception e) {


### PR DESCRIPTION
This guide (https://github.com/Netflix/archaius/wiki/Users-Guide) says that I can enable JMX support when i set system property like this. but i can't.

```java
archaius.dynamicPropertyFactory.registerConfigWithJMX=true
```

I searched source code why this could be happen and i found this.

```java
package com.netflix.config

public class ConfigurationManager {

    private static void registerConfigBean() {
        if (Boolean.getBoolean(DynamicPropertyFactory.ENABLE_JMX)) { // <--HERE !!
            try {
                configMBean = ConfigJMXManager.registerConfigMbean(instance);
            } catch (Exception e) {
                logger.error("Unable to register with JMX", e);
            }
        }        
    }
```

It seems to be always return FALSE. So, there's no way of enabling JMX.
Am I got something missing or wrong? or Is it just a bug?
Maybe changing like this seems should be ok.

```java
    private static void registerConfigBean() {
        if (Boolean.getBoolean(System.getProperty(DynamicPropertyFactory.ENABLE_JMX))) { 
            try {
                configMBean = ConfigJMXManager.registerConfigMbean(instance);
            } catch (Exception e) {
                logger.error("Unable to register with JMX", e);
            }
        }        
    }
```