### PR TITLE
Improvements to .properties file loading

### DIFF
--- a/archaius2-core/src/main/java/com/netflix/archaius/ConfigLoader.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/ConfigLoader.java
@@ -17,9 +17,9 @@ package com.netflix.archaius;
 
 import java.io.File;
 import java.net.URL;
-import java.util.LinkedHashMap;
 import java.util.Properties;
 
+import com.netflix.archaius.ConfigLoader.Loader;
 import com.netflix.archaius.config.CompositeConfig;
 import com.netflix.archaius.exceptions.ConfigException;
 
@@ -51,11 +51,9 @@ public interface ConfigLoader {
         Loader withClassLoader(ClassLoader loader);
         
         /**
-         * When true, fail the entire load operation if the first resource name
-         * can't be loaded.  By definition all cascaded variations are treated 
-         * as overrides
-         * @param flag
+         * @deprecated Requiring the existence of a configuration file seems excessive
          */
+        @Deprecated
         Loader withFailOnFirst(boolean flag);
         
         /**

--- a/archaius2-core/src/test/java/com/netflix/archaius/config/ConfigLoaderTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/ConfigLoaderTest.java
@@ -1,28 +1,20 @@
 package com.netflix.archaius.config;
 
+import org.junit.Assert;
 import org.junit.Test;
 
+import com.netflix.archaius.Config;
 import com.netflix.archaius.DefaultConfigLoader;
 import com.netflix.archaius.exceptions.ConfigException;
 
 public class ConfigLoaderTest {
     
-    @Test(expected=ConfigException.class)
-    public void shouldFailWithNoApplicationConfig() throws ConfigException {
-        DefaultConfigLoader loader = DefaultConfigLoader.builder()
-                .withFailOnFirst(true)
-                .build();
-        
-        loader.newLoader().load("non-existant");
-    }
-    
     @Test
-    public void shouldNotFailWithNoApplicationConfig() throws ConfigException {
+    public void testLoadingOfNonExistantFile() throws ConfigException {
         DefaultConfigLoader loader = DefaultConfigLoader.builder()
-                .withFailOnFirst(false)
                 .build();
         
-        loader.newLoader().load("non-existant");
+        Config config = loader.newLoader().load("non-existant");
+        Assert.assertTrue(config.isEmpty());
     }
-
 }

--- a/archaius2-core/src/test/resources/test-test.properties
+++ b/archaius2-core/src/test/resources/test-test.properties
@@ -17,3 +17,4 @@
 # Configuration file used by com.netflix.config.samples.SampleApplicationWithDefaultConfiguration
 
 com.netflix.config.samples.SampleApp.SampleBean.numSeeds=9
+cascaded.property=test-test.properties

--- a/archaius2-core/src/test/resources/test-us-east-1.properties
+++ b/archaius2-core/src/test/resources/test-us-east-1.properties
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-cascaded.property=1
+cascaded.property=test-us-east-1.properties

--- a/archaius2-core/src/test/resources/test.properties
+++ b/archaius2-core/src/test/resources/test.properties
@@ -17,7 +17,7 @@
 # Configuration file used by com.netflix.config.samples.SampleApplicationWithDefaultConfiguration
 
 com.netflix.config.samples.SampleApp.SampleBean.numSeeds=5
-cascaded.property=0
+cascaded.property=test.properties
 com.netflix.test-subject=中文测试
 
-@next=${bogus}.properties,doesNotExist.properties,test-${@region}.properties
+@next=${bogus}.properties,doesNotExist.properties,test-${@region},test


### PR DESCRIPTION
* Change property file loading behavior to succeed whether the first file exists or not.  Deprecate ConfigLoader.Loader.withFailOnFirst
* Simplify @next support implementation using recursion
* '.properties' is optional for files listed in @next