### PR TITLE
Enhancements to configuration proxy

### DIFF
--- a/archaius2-core/src/main/java/com/netflix/archaius/ImmutableProperty.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/ImmutableProperty.java
@@ -1,0 +1,42 @@
+package com.netflix.archaius;
+
+import java.util.concurrent.TimeUnit;
+
+public class ImmutableProperty<T> implements Property<T> {
+
+    private final T value;
+    private final String name;
+    
+    public ImmutableProperty(String name, T value) {
+        this.value = value;
+        this.name = name;
+    }
+    
+    @Override
+    public T get() {
+        return value;
+    }
+
+    @Override
+    public long getLastUpdateTime(TimeUnit units) {
+        return 0;
+    }
+
+    @Override
+    public void unsubscribe() {
+    }
+
+    @Override
+    public Property<T> addListener(PropertyListener<T> listener) {
+        return null;
+    }
+
+    @Override
+    public void removeListener(PropertyListener<T> listener) {
+    }
+
+    @Override
+    public String getKey() {
+        return name;
+    }
+}

--- a/archaius2-core/src/main/java/com/netflix/archaius/Property.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/Property.java
@@ -76,5 +76,6 @@ public interface Property<T> {
      */
     void removeListener(PropertyListener<T> listener);
     
+    String getKey();
     
 }

--- a/archaius2-core/src/main/java/com/netflix/archaius/ProxyFactory.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/ProxyFactory.java
@@ -12,7 +12,7 @@ import javax.inject.Inject;
 
 import com.netflix.archaius.annotations.Configuration;
 import com.netflix.archaius.annotations.DefaultValue;
-import com.netflix.archaius.annotations.PropertyInfo;
+import com.netflix.archaius.annotations.PropertyName;
 
 /**
  * Factory for creating a Proxy instance that is bound to configuration.
@@ -85,10 +85,10 @@ public class ProxyFactory {
                 throw new RuntimeException("Method with primite return type must have a @DefaultValue.  method=" + m.getName());
             }
             
-            PropertyInfo info = m.getAnnotation(PropertyInfo.class); 
+            PropertyName nameAnnot = m.getAnnotation(PropertyName.class); 
             // TODO: sub proxy for non-primitive types
-            String propName = info != null && info.name() != null
-                            ? prefix + info.name()
+            String propName = nameAnnot != null && nameAnnot.name() != null
+                            ? prefix + nameAnnot.name()
                             : prefix + Character.toLowerCase(m.getName().charAt(verb.length())) + m.getName().substring(verb.length() + 1);
                             
             Property prop = factory.getProperty(propName).asType((Class)m.getReturnType(), defaultValue);

--- a/archaius2-core/src/main/java/com/netflix/archaius/ProxyFactory.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/ProxyFactory.java
@@ -4,12 +4,15 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import javax.inject.Inject;
 
 import com.netflix.archaius.annotations.Configuration;
 import com.netflix.archaius.annotations.DefaultValue;
+import com.netflix.archaius.annotations.PropertyInfo;
 
 /**
  * Factory for creating a Proxy instance that is bound to configuration.
@@ -42,10 +45,10 @@ public class ProxyFactory {
      * @return
      */
     @SuppressWarnings("unchecked")
-    public <T> T newProxy(Class<T> type, PropertyFactory factory) {
+    public <T> T newProxy(final Class<T> type, PropertyFactory factory) {
         Configuration annot = type.getAnnotation(Configuration.class);
         
-        String prefix = annot == null 
+        final String prefix = annot == null 
                       ? "" 
                       : !annot.prefix().isEmpty() && !annot.prefix().endsWith(".")
                           ? annot.prefix() + "."
@@ -56,8 +59,15 @@ public class ProxyFactory {
         //      prefix + lowerCamelCaseDerivedPropertyName
         final Map<Method, Property<?>> properties = new HashMap<Method, Property<?>>();
         for (Method m : type.getDeclaredMethods()) {
-            if (!m.getName().startsWith("get")) {
-                continue;
+            final String verb;
+            if (m.getName().startsWith("get")) {
+                verb = "get";
+            }
+            else if (m.getName().startsWith("is")) {
+                verb = "is";
+            }
+            else {
+                verb = "";
             }
             
             Object defaultValue = null;
@@ -75,16 +85,40 @@ public class ProxyFactory {
                 throw new RuntimeException("Method with primite return type must have a @DefaultValue.  method=" + m.getName());
             }
             
-            // TODO: default value
+            PropertyInfo info = m.getAnnotation(PropertyInfo.class); 
             // TODO: sub proxy for non-primitive types
-            String propName = prefix + Character.toLowerCase(m.getName().charAt(3)) + m.getName().substring(4);
-            properties.put(m, factory.getProperty(propName).asType((Class)m.getReturnType(), defaultValue));
+            String propName = info != null && info.name() != null
+                            ? prefix + info.name()
+                            : prefix + Character.toLowerCase(m.getName().charAt(verb.length())) + m.getName().substring(verb.length() + 1);
+                            
+            Property prop = factory.getProperty(propName).asType((Class)m.getReturnType(), defaultValue);
+            properties.put(m, annot != null && annot.immutable() ? new ImmutableProperty(propName, prop.get()) : prop);
         }
         
         final InvocationHandler handler = new InvocationHandler() {
             @Override
             public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-                return properties.get(method).get();
+                Property prop = properties.get(method);
+                if (prop != null) {
+                    return prop.get();
+                }
+                else if ("toString".equals(method.getName())) {
+                    StringBuilder sb = new StringBuilder();
+                    sb.append(type.getSimpleName()).append("[");
+                    Iterator<Entry<Method, Property<?>>> iter = properties.entrySet().iterator();
+                    while (iter.hasNext()) {
+                        Property entry = iter.next().getValue();
+                        sb.append(entry.getKey().substring(prefix.length())).append("=").append(entry.get());
+                        if (iter.hasNext()) {
+                            sb.append(", ");
+                        }
+                    }
+                    sb.append("]");
+                    return sb.toString();
+                }
+                else {
+                    throw new NoSuchMethodError(method.getName() + " not found on interface " + type.getName());
+                }
             }
         };
         return (T) Proxy.newProxyInstance(type.getClassLoader(), new Class[] { type }, handler);

--- a/archaius2-core/src/main/java/com/netflix/archaius/annotations/Configuration.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/annotations/Configuration.java
@@ -59,4 +59,10 @@ public @interface Configuration
      * @return Method to call after configuration is bound
      */
     String      postConfigure() default "";
+    
+    /**
+     * @return If true then properties cannot change once set otherwise methods will be 
+     * bound to dynamic properties via PropertyFactory.
+     */
+    boolean     immutable() default false;
 }

--- a/archaius2-core/src/main/java/com/netflix/archaius/annotations/PropertyInfo.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/annotations/PropertyInfo.java
@@ -23,6 +23,6 @@ import java.lang.annotation.Target;
 @Documented
 @Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD, ElementType.METHOD})
-public @interface Value {
+public @interface PropertyInfo {
     String name();
 }

--- a/archaius2-core/src/main/java/com/netflix/archaius/annotations/PropertyName.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/annotations/PropertyName.java
@@ -23,6 +23,6 @@ import java.lang.annotation.Target;
 @Documented
 @Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD, ElementType.METHOD})
-public @interface PropertyInfo {
+public @interface PropertyName {
     String name();
 }

--- a/archaius2-core/src/main/java/com/netflix/archaius/property/DefaultPropertyContainer.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/property/DefaultPropertyContainer.java
@@ -283,6 +283,11 @@ public class DefaultPropertyContainer implements PropertyContainer {
         public void removeListener(PropertyListener<T> listener) {
             delegate.removeListener(listener);
         }
+
+        @Override
+        public String getKey() {
+            return key;
+        }
     }
     
     /**

--- a/archaius2-core/src/test/java/com/netflix/archaius/mapper/ProxyFactoryTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/mapper/ProxyFactoryTest.java
@@ -24,7 +24,7 @@ import com.netflix.archaius.Config;
 import com.netflix.archaius.DefaultPropertyFactory;
 import com.netflix.archaius.ProxyFactory;
 import com.netflix.archaius.annotations.DefaultValue;
-import com.netflix.archaius.annotations.PropertyInfo;
+import com.netflix.archaius.annotations.PropertyName;
 import com.netflix.archaius.config.EmptyConfig;
 import com.netflix.archaius.config.MapConfig;
 import com.netflix.archaius.exceptions.ConfigException;
@@ -66,7 +66,7 @@ public class ProxyFactoryTest {
         Double getDouble2();
         
         @DefaultValue("default")
-        @PropertyInfo(name="renamed.string")
+        @PropertyName(name="renamed.string")
         String getRenamed();
         
         @DefaultValue("default")

--- a/archaius2-core/src/test/java/com/netflix/archaius/mapper/ProxyFactoryTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/mapper/ProxyFactoryTest.java
@@ -24,14 +24,15 @@ import com.netflix.archaius.Config;
 import com.netflix.archaius.DefaultPropertyFactory;
 import com.netflix.archaius.ProxyFactory;
 import com.netflix.archaius.annotations.DefaultValue;
+import com.netflix.archaius.annotations.PropertyInfo;
 import com.netflix.archaius.config.EmptyConfig;
 import com.netflix.archaius.config.MapConfig;
 import com.netflix.archaius.exceptions.ConfigException;
 import com.netflix.archaius.property.PrefixedObservablePropertyFactory;
 
-public class DefaultConfigMapperTest {
+public class ProxyFactoryTest {
     public static interface MyConfig {
-        @DefaultValue("notoaded")
+        @DefaultValue("default")
         String getString();
         
         @DefaultValue("123")
@@ -63,6 +64,16 @@ public class DefaultConfigMapperTest {
         double getDouble();
         
         Double getDouble2();
+        
+        @DefaultValue("default")
+        @PropertyInfo(name="renamed.string")
+        String getRenamed();
+        
+        @DefaultValue("default")
+        String noVerb();
+        
+        @DefaultValue("false")
+        boolean isIs();
     }
     
     @Test
@@ -81,17 +92,22 @@ public class DefaultConfigMapperTest {
         props.put("prefix.float2",   2.1);
         props.put("prefix.double",   1.1);
         props.put("prefix.double2",  2.1);
-        
+        props.put("prefix.renamed.string", "loaded");
+        props.put("prefix.noVerb",   "loaded");
+        props.put("prefix.is",       "true");
         Config config = MapConfig.from(props);
 
-        Assert.assertEquals("loaded", config.getString("prefix.string"));
         ProxyFactory proxy = new ProxyFactory();
         MyConfig c = proxy.newProxy(MyConfig.class, new PrefixedObservablePropertyFactory("prefix", DefaultPropertyFactory.from(config)));
 
+        Assert.assertEquals("loaded", c.getString());
+        Assert.assertEquals("loaded", c.getRenamed());
+        Assert.assertEquals("loaded", c.noVerb());
         Assert.assertEquals(1, c.getInteger());
         Assert.assertEquals(2, (int)c.getInteger2());
         Assert.assertEquals(true, c.getBoolean());
         Assert.assertEquals(true, c.getBoolean2());
+        Assert.assertEquals(true, c.isIs());
         Assert.assertEquals(1, c.getShort());
         Assert.assertEquals(2, (short)c.getShort2());
         Assert.assertEquals(1, c.getLong());
@@ -101,6 +117,7 @@ public class DefaultConfigMapperTest {
         Assert.assertEquals(1.1, c.getDouble(), 0);
         Assert.assertEquals(2.1, (double)c.getDouble2(), 0);
         
+        System.out.println(c.toString());
     }
     
     @Test


### PR DESCRIPTION
* Add PropertyInfo annotation to override the property name when proxying
* Add support for making proxied configuration immutable
* Add toString to proxies configuration interfaces

Example of new features,
```java
@Configuration(immtuable=true) // Once created properties never change
public interface MyConfig {
   // Looks for property named "foo.bar" instead of "fooBar" (derived from name)
   @PropertyInfo("foo.bar")
   public String getFooBar();

   // 'is' verb supported in addition to 'get'
   public Boolean isEnabled();
}
```