### PR TITLE
issue #351. Remove accessor to last update timestamp since the attrib…

### DIFF
--- a/archaius2-core/src/main/java/com/netflix/archaius/AbstractProperty.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/AbstractProperty.java
@@ -11,11 +11,6 @@ public abstract class AbstractProperty<T> implements Property<T> {
     }
     
     @Override
-    public long getLastUpdateTime(TimeUnit units) {
-        return 0;
-    }
-
-    @Override
     public void unsubscribe() {
         throw new UnsupportedOperationException();
     }

--- a/archaius2-core/src/main/java/com/netflix/archaius/DelegatingProperty.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/DelegatingProperty.java
@@ -11,11 +11,6 @@ public abstract class DelegatingProperty<T> implements Property<T> {
     }
     
     @Override
-    public long getLastUpdateTime(TimeUnit units) {
-        return delegate.getLastUpdateTime(units);
-    }
-
-    @Override
     public void unsubscribe() {
         delegate.unsubscribe();
     }

--- a/archaius2-core/src/main/java/com/netflix/archaius/Property.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/Property.java
@@ -49,14 +49,7 @@ public interface Property<T> {
      * @return  Most recent value for the property
      */
     T get();
-    
-    /**
-     * Get the last time the property was updated
-     * @param units
-     * @return
-     */
-    long getLastUpdateTime(TimeUnit units);
-    
+
     /**
      * Unsubscribe from property value update notifications.  The property object cannot be resubscribed.
      */

--- a/archaius2-core/src/main/java/com/netflix/archaius/property/DefaultPropertyContainer.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/property/DefaultPropertyContainer.java
@@ -264,11 +264,6 @@ public class DefaultPropertyContainer implements PropertyContainer {
         }
 
         @Override
-        public long getLastUpdateTime(TimeUnit units) {
-            return delegate.getLastUpdateTime(units);
-        }
-
-        @Override
         public void unsubscribe() {
             // TODO:
         }


### PR DESCRIPTION
…ute is out of place in latest Archaius2 architecture. If in the future, there's need to track the update timestamp in settable config, we can track at SettableConfig level instead of Property level.