### PR TITLE
Fix DefaultSettableConfig interpolation

### DIFF
--- a/archaius2-core/src/main/java/com/netflix/archaius/config/DefaultSettableConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/DefaultSettableConfig.java
@@ -73,7 +73,7 @@ public class DefaultSettableConfig extends AbstractConfig implements SettableCon
             Iterator<String> iter = config.getKeys();
             while (iter.hasNext()) {
                 String key = iter.next();
-                setProperty(key, config.getString(key));
+                setProperty(key, config.getRawProperty(key));
             }
         }
     }


### PR DESCRIPTION
When copying properties from a Config onto a DefaultSettableConfig copy the uninterpolated value