### PR TITLE
2.x poll with fixed delay rather than fixed rate

### DIFF
--- a/archaius2-core/src/main/java/com/netflix/archaius/config/polling/FixedPollingStrategy.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/polling/FixedPollingStrategy.java
@@ -63,7 +63,7 @@ public class FixedPollingStrategy implements PollingStrategy {
                 }
             }
         }
-        return executor.scheduleAtFixedRate(new Runnable() {
+        return executor.scheduleWithFixedDelay(new Runnable() {
             @Override
             public void run() {
                 try {


### PR DESCRIPTION
If the polling operation becomes slow, then `scheduleAtFixedRate`
will queue up new requests. This caused a problem for us because
we had an issue with the server side, many requests backed up,
and then when the service was recovered it got hammered with a
much higher rate of requests until the backlog had cleared.

This changes the poller to use `scheduleWithFixedDelay` to avoid
the issue. In general for the properties the overall staleness
seems more important and for the typical case of a quick response
it should make little difference.