### PR TITLE
issue #350. Fix the bug in key prefix iterator in Config

### DIFF
--- a/archaius2-core/src/main/java/com/netflix/archaius/config/AbstractConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/AbstractConfig.java
@@ -162,8 +162,7 @@ public abstract class AbstractConfig implements Config {
         return new Iterator<String>() {
             Iterator<String> iter = getKeys();
             String next;
-            String prev;
-            
+
             {
                 while (iter.hasNext()) {
                     next = iter.next();
@@ -187,7 +186,8 @@ public abstract class AbstractConfig implements Config {
                     throw new IllegalStateException();
                 }
                 
-                prev = next;
+                String current = next;
+                next = null;
                 while (iter.hasNext()) {
                     next = iter.next();
                     if (next.startsWith(prefix)) {
@@ -197,10 +197,7 @@ public abstract class AbstractConfig implements Config {
                         next = null;
                     }
                 }
-                if (next != null && next.equals(prev)) {
-                    next = null;
-                }
-                return prev;
+                return current;
             }
 
             @Override

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/AbstractConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/AbstractConfig.java
@@ -162,10 +162,17 @@ public abstract class AbstractConfig implements Config {
         return new Iterator<String>() {
             Iterator<String> iter = getKeys();
             String next;
+            String prev;
             
             {
-                if (iter.hasNext()) {
+                while (iter.hasNext()) {
                     next = iter.next();
+                    if (next.startsWith(prefix)) {
+                        break;
+                    }
+                    else {
+                        next = null;
+                    }
                 }
             }
             
@@ -180,7 +187,7 @@ public abstract class AbstractConfig implements Config {
                     throw new IllegalStateException();
                 }
                 
-                String prev = next;
+                prev = next;
                 while (iter.hasNext()) {
                     next = iter.next();
                     if (next.startsWith(prefix)) {
@@ -189,6 +196,9 @@ public abstract class AbstractConfig implements Config {
                     else {
                         next = null;
                     }
+                }
+                if (next != null && next.equals(prev)) {
+                    next = null;
                 }
                 return prev;
             }


### PR DESCRIPTION
This is actually pretty tricky. There are a couple of issues prior to this. One is at the beginning, the other is at the end of underneath iterator. We need to proceed until we can find one matching prefix at the beginning. At the end, we need to terminate properly by setting the "next" to null at proper place. It's very easy to miss the final one element.