### PR TITLE
Cleanup PropertyFactory API

### DIFF
--- a/archaius2-api/src/main/java/com/netflix/archaius/api/ListenerSubscription.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/api/ListenerSubscription.java
@@ -1,0 +1,9 @@
+package com.netflix.archaius.api;
+
+/**
+ * Subscription created when adding a listener for a property.  The subscription's 
+ * remove() method must be called to stop receiving property change updates.
+ */
+public interface ListenerSubscription {
+    void unsubscribe();
+}

--- a/archaius2-api/src/main/java/com/netflix/archaius/api/ListenerSubscription.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/api/ListenerSubscription.java
@@ -1,9 +1,0 @@
-package com.netflix.archaius.api;
-
-/**
- * Subscription created when adding a listener for a property.  The subscription's 
- * remove() method must be called to stop receiving property change updates.
- */
-public interface ListenerSubscription {
-    void unsubscribe();
-}

--- a/archaius2-api/src/main/java/com/netflix/archaius/api/Property.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/api/Property.java
@@ -17,20 +17,18 @@ package com.netflix.archaius.api;
 
 /**
  * API to access latest cached value for a Property.  A Property is created from a PropertyFactory
- * that is normally bound to a top level configuration object such ask {@link AppConfig}.  Through
- * a Property its also possible to receive a stream of property update notifications.
+ * that is normally bound to a top level configuration.  
  * 
  * {@code 
  * class MyService {
  *     private final Property<String> prop;
  *     
- *     MyService(PropertyFactory config) {
- *        prop = config.connectProperty("foo.prop").asString("defaultValue");
+ *     MyService(PropertyFactory factory) {
+ *        prop = factory.getProperty("foo.prop").asString("defaultValue");
  *     }
  *     
- *     void doSomething() {
- *         // Will print out the most up to date value for the property
- *         System.out.println(prop.get());
+ *     public void doSomething() {
+ *         String currentValue = prop.get();
  *     }
  * }
  * }
@@ -44,29 +42,21 @@ package com.netflix.archaius.api;
  */
 public interface Property<T> {
     /**
+     * Return the most recent value of the property.  
+     * 
      * @return  Most recent value for the property
      */
     T get();
-
-    /**
-     * Unsubscribe from property value update notifications.  The property object cannot be resubscribed.
-     */
-    void unsubscribe();
 
     /**
      * Add a listener that will be called whenever the property value changes
      * @param listener
      * @return
      */
-    Property<T> addListener(PropertyListener<T> listener);
+    ListenerSubscription addListener(PropertyListener<T> listener);
 
     /**
-     * Remove a listener
-     * 
-     * @param listener
+     * @return Key or path to the property 
      */
-    void removeListener(PropertyListener<T> listener);
-    
     String getKey();
-    
 }

--- a/archaius2-api/src/main/java/com/netflix/archaius/api/Property.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/api/Property.java
@@ -51,10 +51,15 @@ public interface Property<T> {
     /**
      * Add a listener that will be called whenever the property value changes
      * @param listener
-     * @return
      */
-    ListenerSubscription addListener(PropertyListener<T> listener);
+    void addListener(PropertyListener<T> listener);
 
+    /**
+     * Remove a listener previously registered by calling addListener
+     * @param listener
+     */
+    void removeListener(PropertyListener<T> listener);
+    
     /**
      * @return Key or path to the property 
      */

--- a/archaius2-api/src/main/java/com/netflix/archaius/api/PropertyFactory.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/api/PropertyFactory.java
@@ -26,11 +26,5 @@ public interface PropertyFactory {
     /**
      * Create a property for the property name.  
      */
-    public PropertyContainer getProperty(String propName);
-    
-    /**
-     * Get the Config object backing this factory
-     * @return
-     */
-    public Config getConfig();
+    PropertyContainer getProperty(String propName);
 }

--- a/archaius2-core/src/main/java/com/netflix/archaius/AbstractProperty.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/AbstractProperty.java
@@ -1,5 +1,6 @@
 package com.netflix.archaius;
 
+import com.netflix.archaius.api.ListenerSubscription;
 import com.netflix.archaius.api.Property;
 import com.netflix.archaius.api.PropertyListener;
 
@@ -12,17 +13,7 @@ public abstract class AbstractProperty<T> implements Property<T> {
     }
     
     @Override
-    public void unsubscribe() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Property<T> addListener(PropertyListener<T> listener) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void removeListener(PropertyListener<T> listener) {
+    public ListenerSubscription addListener(PropertyListener<T> listener) {
         throw new UnsupportedOperationException();
     }
 

--- a/archaius2-core/src/main/java/com/netflix/archaius/AbstractProperty.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/AbstractProperty.java
@@ -1,6 +1,5 @@
 package com.netflix.archaius;
 
-import com.netflix.archaius.api.ListenerSubscription;
 import com.netflix.archaius.api.Property;
 import com.netflix.archaius.api.PropertyListener;
 
@@ -13,7 +12,12 @@ public abstract class AbstractProperty<T> implements Property<T> {
     }
     
     @Override
-    public ListenerSubscription addListener(PropertyListener<T> listener) {
+    public void addListener(PropertyListener<T> listener) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void removeListener(PropertyListener<T> listener) {
         throw new UnsupportedOperationException();
     }
 

--- a/archaius2-core/src/main/java/com/netflix/archaius/ConfigMapper.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/ConfigMapper.java
@@ -21,10 +21,10 @@ import java.lang.reflect.Modifier;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.netflix.archaius.api.Config;
-import com.netflix.archaius.api.IoCContainer;
 import org.apache.commons.lang3.text.StrSubstitutor;
 
+import com.netflix.archaius.api.Config;
+import com.netflix.archaius.api.IoCContainer;
 import com.netflix.archaius.api.annotations.Configuration;
 import com.netflix.archaius.exceptions.MappingException;
 import com.netflix.archaius.interpolate.ConfigStrLookup;

--- a/archaius2-core/src/main/java/com/netflix/archaius/ConfigProxyFactory.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/ConfigProxyFactory.java
@@ -163,19 +163,11 @@ public class ConfigProxyFactory {
                                 values.put("" + i, args[i]);
                             }
                             String propName = new StrSubstitutor(values, "${", "}", '$').replace(nameAnnot.name());
-                            
-                            // Read the actual value now that the proeprty name is known.  Note that we can't create
-                            // 
-                            if (defaultValue != null) {
-                                return getPropertyWithDefault(returnType, propName, defaultValue.value());
-                            }
-                            else {
-                                return propertyFactory.getConfig().get(returnType, propName, null);
-                            }
+                            return getPropertyWithDefault(returnType, propName, (defaultValue != null) ? defaultValue.value() : null);
                         }
 
                         <R> R getPropertyWithDefault(Class<R> type, String propName, String defaultValue) {
-                            return propertyFactory.getConfig().get(type, propName, decoder.decode(type, defaultValue));
+                            return propertyFactory.getProperty(propName).asType(type, decoder.decode(type, defaultValue)).get();
                         }
 
                         @Override
@@ -247,20 +239,7 @@ public class ConfigProxyFactory {
             @Override
             public T get() {
                 if (cached == null) {
-                    cached = propertyFactory.getConfig().get(type, propName, decoder.decode(type, defaultValue));
-                }
-                return cached;
-            }
-        };
-    }
-    
-    private <T> MethodInvoker<T> createImmutableProperty(final Class<T> type, final String propName) {
-        return new PropertyMethodInvoker<T>(propName) {
-            private volatile T cached;
-            @Override
-            public T get() {
-                if (cached == null) {
-                    cached = propertyFactory.getConfig().get(type, propName);
+                    cached = propertyFactory.getProperty(propName).asType(type, decoder.decode(type, defaultValue)).get();
                 }
                 return cached;
             }

--- a/archaius2-core/src/main/java/com/netflix/archaius/DefaultPropertyFactory.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/DefaultPropertyFactory.java
@@ -93,9 +93,4 @@ public class DefaultPropertyFactory implements PropertyFactory, ConfigListener {
         // a dependency graph of replacements.
         listeners.updateAll();
     }
-
-    @Override
-    public Config getConfig() {
-        return config;
-    }
 }

--- a/archaius2-core/src/main/java/com/netflix/archaius/DelegatingProperty.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/DelegatingProperty.java
@@ -1,6 +1,5 @@
 package com.netflix.archaius;
 
-import com.netflix.archaius.api.ListenerSubscription;
 import com.netflix.archaius.api.Property;
 import com.netflix.archaius.api.PropertyListener;
 
@@ -13,9 +12,15 @@ public abstract class DelegatingProperty<T> implements Property<T> {
     }
     
     @Override
-    public ListenerSubscription addListener(PropertyListener<T> listener) {
-        return delegate.addListener(listener);
+    public void addListener(PropertyListener<T> listener) {
+        delegate.addListener(listener);
     }
+    
+    @Override
+    public void removeListener(PropertyListener<T> listener) {
+        delegate.removeListener(listener);
+    }
+    
     @Override
     public String getKey() {
         return delegate.getKey();

--- a/archaius2-core/src/main/java/com/netflix/archaius/DelegatingProperty.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/DelegatingProperty.java
@@ -1,5 +1,6 @@
 package com.netflix.archaius;
 
+import com.netflix.archaius.api.ListenerSubscription;
 import com.netflix.archaius.api.Property;
 import com.netflix.archaius.api.PropertyListener;
 
@@ -12,24 +13,11 @@ public abstract class DelegatingProperty<T> implements Property<T> {
     }
     
     @Override
-    public void unsubscribe() {
-        delegate.unsubscribe();
+    public ListenerSubscription addListener(PropertyListener<T> listener) {
+        return delegate.addListener(listener);
     }
-
-    @Override
-    public Property<T> addListener(PropertyListener<T> listener) {
-        delegate.addListener(listener);
-        return this;
-    }
-
-    @Override
-    public void removeListener(PropertyListener<T> listener) {
-        delegate.removeListener(listener);
-    }
-
     @Override
     public String getKey() {
         return delegate.getKey();
     }
-
 }

--- a/archaius2-core/src/main/java/com/netflix/archaius/property/DefaultPropertyContainer.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/property/DefaultPropertyContainer.java
@@ -27,7 +27,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.netflix.archaius.api.Config;
-import com.netflix.archaius.api.ListenerSubscription;
 import com.netflix.archaius.api.Property;
 import com.netflix.archaius.api.PropertyContainer;
 import com.netflix.archaius.api.PropertyListener;
@@ -265,14 +264,13 @@ public class DefaultPropertyContainer implements PropertyContainer {
         }
 
         @Override
-        public ListenerSubscription addListener(final PropertyListener<T> listener) {
+        public void addListener(final PropertyListener<T> listener) {
             delegate.addListener(listener, defaultValue);
-            return new ListenerSubscription() {
-                @Override
-                public void unsubscribe() {
-                    delegate.removeListener(listener);
-                }
-            };
+        }
+        
+        @Override
+        public void removeListener(final PropertyListener<T> listener) {
+            delegate.removeListener(listener);
         }
 
         @Override

--- a/archaius2-core/src/main/java/com/netflix/archaius/property/DefaultPropertyContainer.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/property/DefaultPropertyContainer.java
@@ -27,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.netflix.archaius.api.Config;
+import com.netflix.archaius.api.ListenerSubscription;
 import com.netflix.archaius.api.Property;
 import com.netflix.archaius.api.PropertyContainer;
 import com.netflix.archaius.api.PropertyListener;
@@ -264,19 +265,14 @@ public class DefaultPropertyContainer implements PropertyContainer {
         }
 
         @Override
-        public void unsubscribe() {
-            // TODO:
-        }
-
-        @Override
-        public Property<T> addListener(PropertyListener<T> listener) {
+        public ListenerSubscription addListener(final PropertyListener<T> listener) {
             delegate.addListener(listener, defaultValue);
-            return this;
-        }
-
-        @Override
-        public void removeListener(PropertyListener<T> listener) {
-            delegate.removeListener(listener);
+            return new ListenerSubscription() {
+                @Override
+                public void unsubscribe() {
+                    delegate.removeListener(listener);
+                }
+            };
         }
 
         @Override

--- a/archaius2-core/src/test/java/com/netflix/archaius/junit/TestHttpServer.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/junit/TestHttpServer.java
@@ -34,7 +34,6 @@ import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.netflix.archaius.util.ThreadFactories;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;

--- a/archaius2-core/src/test/java/com/netflix/archaius/property/PropertyTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/property/PropertyTest.java
@@ -24,9 +24,9 @@ import com.netflix.archaius.DefaultPropertyFactory;
 import com.netflix.archaius.api.Property;
 import com.netflix.archaius.api.PropertyFactory;
 import com.netflix.archaius.api.PropertyListener;
-import com.netflix.archaius.config.DefaultSettableConfig;
 import com.netflix.archaius.api.config.SettableConfig;
 import com.netflix.archaius.api.exceptions.ConfigException;
+import com.netflix.archaius.config.DefaultSettableConfig;
 
 public class PropertyTest {
     public static class MyService {
@@ -34,7 +34,8 @@ public class PropertyTest {
         private Property<Integer> value2;
         
         public MyService(PropertyFactory config) {
-            value  = config.getProperty("foo").asInteger(1).addListener(new MethodInvoker<Integer>(this, "setValue"));
+            value  = config.getProperty("foo").asInteger(1);
+            value.addListener(new MethodInvoker<Integer>(this, "setValue"));
             value2 = config.getProperty("foo").asInteger(2);
         }
         


### PR DESCRIPTION
Clean up the PropertyFactory and Property APIs to decouple them completely from the Config API so they can be backed by other configuration mechanisms.
