### PR TITLE
First draft of making MapConfig generic.

### DIFF
--- a/archaius2-core/src/main/java/com/netflix/archaius/config/MapConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/MapConfig.java
@@ -25,7 +25,7 @@ import java.util.Properties;
 /**
  * Config backed by an immutable map.
  */
-public class MapConfig extends AbstractConfig {
+public class MapConfig<T> extends AbstractConfig {
 
     /**
      * The builder only provides convenience for fluent style adding of properties
@@ -40,11 +40,11 @@ public class MapConfig extends AbstractConfig {
      * }
      * @author elandau
      */
-    public static class Builder {
-        Map<String, String> map = new HashMap<String, String>();
+    public static class Builder<T> {
+        Map<String, T> map = new HashMap<>();
         
-        public <T> Builder put(String key, T value) {
-            map.put(key, value.toString());
+        public Builder put(String key, T value) {
+            map.put(key, value);
             return this;
         }
         
@@ -53,42 +53,35 @@ public class MapConfig extends AbstractConfig {
         }
     }
     
-    public static Builder builder() {
-        return new Builder();
+    public static <T> Builder builder() {
+        return new Builder<T>();
     }
     
-    public static MapConfig from(Properties props) {
-        return new MapConfig(props);
+    public static MapConfig<String> from(Properties props) {
+        Map<String, String> tempMap = new HashMap<>(props.size());
+
+        for (Entry<Object, Object> entry : props.entrySet()) {
+            tempMap.put(entry.getKey().toString(), entry.getValue().toString());
+        }
+
+        return new MapConfig<String>(Collections.unmodifiableMap(tempMap));
     }
     
-    public static MapConfig from(Map<String, String> props) {
-        return new MapConfig(props);
+    public static <T> MapConfig from(Map<String, T> props) {
+        return new MapConfig<T>(props);
     }
     
-    private Map<String, String> props = new HashMap<String, String>();
+    private Map<String, T> props = new HashMap<>();
     
     /**
      * Construct a MapConfig as a copy of the provided Map
-     * @param name
      * @param props
      */
-    public MapConfig(Map<String, String> props) {
+    public MapConfig(Map<String, T> props) {
         this.props.putAll(props);
         this.props = Collections.unmodifiableMap(this.props);
     }
 
-    /**
-     * Construct a MapConfig as a copy of the provided properties
-     * @param name
-     * @param props
-     */
-    public MapConfig(Properties props) {
-        for (Entry<Object, Object> entry : props.entrySet()) {
-            this.props.put(entry.getKey().toString(), entry.getValue().toString());
-        }
-        this.props = Collections.unmodifiableMap(this.props);
-    }
-    
     @Override
     public Object getRawProperty(String key) {
         return props.get(key);

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/MapConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/MapConfig.java
@@ -43,13 +43,13 @@ public class MapConfig<T> extends AbstractConfig {
     public static class Builder<T> {
         Map<String, T> map = new HashMap<>();
         
-        public Builder put(String key, T value) {
+        public Builder<T> put(String key, T value) {
             map.put(key, value);
             return this;
         }
         
         public MapConfig build() {
-            return new MapConfig(map);
+            return new MapConfig<>(map);
         }
     }
     
@@ -64,11 +64,11 @@ public class MapConfig<T> extends AbstractConfig {
             tempMap.put(entry.getKey().toString(), entry.getValue().toString());
         }
 
-        return new MapConfig<String>(Collections.unmodifiableMap(tempMap));
+        return new MapConfig<>(Collections.unmodifiableMap(tempMap));
     }
     
     public static <T> MapConfig from(Map<String, T> props) {
-        return new MapConfig<T>(props);
+        return new MapConfig<>(props);
     }
     
     private Map<String, T> props = new HashMap<>();

--- a/archaius2-core/src/test/java/com/netflix/archaius/config/MapConfigTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/MapConfigTest.java
@@ -26,7 +26,7 @@ import com.netflix.archaius.exceptions.ConfigException;
 import com.netflix.archaius.exceptions.ParseException;
 
 public class MapConfigTest {
-    private MapConfig config = MapConfig.builder()
+    private MapConfig<String> config = MapConfig.builder()
             .put("str", "value")
             .put("badnumber", "badnumber")
             .build();

--- a/archaius2-guice/src/test/java/com/netflix/archaius/guice/ProxyTest.java
+++ b/archaius2-guice/src/test/java/com/netflix/archaius/guice/ProxyTest.java
@@ -51,9 +51,9 @@ public class ProxyTest {
                     ConfigSeeders.bind(binder(), 
                             MapConfig.<String>builder()
 
-                                    .put("integer", 1)
+                                    .put("integer", "1")
                                 .put("string", "bar")
-                                .put("subConfig.integer", 2)
+                                .put("subConfig.integer", "2")
                                 .build(), 
                             RuntimeLayer.class);
                 }
@@ -86,7 +86,7 @@ public class ProxyTest {
                 protected void configure() {
                     ConfigSeeders.bind(binder(), 
                             MapConfig.<String>builder()
-                                .put("prefix.integer", 1)
+                                .put("prefix.integer", "1")
                                 .put("prefix.string", "bar")
                                 .build(), 
                             RuntimeLayer.class);

--- a/archaius2-guice/src/test/java/com/netflix/archaius/guice/ProxyTest.java
+++ b/archaius2-guice/src/test/java/com/netflix/archaius/guice/ProxyTest.java
@@ -49,8 +49,9 @@ public class ProxyTest {
                 @Override
                 protected void configure() {
                     ConfigSeeders.bind(binder(), 
-                            MapConfig.builder()
-                                .put("integer", 1)
+                            MapConfig.<String>builder()
+
+                                    .put("integer", 1)
                                 .put("string", "bar")
                                 .put("subConfig.integer", 2)
                                 .build(), 
@@ -84,7 +85,7 @@ public class ProxyTest {
                 @Override
                 protected void configure() {
                     ConfigSeeders.bind(binder(), 
-                            MapConfig.builder()
+                            MapConfig.<String>builder()
                                 .put("prefix.integer", 1)
                                 .put("prefix.string", "bar")
                                 .build(), 


### PR DESCRIPTION
In the current implementation MapConfig is forced to be String, String.  I don't think this makes sense for all cases and have a specific case where it would be nice if it was String, Object.  It seemed like it might make more sense to add a type parameter than proliferate MapConfig classes of various types.  I tried to leave as much of the functionality intact as possible.

If the String flavor is highly used it would be an option to make a child class that uses that type.

There is still one test broken, but I wanted to get a draft up for discussion.