### PR TITLE
Nullable and argument replacement for configuration proxy

### DIFF
--- a/archaius2-core/build.gradle
+++ b/archaius2-core/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     compile     'org.apache.commons:commons-lang3:3.3.2'
     compile     'org.slf4j:slf4j-api:1.6.3'
     compile     'javax.inject:javax.inject:1'
+    compile     'com.google.code.findbugs:annotations:2.0.0'
 
     testCompile 'org.hamcrest:hamcrest-all:1.3'
     testCompile 'org.slf4j:slf4j-log4j12:1.6.1'

--- a/archaius2-core/src/main/java/com/netflix/archaius/ProxyFactory.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/ProxyFactory.java
@@ -8,6 +8,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -16,7 +17,6 @@ import org.apache.commons.lang3.text.StrSubstitutor;
 import com.netflix.archaius.annotations.Configuration;
 import com.netflix.archaius.annotations.DefaultValue;
 import com.netflix.archaius.annotations.PropertyName;
-import com.sun.istack.internal.Nullable;
 
 /**
  * Factory for binding a configuration interface to properties in a Config

--- a/archaius2-core/src/main/java/com/netflix/archaius/ProxyFactory.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/ProxyFactory.java
@@ -178,8 +178,8 @@ public class ProxyFactory {
                         public Object invoke(Object[] args) {
                             // Determine the actual property name by replacing with arguments using the argument index
                             // to the method.  For example,
-                            //      @PropertyName("foo.${arg2}.${arg1}
-                            //      String getFooValue(String arg1, Integer arg2) 
+                            //      @PropertyName(name="foo.${1}.${0}")
+                            //      String getFooValue(String arg0, Integer arg1) 
                             // 
                             // called as getFooValue("bar", 1) would look for the property 'foo.1.bar'
                             Map<String, Object> values = new HashMap<>();

--- a/archaius2-core/src/main/java/com/netflix/archaius/ProxyFactory.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/ProxyFactory.java
@@ -11,9 +11,12 @@ import java.util.Map.Entry;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import org.apache.commons.lang3.text.StrSubstitutor;
+
 import com.netflix.archaius.annotations.Configuration;
 import com.netflix.archaius.annotations.DefaultValue;
 import com.netflix.archaius.annotations.PropertyName;
+import com.sun.istack.internal.Nullable;
 
 /**
  * Factory for binding a configuration interface to properties in a Config
@@ -72,6 +75,66 @@ public class ProxyFactory {
         return newProxy(type, initialPrefix, annot == null ? false : annot.immutable());
     }
     
+    /**
+     * Encapsulated the invocation of a single method of the interface
+     * @author elandau
+     *
+     * @param <T>
+     */
+    private static interface MethodInvoker<T> {
+        /**
+         * Invoke the method with the provided arguments
+         * @param args
+         * @return
+         */
+        T invoke(Object[] args);
+
+        /**
+         * Return the property key
+         * @return
+         */
+        String getKey();
+    }
+    
+    /**
+     * Abstract method invoker that encapsulates a property
+     * @author elandau
+     *
+     * @param <T>
+     */
+    private static abstract class PropertyMethodInvoker<T> extends AbstractProperty<T> implements MethodInvoker<T> {
+        public PropertyMethodInvoker(String key) {
+            super(key);
+        }
+        
+        @Override
+        public T invoke(Object[] args) {
+            return get();
+        }
+    }
+    
+    private static class RequiredMethodInvoker<T> implements MethodInvoker<T> {
+        private final MethodInvoker<T> delegate;
+
+        public RequiredMethodInvoker(MethodInvoker<T> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public T invoke(Object[] args) {
+            T value = delegate.invoke(args);
+            if (value == null) {
+                throw new RuntimeException("Missing value for property " + getKey());
+            }
+            return value;
+        }
+
+        @Override
+        public String getKey() {
+            return delegate.getKey();
+        }
+    }
+    
     @SuppressWarnings({ "rawtypes", "unchecked" })
     <T> T newProxy(final Class<T> type, final String initialPrefix, boolean immutable) {
         Configuration annot = type.getAnnotation(Configuration.class);
@@ -81,7 +144,8 @@ public class ProxyFactory {
         // Iterate through all declared methods of the class looking for setter methods.
         // Each setter will be mapped to a Property<T> for the property name:
         //      prefix + lowerCamelCaseDerivedPropertyName
-        final Map<Method, Property<?>> properties = new HashMap<>();
+        final Map<Method, MethodInvoker<?>> invokers = new HashMap<>();
+        
         for (Method m : type.getMethods()) {
             final String verb;
             if (m.getName().startsWith("get")) {
@@ -94,35 +158,79 @@ public class ProxyFactory {
                 verb = "";
             }
             
-            DefaultValue annotDefaultValue = m.getAnnotation(DefaultValue.class);
-            Class<?> returnType = m.getReturnType();
-            
-            PropertyName nameAnnot = m.getAnnotation(PropertyName.class); 
-            String propName = nameAnnot != null && nameAnnot.name() != null
+            final DefaultValue defaultValue = m.getAnnotation(DefaultValue.class);
+            final Nullable nullable = m.getAnnotation(Nullable.class);
+            final Class<?> returnType = m.getReturnType();
+            final PropertyName nameAnnot = m.getAnnotation(PropertyName.class); 
+            final String propName = nameAnnot != null && nameAnnot.name() != null
                             ? prefix + nameAnnot.name()
                             : prefix + Character.toLowerCase(m.getName().charAt(verb.length())) + m.getName().substring(verb.length() + 1);
 
             // For sub-interfaces create a proxy instance where the same proxy instance is returned but its
             // methods can still return dynamic values
             if (returnType.isInterface()) {
-                properties.put(m, createInterfaceProperty(propName, newProxy(returnType, propName, immutable)));
+                invokers.put(m, createInterfaceProperty(propName, newProxy(returnType, propName, immutable)));
             }
             else {
-                
-                if (immutable) {
-                    if (annotDefaultValue == null) {
-                        properties.put(m, createImmutableProperty(propName, m.getReturnType()));
+                if (m.getParameterTypes().length > 0) {
+                    invokers.put(m, new MethodInvoker() {
+                        @Override
+                        public Object invoke(Object[] args) {
+                            // Determine the actual property name by replacing with arguments using the argument index
+                            // to the method.  For example,
+                            //      @PropertyName("foo.${arg2}.${arg1}
+                            //      String getFooValue(String arg1, Integer arg2) 
+                            // 
+                            // called as getFooValue("bar", 1) would look for the property 'foo.1.bar'
+                            Map<String, Object> values = new HashMap<>();
+                            for (int i = 0; i < args.length; i++) {
+                                values.put("" + i, args[i]);
+                            }
+                            String propName = new StrSubstitutor(values, "${", "}", '$').replace(nameAnnot.name());
+                            
+                            // Read the actual value now that the proeprty name is known.  Note that we can't create
+                            // 
+                            if (nullable != null) {
+                                return propertyFactory.getConfig().get(returnType, propName, null);
+                            }
+                            else if (defaultValue != null) {
+                                return getPropertyWithDefault(returnType, propName, defaultValue.value());
+                            }
+                            else {
+                                return propertyFactory.getConfig().get(returnType, propName);
+                            }
+                        }
+
+                        <R> R getPropertyWithDefault(Class<R> type, String propName, String defaultValue) {
+                            return propertyFactory.getConfig().get(type, propName, decoder.decode(type, defaultValue));
+                        }
+
+                        @Override
+                        public String getKey() {
+                            return propName;
+                        }
+                    });
+                }
+                else if (immutable) {
+                    if (defaultValue != null) {
+                        invokers.put(m, createImmutablePropertyWithDefault(m.getReturnType(), propName, defaultValue.value()));
+                    }
+                    else if (nullable != null) {
+                        invokers.put(m, createImmutablePropertyWithDefault(m.getReturnType(), propName, null));
                     }
                     else {
-                        properties.put(m, createImmutablePropertyWithDefault(propName, m.getReturnType(), annotDefaultValue.value()));
+                        invokers.put(m, createImmutableProperty(m.getReturnType(), propName));
                     }
                 }
                 else {
-                    if (annotDefaultValue == null) {
-                        properties.put(m, new RequiredProperty(createDynamicProperty(propName, m.getReturnType(), null)));
+                    if (defaultValue != null) {
+                        invokers.put(m, createDynamicProperty(m.getReturnType(), propName, defaultValue.value()));
+                    }
+                    else if (nullable != null) {
+                        invokers.put(m, createDynamicProperty(m.getReturnType(), propName, null));
                     }
                     else {
-                        properties.put(m, createDynamicProperty(propName, m.getReturnType(), annotDefaultValue.value()));
+                        invokers.put(m, new RequiredMethodInvoker(createDynamicProperty(m.getReturnType(), propName, null)));
                     }
                 }
             }
@@ -131,19 +239,20 @@ public class ProxyFactory {
         final InvocationHandler handler = new InvocationHandler() {
             @Override
             public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-                Property prop = properties.get(method);
-                if (prop != null) {
-                    return prop.get();
+                MethodInvoker<?> invoker = invokers.get(method);
+                if (invoker != null) {
+                    return invoker.invoke(args);
                 }
-                else if ("toString".equals(method.getName())) {
+                
+                if ("toString".equals(method.getName())) {
                     StringBuilder sb = new StringBuilder();
                     sb.append(type.getSimpleName()).append("[");
-                    Iterator<Entry<Method, Property<?>>> iter = properties.entrySet().iterator();
+                    Iterator<Entry<Method, MethodInvoker<?>>> iter = invokers.entrySet().iterator();
                     while (iter.hasNext()) {
-                        Property entry = iter.next().getValue();
+                        MethodInvoker entry = iter.next().getValue();
                         sb.append(entry.getKey().substring(prefix.length())).append("='");
                         try {
-                            sb.append(entry.get());
+                            sb.append(entry.invoke(null));
                         }
                         catch (Exception e) {
                             sb.append(e.getMessage());
@@ -164,8 +273,8 @@ public class ProxyFactory {
         return (T) Proxy.newProxyInstance(type.getClassLoader(), new Class[] { type }, handler);
     }
     
-    private <T> Property<T> createImmutablePropertyWithDefault(final String propName, final Class<T> type, final String defaultValue) {
-        return new AbstractProperty<T>(propName) {
+    private <T> MethodInvoker<T> createImmutablePropertyWithDefault(final Class<T> type, final String propName, final String defaultValue) {
+        return new PropertyMethodInvoker<T>(propName) {
             private volatile T cached;
             
             @Override
@@ -178,8 +287,8 @@ public class ProxyFactory {
         };
     }
     
-    private <T> Property<T> createImmutableProperty(final String propName, final Class<T> type) {
-        return new AbstractProperty<T>(propName) {
+    private <T> MethodInvoker<T> createImmutableProperty(final Class<T> type, final String propName) {
+        return new PropertyMethodInvoker<T>(propName) {
             private volatile T cached;
             @Override
             public T get() {
@@ -191,8 +300,8 @@ public class ProxyFactory {
         };
     }
     
-    private <T> Property<T> createInterfaceProperty(String propName, final T proxy) {
-        return new AbstractProperty<T>(propName) {
+    private <T> MethodInvoker<T> createInterfaceProperty(String propName, final T proxy) {
+        return new PropertyMethodInvoker<T>(propName) {
             @Override
             public T get() {
                 return proxy;
@@ -200,22 +309,18 @@ public class ProxyFactory {
         };
     }
 
-    private <T> Property<T> createDynamicProperty(final String propName, final Class<T> type, final String defaultValue) {
-        return propertyFactory.getProperty(propName).asType(type, defaultValue != null ? decoder.decode(type, defaultValue) : null);
-    }
-
-    public static class RequiredProperty<T> extends DelegatingProperty<T> {
-        public RequiredProperty(Property<T> prop) {
-            super(prop);
-        }
-
-        @Override
-        public T get() {
-            T value = delegate.get();
-            if (value == null) {
-                throw new RuntimeException("Missing value for property " + getKey());
+    private <T> MethodInvoker<T> createDynamicProperty(final Class<T> type, final String propName, final String defaultValue) {
+        final Property<T> prop = propertyFactory.getProperty(propName).asType(type, defaultValue != null ? decoder.decode(type, defaultValue) : null);
+        return new MethodInvoker<T>() {
+            @Override
+            public T invoke(Object[] args) {
+                return prop.get();
             }
-            return value;
-        }
+
+            @Override
+            public String getKey() {
+                return prop.getKey();
+            }
+        };
     }
 }

--- a/archaius2-core/src/test/java/com/netflix/archaius/ProxyFactoryTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/ProxyFactoryTest.java
@@ -2,6 +2,9 @@ package com.netflix.archaius;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+import javax.annotation.Nullable;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -36,6 +39,9 @@ public class ProxyFactoryTest {
         String getStr();
         
         Boolean getBaseBoolean();
+        
+        @Nullable
+        Integer getNullable();
     }
     
     public static interface RootConfig extends BaseConfig {
@@ -123,6 +129,7 @@ public class ProxyFactoryTest {
         assertThat(a.getSubConfig().str(),              equalTo("default"));
         assertThat(a.getSubConfigFromString().part1(),  equalTo("default1"));
         assertThat(a.getSubConfigFromString().part2(),  equalTo("default2"));
+        assertThat(a.getNullable(),                     nullValue());
         
         try {
             a.getBaseBoolean();

--- a/archaius2-core/src/test/java/com/netflix/archaius/ProxyFactoryTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/ProxyFactoryTest.java
@@ -8,9 +8,9 @@ import org.junit.Test;
 
 import com.netflix.archaius.annotations.Configuration;
 import com.netflix.archaius.annotations.DefaultValue;
+import com.netflix.archaius.annotations.PropertyName;
 import com.netflix.archaius.config.DefaultSettableConfig;
 import com.netflix.archaius.config.EmptyConfig;
-import com.netflix.archaius.config.MapConfig;
 import com.netflix.archaius.config.SettableConfig;
 
 public class ProxyFactoryTest {
@@ -166,5 +166,26 @@ public class ProxyFactoryTest {
         catch (Exception e) {
         }
         System.out.println(a.toString());
+    }
+    
+    static interface WithArguments {
+        @PropertyName(name="${0}.abc.${1}")
+        @DefaultValue("default")
+        String getProperty(String part0, int part1);
+    }
+    
+    @Test
+    public void testWithArguments() {
+        SettableConfig config = new DefaultSettableConfig();
+        config.setProperty("a.abc.1", "value1");
+        config.setProperty("b.abc.2", "value2");
+        
+        PropertyFactory factory = DefaultPropertyFactory.from(config);
+        ConfigProxyFactory proxy = new ConfigProxyFactory(config.getDecoder(), factory);
+        WithArguments withArgs = proxy.newProxy(WithArguments.class);
+        
+        Assert.assertEquals("value1",  withArgs.getProperty("a", 1));
+        Assert.assertEquals("value2",  withArgs.getProperty("b", 2));
+        Assert.assertEquals("default", withArgs.getProperty("a", 2));
     }
 }


### PR DESCRIPTION
Add support for @Nullable property values.
```java
@Nullable
public getSomeProperty();
```

Add support to use arguments passed to interface getters as replacements for deriving the property names.
```java
@PropertyName(name="foo.${0}.${1}")
public getFoo(String arg0, String arg1);
```