### PR TITLE
Adding @DefaultsLayer to AbstractModule

### DIFF
--- a/archaius2-core/src/main/java/com/netflix/archaius/inject/DefaultsLayer.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/inject/DefaultsLayer.java
@@ -1,0 +1,15 @@
+package com.netflix.archaius.inject;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+@Qualifier
+@Target({ElementType.TYPE, ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DefaultsLayer {
+
+}

--- a/archaius2-guice/src/main/java/com/netflix/archaius/guice/ArchaiusConfiguration.java
+++ b/archaius2-guice/src/main/java/com/netflix/archaius/guice/ArchaiusConfiguration.java
@@ -30,6 +30,12 @@ public interface ArchaiusConfiguration {
      * @return Set of seeders or empty set if none specified
      */
     Set<ConfigSeeder> getRemoteLayerSeeders();
+    
+    /**
+     * Return seeders for the defaults layer.  
+     * @return
+     */
+    Set<ConfigSeeder> getDefaultsLayerSeeders();
 
     /**
      * Return the application configuration name.  Default value is 'application'

--- a/archaius2-guice/src/main/java/com/netflix/archaius/guice/ConfigSeeders.java
+++ b/archaius2-guice/src/main/java/com/netflix/archaius/guice/ConfigSeeders.java
@@ -4,6 +4,7 @@ import java.lang.annotation.Annotation;
 import java.util.Properties;
 
 import com.google.inject.Binder;
+import com.google.inject.binder.LinkedBindingBuilder;
 import com.google.inject.multibindings.Multibinder;
 import com.netflix.archaius.Config;
 import com.netflix.archaius.config.MapConfig;
@@ -70,4 +71,10 @@ public abstract class ConfigSeeders {
                      });
         
     }
+
+    public static LinkedBindingBuilder<ConfigSeeder> bind(Binder binder, Class<? extends Annotation> annot) {
+        return Multibinder.newSetBinder(binder, ConfigSeeder.class, annot)
+            .addBinding();
+    }
+
 }

--- a/archaius2-guice/src/main/java/com/netflix/archaius/guice/OptionalArchaiusConfiguration.java
+++ b/archaius2-guice/src/main/java/com/netflix/archaius/guice/OptionalArchaiusConfiguration.java
@@ -15,6 +15,7 @@ import com.netflix.archaius.DefaultDecoder;
 import com.netflix.archaius.cascade.NoCascadeStrategy;
 import com.netflix.archaius.inject.ApplicationLayer;
 import com.netflix.archaius.inject.ApplicationOverrideLayer;
+import com.netflix.archaius.inject.DefaultsLayer;
 import com.netflix.archaius.inject.LibrariesLayer;
 import com.netflix.archaius.inject.RemoteLayer;
 import com.netflix.archaius.inject.RuntimeLayer;
@@ -29,6 +30,10 @@ public class OptionalArchaiusConfiguration implements ArchaiusConfiguration {
     @Inject(optional=true)
     @RemoteLayer
     Set<ConfigSeeder> remoteLayerSeeders;
+    
+    @Inject(optional=true)
+    @DefaultsLayer
+    Set<ConfigSeeder> defaultsLayerSeeders;
     
     @Inject(optional=true)
     Set<ConfigListener> configListeners;
@@ -59,6 +64,11 @@ public class OptionalArchaiusConfiguration implements ArchaiusConfiguration {
     @Override
     public Set<ConfigSeeder> getRemoteLayerSeeders() {
         return remoteLayerSeeders != null ? remoteLayerSeeders : Collections.<ConfigSeeder>emptySet();
+    }
+
+    @Override
+    public Set<ConfigSeeder> getDefaultsLayerSeeders() {
+        return defaultsLayerSeeders != null ? defaultsLayerSeeders : Collections.<ConfigSeeder>emptySet();
     }
 
     @Override


### PR DESCRIPTION
Add a new DefaultsLayer that is at the bottom of the hierarchy.  This layer will be used mostly by other modules to set any default values that must be present when necessary for code to function properly.  This is placed at the lowest layer to allow for these configurations to be overwritten.