### PR TITLE
Clean up usage of ArchaiusModule

### DIFF
--- a/archaius2-core/src/main/java/com/netflix/archaius/ConfigLoader.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/ConfigLoader.java
@@ -66,6 +66,14 @@ public interface ConfigLoader {
         Loader withOverrides(Properties props);
         
         /**
+         * Externally provided property overrides that are applied once 
+         * all cascaded files have been loaded
+         * 
+         * @param props
+         */
+        Loader withOverrides(Config config);
+        
+        /**
          * Load configuration by cascade resource name.
          * @param resourceName
          * @return

--- a/archaius2-core/src/main/java/com/netflix/archaius/ConfigProxyFactory.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/ConfigProxyFactory.java
@@ -1,8 +1,5 @@
 package com.netflix.archaius;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
-
 /**
  * Factory for binding a configuration interface to properties in a PropertyFactory
  * instance.  Getter methods on the interface are mapped by naming convention
@@ -13,10 +10,8 @@ import javax.inject.Singleton;
  * 
  * @author elandau
  */
-@Singleton
 public class ConfigProxyFactory extends ProxyFactory {
 
-    @Inject
     public ConfigProxyFactory(Decoder decoder, PropertyFactory factory) {
         super(decoder, factory);
     }

--- a/archaius2-core/src/main/java/com/netflix/archaius/cascade/NoCascadeStrategy.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/cascade/NoCascadeStrategy.java
@@ -28,6 +28,8 @@ import com.netflix.archaius.StrInterpolator;
  *
  */
 public class NoCascadeStrategy implements CascadeStrategy {
+    public static final CascadeStrategy INSTANCE = new NoCascadeStrategy();
+
     @Override
     public List<String> generate(String name, StrInterpolator interpolator, StrInterpolator.Lookup config) {
         List<String> list = new ArrayList<String>();

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/CompositeConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/CompositeConfig.java
@@ -308,7 +308,7 @@ public class CompositeConfig extends AbstractConfig {
     public static CompositeConfig from(LinkedHashMap<String, Config> load) throws ConfigException {
         Builder builder = builder();
         for (Entry<String, Config> config : load.entrySet()) {
-            builder().withConfig(config.getKey(), config.getValue());
+            builder.withConfig(config.getKey(), config.getValue());
         }
         return builder.build();
     }

--- a/archaius2-core/src/main/java/com/netflix/archaius/inject/ApplicationOverrideLayer.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/inject/ApplicationOverrideLayer.java
@@ -1,0 +1,15 @@
+package com.netflix.archaius.inject;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+@Qualifier
+@Target({ElementType.TYPE, ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApplicationOverrideLayer {
+
+}

--- a/archaius2-core/src/main/java/com/netflix/archaius/readers/URLConfigReader.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/readers/URLConfigReader.java
@@ -17,6 +17,7 @@ package com.netflix.archaius.readers;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Collection;
@@ -72,8 +73,17 @@ public class URLConfigReader implements Callable<PollingResponse> {
         for (URL url: configUrls) {
             Properties props = new Properties();
             InputStream fin = url.openStream();
+            InputStreamReader reader;
             try {
-                props.load(fin);
+                reader = new InputStreamReader(fin, "UTF-8");
+                try {
+                    props.load(fin);
+                }
+                finally {
+                    if (reader != null) {
+                        reader.close();
+                    }
+                }
             }
             finally {
                 fin.close();

--- a/archaius2-guice/src/main/java/com/netflix/archaius/guice/ArchaiusConfiguration.java
+++ b/archaius2-guice/src/main/java/com/netflix/archaius/guice/ArchaiusConfiguration.java
@@ -1,0 +1,82 @@
+package com.netflix.archaius.guice;
+
+import java.util.Map;
+import java.util.Set;
+
+import com.netflix.archaius.CascadeStrategy;
+import com.netflix.archaius.Config;
+import com.netflix.archaius.ConfigListener;
+import com.netflix.archaius.Decoder;
+
+/**
+ * Configuration interface for archaius
+ * 
+ * @author elandau
+ *
+ */
+public interface ArchaiusConfiguration {
+    /**
+     * Return seeders for the runtime layer.  These seeders
+     * are called after initial loading the system, env and application layer
+     * 
+     * @return Set of seeders or empty set if none specified
+     */
+    Set<ConfigSeeder> getRuntimeLayerSeeders();
+    
+    /**
+     * Return seeders for the runtime layer.  These seeders
+     * are called after initial loading the system, env and application layer
+     * 
+     * @return Set of seeders or empty set if none specified
+     */
+    Set<ConfigSeeder> getRemoteLayerSeeders();
+
+    /**
+     * Return the application configuration name.  Default value is 'application'
+     * 
+     * @return Valid configuration name.  Must not be null or empty.
+     */
+    String getConfigName();
+    
+    /**
+     * Return the default cascade strategy to use for library
+     * and application configuration resource loading
+     * 
+     * @return Return a valid CascadeStrategy
+     */
+    CascadeStrategy getCascadeStrategy();
+
+    /**
+     * Return the main decoder to be used
+     * 
+     * @return Return a valid Decoder.
+     */
+    Decoder getDecoder();
+    
+    /**
+     * Return a set of configuration listeners that will be registered before
+     * any configuration is loaded
+     * 
+     * @return Set of listeners or empty set if non specified
+     */
+    Set<ConfigListener> getConfigListeners();
+    
+    /**
+     * Return a map of library name to a Config override object.
+     * These overrides take precedence over the main library configuration
+     * as well as all the cascade override values
+     * 
+     * @return Map of overrides for libraries/resources.  Should return an empty map
+     * if no overrides specified
+     */
+    Map<String, Config> getLibraryOverrides();
+    
+    /**
+     * Return override values for the application layer.  This override takes
+     * precedence over the main library configuration as well asll the cascade
+     * override values.
+     * 
+     * @return Config to use as override or null if no override
+     */
+    Config getApplicationOverride();
+}

--- a/archaius2-guice/src/main/java/com/netflix/archaius/guice/OptionalArchaiusConfiguration.java
+++ b/archaius2-guice/src/main/java/com/netflix/archaius/guice/OptionalArchaiusConfiguration.java
@@ -1,0 +1,93 @@
+package com.netflix.archaius.guice;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import javax.inject.Singleton;
+
+import com.google.inject.Inject;
+import com.netflix.archaius.CascadeStrategy;
+import com.netflix.archaius.Config;
+import com.netflix.archaius.ConfigListener;
+import com.netflix.archaius.Decoder;
+import com.netflix.archaius.DefaultDecoder;
+import com.netflix.archaius.cascade.NoCascadeStrategy;
+import com.netflix.archaius.inject.ApplicationLayer;
+import com.netflix.archaius.inject.ApplicationOverrideLayer;
+import com.netflix.archaius.inject.LibrariesLayer;
+import com.netflix.archaius.inject.RemoteLayer;
+import com.netflix.archaius.inject.RuntimeLayer;
+
+@Singleton
+public class OptionalArchaiusConfiguration implements ArchaiusConfiguration {
+
+    @Inject(optional=true)
+    @RuntimeLayer
+    Set<ConfigSeeder> runtimeLayerSeeders;
+    
+    @Inject(optional=true)
+    @RemoteLayer
+    Set<ConfigSeeder> remoteLayerSeeders;
+    
+    @Inject(optional=true)
+    Set<ConfigListener> configListeners;
+    
+    @Inject(optional=true)
+    @ApplicationLayer
+    String configurationName;
+    
+    @Inject(optional=true)
+    CascadeStrategy cascadeStrategy;
+    
+    @Inject(optional=true)
+    Decoder decoder;
+    
+    @Inject(optional=true)
+    @LibrariesLayer
+    Map<String, Config> libraryOverrides;
+    
+    @Inject(optional=true)
+    @ApplicationOverrideLayer
+    Config applicationOverrideLayer;
+    
+    @Override
+    public Set<ConfigSeeder> getRuntimeLayerSeeders() {
+        return runtimeLayerSeeders != null ? runtimeLayerSeeders : Collections.<ConfigSeeder>emptySet();
+    }
+
+    @Override
+    public Set<ConfigSeeder> getRemoteLayerSeeders() {
+        return remoteLayerSeeders != null ? remoteLayerSeeders : Collections.<ConfigSeeder>emptySet();
+    }
+
+    @Override
+    public String getConfigName() {
+        return configurationName != null ? configurationName : "application";
+    }
+
+    @Override
+    public CascadeStrategy getCascadeStrategy() {
+        return cascadeStrategy != null ? cascadeStrategy : NoCascadeStrategy.INSTANCE;
+    }
+
+    @Override
+    public Decoder getDecoder() {
+        return decoder != null ? decoder : DefaultDecoder.INSTANCE;
+    }
+
+    @Override
+    public Set<ConfigListener> getConfigListeners() {
+        return configListeners != null ? configListeners : Collections.<ConfigListener>emptySet();
+    }
+
+    @Override
+    public Map<String, Config> getLibraryOverrides() {
+        return libraryOverrides != null ? libraryOverrides : Collections.<String, Config>emptyMap();
+    }
+
+    @Override
+    public Config getApplicationOverride() {
+        return applicationOverrideLayer;
+    }
+}

--- a/archaius2-guice/src/test/resources/moduleTest.properties
+++ b/archaius2-guice/src/test/resources/moduleTest.properties
@@ -15,3 +15,4 @@
 #
 
 moduleTest.loaded=true
+moduleTest.prop1=fromFile

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 // Establish version and status
-ext.githubProjectName = rootProject.name // Change if github project name is not the same as the root project's name
+ext.githubProjectName = rootProject.name
 
 subprojects {
     apply plugin: 'nebula.netflixoss'


### PR DESCRIPTION
* Parse properties sources as UTF-8
* Clean up configuration of Archaius for ArchaiusModule to avoid ever having to override ArchaiusModule  to change behavior
* Fix bug in CompositeConfig.from where it always returned an empty configuration
* Add support for library level configuration override via a multi-binding
```java
MapBinder.newMapBinder(binder(), String.class, Config.class, LibrariesLayer.class)
                            .addBinding("resourceNameToOverride")
                            .toInstance(MapConfig.from(overrideProps));
```
* Add support for application properties override layer via binding
```java
   bind(Config.class).annotatedWith(ApplicationOverrideLayer.class).to(MapConfig.from(overrideProps));
```