### PR TITLE
Back port module to enable ConfigProxyFactory for legacy archaius

### DIFF
--- a/archaius2-archaius1-bridge/src/main/java/com/netflix/archaius/bridge/Archaius2BackportModule.java
+++ b/archaius2-archaius1-bridge/src/main/java/com/netflix/archaius/bridge/Archaius2BackportModule.java
@@ -1,0 +1,37 @@
+package com.netflix.archaius.bridge;
+
+import javax.inject.Singleton;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.netflix.archaius.ConfigProxyFactory;
+import com.netflix.archaius.commons.CommonsToConfig;
+import com.netflix.config.ConfigurationManager;
+
+/**
+ * Install this module so that an injectable {@link ConfigProxyFactory} can be backed by the static
+ * Archaius1 {@link ConfigurationManager}.  Use this for legacy applications that use Archaius1 and
+ * haven't yet update to use Archaius2 as its configuration solution.
+ */
+public final class Archaius2BackportModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+    }
+
+    @Provides 
+    @Singleton
+    ConfigProxyFactory getConfigProxyFactory() {
+        return new ConfigProxyFactory(new CommonsToConfig(ConfigurationManager.getConfigInstance()));
+    }
+    
+    @Override
+    public boolean equals(Object obj) {
+        return obj != null && getClass().equals(obj.getClass());
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
+}

--- a/archaius2-archaius1-bridge/src/test/java/com/netflix/archaius/bridge/Arcahsiu2BackportModuleTest.java
+++ b/archaius2-archaius1-bridge/src/test/java/com/netflix/archaius/bridge/Arcahsiu2BackportModuleTest.java
@@ -1,0 +1,97 @@
+package com.netflix.archaius.bridge;
+
+import javax.inject.Singleton;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Provides;
+import com.netflix.archaius.ConfigProxyFactory;
+import com.netflix.config.ConfigurationManager;
+
+public class Arcahsiu2BackportModuleTest {
+    
+    public static interface MyConfiguration {
+        String getString();
+        int getInteger();
+        int getStringInteger();
+        int getInterpolatedInteger();
+    }
+    
+    public static class MyConfigurationModule extends AbstractModule {
+        @Override
+        protected void configure() {
+        }
+        
+        @Provides
+        @Singleton
+        MyConfiguration getConfiguration(ConfigProxyFactory factory) {
+            return factory.newProxy(MyConfiguration.class);
+        }
+    }
+    
+    @Test
+    public void stringPropertyBinding() {
+        ConfigurationManager.getConfigInstance().setProperty("string", "value");
+        
+        Injector injector = Guice.createInjector(new Archaius2BackportModule(), new MyConfigurationModule());
+        
+        MyConfiguration config = injector.getInstance(MyConfiguration.class);
+        
+        Assert.assertEquals("value", config.getString());
+    }
+    
+    @Test
+    public void nonStringPropertyBinding() {
+        ConfigurationManager.getConfigInstance().setProperty("integer", 123);
+        ConfigurationManager.getConfigInstance().setProperty("stringInteger", "124");
+        
+        Injector injector = Guice.createInjector(new Archaius2BackportModule(), new MyConfigurationModule());
+        
+        MyConfiguration config = injector.getInstance(MyConfiguration.class);
+        
+        Assert.assertEquals(123, config.getInteger());
+        Assert.assertEquals(124, config.getStringInteger());
+    }
+    
+    @Test
+    public void interpolatedValueBinding() {
+        ConfigurationManager.getConfigInstance().setProperty("integer", 123);
+        ConfigurationManager.getConfigInstance().setProperty("interpolatedInteger", "${integer}");
+        
+        Injector injector = Guice.createInjector(new Archaius2BackportModule(), new MyConfigurationModule());
+        
+        MyConfiguration config = injector.getInstance(MyConfiguration.class);
+        
+        Assert.assertEquals(123, config.getInterpolatedInteger());
+    }
+    
+    @Test
+    public void proxiedInterfaceUpdates() {
+        ConfigurationManager.getConfigInstance().setProperty("string", "value");
+        
+        Injector injector = Guice.createInjector(new Archaius2BackportModule(),
+            new AbstractModule() {
+                @Override
+                protected void configure() {
+                }
+                
+                @Provides
+                @Singleton
+                MyConfiguration getConfiguration(ConfigProxyFactory factory) {
+                    return factory.newProxy(MyConfiguration.class);
+                }
+        });
+        
+        MyConfiguration config = injector.getInstance(MyConfiguration.class);
+        
+        Assert.assertEquals("value", config.getString());
+        
+        ConfigurationManager.getConfigInstance().setProperty("string", "new_value");
+        Assert.assertEquals("new_value", config.getString());
+        
+    }
+}

--- a/archaius2-commons-configuration/src/main/java/com/netflix/archaius/commons/CommonsToConfig.java
+++ b/archaius2-commons-configuration/src/main/java/com/netflix/archaius/commons/CommonsToConfig.java
@@ -16,14 +16,15 @@
 package com.netflix.archaius.commons;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
 import org.apache.commons.configuration.AbstractConfiguration;
+import org.apache.commons.configuration.event.ConfigurationEvent;
+import org.apache.commons.configuration.event.ConfigurationListener;
+import org.apache.commons.lang3.StringUtils;
 
 import com.netflix.archaius.config.AbstractConfig;
-import org.apache.commons.lang.StringUtils;
 
 /**
  * Adaptor to allow an Apache Commons Configuration AbstractConfig to be used
@@ -38,6 +39,12 @@ public class CommonsToConfig extends AbstractConfig {
     
     public CommonsToConfig(AbstractConfiguration config) {
         this.config = config;
+        config.addConfigurationListener(new ConfigurationListener() {
+            @Override
+            public void configurationChanged(ConfigurationEvent event) {
+                notifyConfigUpdated(CommonsToConfig.this);
+            }
+        });
     }
 
     @Override
@@ -52,7 +59,7 @@ public class CommonsToConfig extends AbstractConfig {
 
     @Override
     public Object getRawProperty(String key) {
-        return config.getString(key);
+        return config.getProperty(key);
     }
 
     @Override
@@ -66,7 +73,7 @@ public class CommonsToConfig extends AbstractConfig {
         if (value == null) {
             return notFound(key);
         }
-;
+
         List<T> result = new ArrayList<T>();
         for (Object part : value) {
             if (type.isInstance(part)) {
@@ -89,7 +96,7 @@ public class CommonsToConfig extends AbstractConfig {
         }
         return value;
     }
-
+    
     @Override
     public String getString(String key, String defaultValue) {
         List value = config.getList(key);

--- a/archaius2-core/src/main/java/com/netflix/archaius/property/DefaultPropertyContainer.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/property/DefaultPropertyContainer.java
@@ -207,7 +207,7 @@ public class DefaultPropertyContainer implements PropertyContainer {
                     newValue = resolveCurrent();
                 }
                 catch (Exception e) {
-                    LOG.warn("Unable to get current version of property '{}'. Error: {}", key, e.getMessage());
+                    LOG.warn("Unable to get current version of property '{}'. Error: {}", key, e);
                 }
                 
                 if (cache.compareAndSet(currentValue, newValue, cacheVersion, latestVersion)) {


### PR DESCRIPTION
This change makes it possible to use `ConfigProxyFactory` with any application that still uses Archaius1 for its configuration.  Libraries can now develop to the Archaius2 style of configuration using interfaces and `ConfigProxyFactory` to bind those interfaces to configuration.  

To enable just install `Archaius2BackportModule` on the injector and add configuration interface bindings as you would with Archaius2.  Note that Archacius2Backport is meant to be installed instead of `ArchaiusModule` and `StaticArchaiusBridgeModule`.

Note that there are a few minor restrictions here.  This change does not add support for `@ConfigurationSource` annotations in applications still using Archaius1.  For internal Netflix applications configuration classes would need to specify both `@ConfigurationSource` (for Archaius2) and `@NFProperties` (for Archaius1).  @Configuration is also not supported so library modules should specify the property prefix when creating a proxy instance.  

For example,

``` java
// This is the library's configuration interface
@ConfigurationSource("myconfig")
@NFProperties("myconfig")
public interface MyConfig {
    int getSomeProperty();
}
```

```
// This is the library module that an application will need to install
public class MyConfigModule {
    @Override
    public void configure() {}

    @Provides
    @Singleton
    MyConfig getMyConfig(ConfigProxyFactory factory) {
        return factory.newProxy(MyConfig.class, "prefix");
    }
}
```

The above setup will load properties from 'myconfig.properties' into archaius and bind the properties

```
prefix.someProperty=123
```
