### PR TITLE
Fix non-string dynamic property bridge

### DIFF
--- a/archaius2-archaius1-bridge/src/main/java/com/netflix/archaius/bridge/StaticAbstractConfiguration.java
+++ b/archaius2-archaius1-bridge/src/main/java/com/netflix/archaius/bridge/StaticAbstractConfiguration.java
@@ -79,6 +79,12 @@ public class StaticAbstractConfiguration extends AbstractConfiguration implement
     }
 
     @Override
+    public String getString(String key, String defaultValue) {
+        Object value = getProperty(key);
+        return value != null ? value.toString() : defaultValue;
+    }
+
+    @Override
     public Object getProperty(String key) {
         if (delegate == null) {
             System.out.println("[getProperty(" + key + ")] StaticAbstractConfiguration not initialized yet.");

--- a/archaius2-archaius1-bridge/src/test/java/com/netflix/archaius/bridge/DynamicPropertyTest.java
+++ b/archaius2-archaius1-bridge/src/test/java/com/netflix/archaius/bridge/DynamicPropertyTest.java
@@ -11,6 +11,8 @@ import com.netflix.archaius.api.PropertyFactory;
 import com.netflix.archaius.api.config.SettableConfig;
 import com.netflix.archaius.guice.ArchaiusModule;
 import com.netflix.archaius.api.inject.RuntimeLayer;
+import com.netflix.config.ConfigurationManager;
+import com.netflix.config.DynamicIntProperty;
 import com.netflix.config.DynamicPropertyFactory;
 import com.netflix.config.DynamicStringProperty;
 
@@ -30,6 +32,21 @@ public class DynamicPropertyTest {
         
         Assert.assertEquals("newvalue", prop.get());
         Assert.assertEquals("newvalue", prop2.get());
+        
+    }
+    
+    @Test
+    public void testNonStringDynamicProperty() {
+        Injector injector = Guice.createInjector(new ArchaiusModule(), new StaticArchaiusBridgeModule());
+
+        ConfigurationManager.getConfigInstance().setProperty("foo", 123);
+        
+        Property<Integer> prop2 = injector.getInstance(PropertyFactory.class).getProperty("foo").asInteger(1);
+        
+        DynamicIntProperty prop = DynamicPropertyFactory.getInstance().getIntProperty("foo", 2);
+        
+        Assert.assertEquals(123, prop.get());
+        Assert.assertEquals(123, (int)prop2.get());
         
     }
 }


### PR DESCRIPTION
Force getString() to do a .toString() since all the dynamic configuration classes depend on properties being stored as strings