### PR TITLE
issues #353, #354. Adding ability to set new list delimiter and prope…

### DIFF
--- a/archaius2-commons-configuration/src/main/java/com/netflix/archaius/commons/CommonsToConfig.java
+++ b/archaius2-commons-configuration/src/main/java/com/netflix/archaius/commons/CommonsToConfig.java
@@ -69,7 +69,14 @@ public class CommonsToConfig extends AbstractConfig {
 ;
         List<T> result = new ArrayList<T>();
         for (Object part : value) {
-            result.add(getDecoder().decode(type, part.toString()));
+            if (type.isInstance(part)) {
+                result.add((T)part);
+            } else if (part instanceof String) {
+                result.add(getDecoder().decode(type, (String) part));
+            } else {
+                throw new UnsupportedOperationException(
+                        "Property values other than " + type.getCanonicalName() +" or String not supported");
+            }
         }
         return result;
     }

--- a/archaius2-commons-configuration/src/main/java/com/netflix/archaius/commons/CommonsToConfig.java
+++ b/archaius2-commons-configuration/src/main/java/com/netflix/archaius/commons/CommonsToConfig.java
@@ -15,7 +15,10 @@
  */
 package com.netflix.archaius.commons;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 
 import org.apache.commons.configuration.AbstractConfiguration;
 
@@ -55,4 +58,64 @@ public class CommonsToConfig extends AbstractConfig {
     public Iterator<String> getKeys() {
         return config.getKeys();
     }
+
+    @Override
+    public <T> List<T> getList(String key, Class<T> type) {
+        List value = config.getList(key);
+        if (value == null) {
+            return notFound(key);
+        }
+;
+        List<T> result = new ArrayList<T>();
+        for (Object part : value) {
+            result.add(getDecoder().decode(type, part.toString()));
+        }
+        return result;
+    }
+
+    @Override
+    public List getList(String key) {
+        List value = config.getList(key);
+        if (value == null) {
+            return notFound(key);
+        }
+        return value;
+    }
+
+    @Override
+    public String getString(String key, String defaultValue) {
+        List value = config.getList(key);
+        if (value == null) {
+            return notFound(key, defaultValue != null ? getStrInterpolator().create(getLookup()).resolve(defaultValue) : null);
+        }
+        List<String> interpolatedResult = new ArrayList<>();
+        for (Object part : value) {
+            if (part instanceof String) {
+                interpolatedResult.add(getStrInterpolator().create(getLookup()).resolve(part.toString()));
+            } else {
+                throw new UnsupportedOperationException(
+                        "Property values other than String not supported");
+            }
+        }
+        return String.join(getListDelimiter(), interpolatedResult);
+    }
+
+    @Override
+    public String getString(String key) {
+        List value = config.getList(key);
+        if (value == null) {
+            return notFound(key);
+        }
+        List<String> interpolatedResult = new ArrayList<>();
+        for (Object part : value) {
+            if (part instanceof String) {
+                interpolatedResult.add(getStrInterpolator().create(getLookup()).resolve(part.toString()));
+            } else {
+                throw new UnsupportedOperationException(
+                        "Property values other than String not supported");
+            }
+        }
+        return String.join(getListDelimiter(), interpolatedResult);
+    }
+
 }

--- a/archaius2-commons-configuration/src/main/java/com/netflix/archaius/commons/CommonsToConfig.java
+++ b/archaius2-commons-configuration/src/main/java/com/netflix/archaius/commons/CommonsToConfig.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.apache.commons.configuration.AbstractConfiguration;
 
 import com.netflix.archaius.config.AbstractConfig;
+import org.apache.commons.lang.StringUtils;
 
 /**
  * Adaptor to allow an Apache Commons Configuration AbstractConfig to be used
@@ -97,7 +98,7 @@ public class CommonsToConfig extends AbstractConfig {
                         "Property values other than String not supported");
             }
         }
-        return String.join(getListDelimiter(), interpolatedResult);
+        return StringUtils.join(interpolatedResult, getListDelimiter());
     }
 
     @Override
@@ -115,7 +116,7 @@ public class CommonsToConfig extends AbstractConfig {
                         "Property values other than String not supported");
             }
         }
-        return String.join(getListDelimiter(), interpolatedResult);
+        return StringUtils.join(interpolatedResult, getListDelimiter());
     }
 
 }

--- a/archaius2-core/src/main/java/com/netflix/archaius/Config.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/Config.java
@@ -164,10 +164,4 @@ public interface Config {
      * @param visitor
      */
     <T> T accept(Visitor<T> visitor);
-
-    /**
-     * Set the delimiter to split property value
-     * @param newDelimiter
-     */
-    void setListDelimiter(String newDelimiter);
 }

--- a/archaius2-core/src/main/java/com/netflix/archaius/Config.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/Config.java
@@ -164,4 +164,10 @@ public interface Config {
      * @param visitor
      */
     <T> T accept(Visitor<T> visitor);
+
+    /**
+     * Set the delimiter to split property value
+     * @param newDelimiter
+     */
+    void setListDelimiter(String newDelimiter);
 }

--- a/archaius2-core/src/main/java/com/netflix/archaius/DefaultDecoder.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/DefaultDecoder.java
@@ -44,7 +44,6 @@ public class DefaultDecoder implements Decoder {
             return (T) encoded;
         }
         else if (type.equals(boolean.class) || type.equals(Boolean.class)) {
-            if (type.equals(boolean.class) || type.equals(Boolean.class)) {
                 if (encoded.equalsIgnoreCase("true") || encoded.equalsIgnoreCase("yes") || encoded.equalsIgnoreCase("on")) {
                     return (T) Boolean.TRUE;
                 }
@@ -52,8 +51,6 @@ public class DefaultDecoder implements Decoder {
                     return (T) Boolean.FALSE;
                 }
                 throw new ParseException("Error parsing value '" + encoded, new Exception("Expected one of [true, yes, on, false, no, off]"));
-            }
-            return (T) Boolean.valueOf(encoded);
         }
         else if (type.equals(int.class) || type.equals(Integer.class)) {
             return (T) Integer.valueOf(encoded);

--- a/archaius2-core/src/main/java/com/netflix/archaius/DefaultDecoder.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/DefaultDecoder.java
@@ -15,6 +15,8 @@
  */
 package com.netflix.archaius;
 
+import com.netflix.archaius.exceptions.ParseException;
+
 import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
@@ -42,6 +44,15 @@ public class DefaultDecoder implements Decoder {
             return (T) encoded;
         }
         else if (type.equals(boolean.class) || type.equals(Boolean.class)) {
+            if (type.equals(boolean.class) || type.equals(Boolean.class)) {
+                if (encoded.equalsIgnoreCase("true") || encoded.equalsIgnoreCase("yes") || encoded.equalsIgnoreCase("on")) {
+                    return (T) Boolean.TRUE;
+                }
+                else if (encoded.equalsIgnoreCase("false") || encoded.equalsIgnoreCase("no") || encoded.equalsIgnoreCase("off")) {
+                    return (T) Boolean.FALSE;
+                }
+                throw new ParseException("Error parsing value '" + encoded, new Exception("Expected one of [true, yes, on, false, no, off]"));
+            }
             return (T) Boolean.valueOf(encoded);
         }
         else if (type.equals(int.class) || type.equals(Integer.class)) {

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/AbstractConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/AbstractConfig.java
@@ -51,7 +51,7 @@ public abstract class AbstractConfig implements Config {
     protected CopyOnWriteArrayList<ConfigListener> getListeners() {
         return listeners;
     }
-
+    protected Lookup getLookup() { return lookup; }
     public String getListDelimiter() {
         return listDelimiter;
     }

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/AbstractConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/AbstractConfig.java
@@ -52,12 +52,9 @@ public abstract class AbstractConfig implements Config {
         return listeners;
     }
 
-
     public String getListDelimiter() {
         return listDelimiter;
     }
-
-    @Override
     public void setListDelimiter(String delimiter) {
         listDelimiter = delimiter;
     }

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/AbstractConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/AbstractConfig.java
@@ -235,15 +235,6 @@ public abstract class AbstractConfig implements Config {
         if (rawProp instanceof String) {
             try {
                 String value = interpolator.create(lookup).resolve(rawProp.toString());
-                if (type.equals(boolean.class) || type.equals(Boolean.class)) {
-                    if (value.equalsIgnoreCase("true") || value.equalsIgnoreCase("yes") || value.equalsIgnoreCase("on")) {
-                        return (T) Boolean.TRUE;
-                    }
-                    else if (value.equalsIgnoreCase("false") || value.equalsIgnoreCase("no") || value.equalsIgnoreCase("off")) {
-                        return (T) Boolean.FALSE;
-                    }
-                    return parseError(key, value, new Exception("Expected one of [true, yes, on, false, no, off]"));
-                }
                 return decoder.decode(type, value);
             } catch (NumberFormatException e) {
                 return parseError(key, rawProp.toString(), e);
@@ -256,6 +247,14 @@ public abstract class AbstractConfig implements Config {
         }
     }
 
+    protected <T> T getValueWithDefault(Class<T> type, String key, T defaultValue) {
+        try {
+            return getValue(type, key);
+        } catch (NoSuchElementException e) {
+            return defaultValue;
+        }
+    }
+
     @Override
     public Long getLong(String key) {
         return getValue(Long.class, key);
@@ -263,11 +262,7 @@ public abstract class AbstractConfig implements Config {
 
     @Override
     public Long getLong(String key, Long defaultValue) {
-        try {
-            return getValue(Long.class, key);
-        } catch (NoSuchElementException e) {
-            return defaultValue;
-        }
+        return getValueWithDefault(Long.class, key, defaultValue);
     }
 
     @Override
@@ -277,11 +272,7 @@ public abstract class AbstractConfig implements Config {
 
     @Override
     public Double getDouble(String key, Double defaultValue) {
-        try {
-            return getValue(Double.class, key);
-        } catch (NoSuchElementException e) {
-            return defaultValue;
-        }
+        return getValueWithDefault(Double.class, key, defaultValue);
     }
 
     @Override
@@ -291,11 +282,7 @@ public abstract class AbstractConfig implements Config {
 
     @Override
     public Integer getInteger(String key, Integer defaultValue) {
-        try {
-            return getValue(Integer.class, key);
-        } catch (NoSuchElementException e) {
-            return defaultValue;
-        }
+        return getValueWithDefault(Integer.class, key, defaultValue);
     }
 
     @Override
@@ -305,11 +292,7 @@ public abstract class AbstractConfig implements Config {
 
     @Override
     public Boolean getBoolean(String key, Boolean defaultValue) {
-        try {
-            return getValue(Boolean.class, key);
-        } catch (NoSuchElementException e) {
-            return defaultValue;
-        }
+        return getValueWithDefault(Boolean.class, key, defaultValue);
     }
 
     @Override
@@ -319,11 +302,7 @@ public abstract class AbstractConfig implements Config {
 
     @Override
     public Short getShort(String key, Short defaultValue) {
-        try {
-            return getValue(Short.class, key);
-        } catch (NoSuchElementException e) {
-            return defaultValue;
-        }
+        return getValueWithDefault(Short.class, key, defaultValue);
     }
 
     @Override
@@ -333,11 +312,7 @@ public abstract class AbstractConfig implements Config {
 
     @Override
     public BigInteger getBigInteger(String key, BigInteger defaultValue) {
-        try {
-            return getValue(BigInteger.class, key);
-        } catch (NoSuchElementException e) {
-            return defaultValue;
-        }
+        return getValueWithDefault(BigInteger.class, key, defaultValue);
     }
 
     @Override
@@ -347,11 +322,7 @@ public abstract class AbstractConfig implements Config {
 
     @Override
     public BigDecimal getBigDecimal(String key, BigDecimal defaultValue) {
-        try {
-            return getValue(BigDecimal.class, key);
-        } catch (NoSuchElementException e) {
-            return defaultValue;
-        }
+        return getValueWithDefault(BigDecimal.class, key, defaultValue);
     }
 
     @Override
@@ -361,11 +332,7 @@ public abstract class AbstractConfig implements Config {
 
     @Override
     public Float getFloat(String key, Float defaultValue) {
-        try {
-            return getValue(Float.class, key);
-        } catch (NoSuchElementException e) {
-            return defaultValue;
-        }
+        return getValueWithDefault(Float.class, key, defaultValue);
     }
 
     @Override
@@ -375,11 +342,7 @@ public abstract class AbstractConfig implements Config {
 
     @Override
     public Byte getByte(String key, Byte defaultValue) {
-        try {
-            return getValue(Byte.class, key);
-        } catch (NoSuchElementException e) {
-            return defaultValue;
-        }
+        return getValueWithDefault(Byte.class, key, defaultValue);
     }
 
     @Override
@@ -423,11 +386,7 @@ public abstract class AbstractConfig implements Config {
 
     @Override
     public <T> T get(Class<T> type, String key, T defaultValue) {
-        try {
-            return getValue(type, key);
-        } catch (NoSuchElementException e) {
-            return defaultValue;
-        }
+        return getValueWithDefault(type, key, defaultValue);
     }
 
     private <T> T parseError(String key, String value, Exception e) {

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/CompositeConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/CompositeConfig.java
@@ -181,7 +181,6 @@ public class CompositeConfig extends AbstractConfig {
         child.setDecoder(getDecoder());
         notifyConfigAdded(child);
         child.addListener(listener);
-        child.setListDelimiter(getListDelimiter());
     }
     
     /**
@@ -230,19 +229,32 @@ public class CompositeConfig extends AbstractConfig {
         return lookup.get(name);
     }
 
-    @Override
-    public void setListDelimiter(String newDelimiter) {
-        super.setListDelimiter(newDelimiter);
-        for (Config child : children) {
-            child.setListDelimiter(newDelimiter);
-        }
-    }
 
     @Override
     public Object getRawProperty(String key) {
         for (Config child : children) {
             if (child.containsKey(key)) {
                 return child.getRawProperty(key);
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public <T> List<T> getList(String key, Class<T> type) {
+        for (Config child : children) {
+            if (child.containsKey(key)) {
+                return child.getList(key, type);
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public List getList(String key) {
+        for (Config child : children) {
+            if (child.containsKey(key)) {
+                return child.getList(key);
             }
         }
         return null;

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/CompositeConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/CompositeConfig.java
@@ -230,6 +230,14 @@ public class CompositeConfig extends AbstractConfig {
     }
 
     @Override
+    public void setListDelimiter(String newDelimiter) {
+        super.setListDelimiter(newDelimiter);
+        for (Config child : children) {
+            child.setListDelimiter(newDelimiter);
+        }
+    }
+
+    @Override
     public Object getRawProperty(String key) {
         for (Config child : children) {
             if (child.containsKey(key)) {

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/CompositeConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/CompositeConfig.java
@@ -247,7 +247,7 @@ public class CompositeConfig extends AbstractConfig {
                 return child.getList(key, type);
             }
         }
-        return null;
+        return notFound(key);
     }
 
     @Override
@@ -257,7 +257,7 @@ public class CompositeConfig extends AbstractConfig {
                 return child.getList(key);
             }
         }
-        return null;
+        return notFound(key);
     }
 
     @Override

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/CompositeConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/CompositeConfig.java
@@ -181,6 +181,7 @@ public class CompositeConfig extends AbstractConfig {
         child.setDecoder(getDecoder());
         notifyConfigAdded(child);
         child.addListener(listener);
+        child.setListDelimiter(getListDelimiter());
     }
     
     /**

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/DefaultSettableConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/DefaultSettableConfig.java
@@ -24,11 +24,11 @@ import java.util.concurrent.ConcurrentMap;
 import com.netflix.archaius.Config;
 
 public class DefaultSettableConfig extends AbstractConfig implements SettableConfig {
-    private ConcurrentMap<String, String> props = new ConcurrentHashMap<String, String>();
+    private ConcurrentMap<String, Object> props = new ConcurrentHashMap<String, Object>();
     
     @Override
     public <T> void setProperty(String propName, T propValue) {
-        props.put(propName, propValue.toString());
+        props.put(propName, propValue);
         notifyConfigUpdated(this);
     }
     


### PR DESCRIPTION
…rty is stored as Object instead of String.

This PR covers two issues. One is to be able to set a new delimiter. The other is treat Property value as Object instead of String. For now, only turns on the storing for Settable config. In the future, it's possible we need to extend to MapConfig.