### PR TITLE
Support dynamic configs of different kinds, not just String

### DIFF
--- a/archaius2-core/src/main/java/com/netflix/archaius/config/PollingDynamicConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/PollingDynamicConfig.java
@@ -40,7 +40,7 @@ import com.netflix.archaius.config.polling.PollingResponse;
 public class PollingDynamicConfig extends AbstractConfig {
     private static final Logger LOG = LoggerFactory.getLogger(PollingDynamicConfig.class);
     
-    private volatile Map<String, String> current = new HashMap<String, String>();
+    private volatile Map<String, Object> current = new HashMap<String, Object>();
     private final AtomicBoolean busy = new AtomicBoolean();
     private final Callable<PollingResponse> reader;
     private final AtomicLong updateCounter = new AtomicLong();

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/polling/PollingResponse.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/polling/PollingResponse.java
@@ -5,10 +5,10 @@ import java.util.Collections;
 import java.util.Map;
 
 public abstract class PollingResponse {
-    public static PollingResponse forSnapshot(final Map<String, String> values) {
+    public static PollingResponse forSnapshot(final Map<String, Object> values) {
         return new PollingResponse() {
             @Override
-            public Map<String, String> getToAdd() {
+            public Map<String, Object> getToAdd() {
                 return values;
             }
 
@@ -28,7 +28,7 @@ public abstract class PollingResponse {
     public static PollingResponse noop() {
         return new PollingResponse() {
             @Override
-            public Map<String, String> getToAdd() {
+            public Map<String, Object> getToAdd() {
                 return Collections.emptyMap();
             }
 
@@ -44,7 +44,7 @@ public abstract class PollingResponse {
         };
     }
     
-    public abstract Map<String, String> getToAdd();
+    public abstract Map<String, Object> getToAdd();
     public abstract Collection<String> getToRemove();
     public abstract boolean hasData(); 
 }

--- a/archaius2-core/src/main/java/com/netflix/archaius/readers/PropertiesConfigReader.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/readers/PropertiesConfigReader.java
@@ -64,13 +64,13 @@ public class PropertiesConfigReader implements ConfigReader {
             try {
                 // Load properties into the single Properties object overriding any property
                 // that may already exist
-                Map<String, String> p = new URLConfigReader(url).call().getToAdd();
+                Map<String, Object> p = new URLConfigReader(url).call().getToAdd();
                 LOG.debug("Loaded : {}", url.toExternalForm());
                 props.putAll(p);
     
                 // Recursively load any files referenced by an @next property in the file
                 // Only one @next property is expected and the value may be a list of files
-                String next = p.get(INCLUDE_KEY);
+                String next = (String) p.get(INCLUDE_KEY);
                 if (next != null) {
                     p.remove(INCLUDE_KEY);
                     for (String urlString : next.split(",")) {

--- a/archaius2-core/src/main/java/com/netflix/archaius/readers/URLConfigReader.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/readers/URLConfigReader.java
@@ -69,7 +69,7 @@ public class URLConfigReader implements Callable<PollingResponse> {
     
     @Override
     public PollingResponse call() throws IOException {
-        final Map<String, String> map = new HashMap<String, String>();
+        final Map<String, Object> map = new HashMap<String, Object>();
         for (URL url: configUrls) {
             Properties props = new Properties();
             InputStream fin = url.openStream();
@@ -95,7 +95,7 @@ public class URLConfigReader implements Callable<PollingResponse> {
         }
         return new PollingResponse() {
             @Override
-            public Map<String, String> getToAdd() {
+            public Map<String, Object> getToAdd() {
                 return map;
             }
 

--- a/archaius2-core/src/test/java/com/netflix/archaius/config/PollingDynamicConfigTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/PollingDynamicConfigTest.java
@@ -46,7 +46,7 @@ public class PollingDynamicConfigTest {
                 server.getServerPathURI("/prop1").toURL()
                 );
         
-        Map<String, String> result;
+        Map<String, Object> result;
         
         prop1.setProperty("a", "a_value");
         result = reader.call().getToAdd();
@@ -72,7 +72,7 @@ public class PollingDynamicConfigTest {
         prop1.setProperty("a", "A");
         prop2.setProperty("b", "B");
         
-        Map<String, String> result = reader.call().getToAdd();
+        Map<String, Object> result = reader.call().getToAdd();
 
         Assert.assertEquals(2, result.size());
         Assert.assertEquals("A", result.get("a"));

--- a/archaius2-persisted2/src/main/java/com/netflix/archaius/persisted2/JsonPersistedV2Reader.java
+++ b/archaius2-persisted2/src/main/java/com/netflix/archaius/persisted2/JsonPersistedV2Reader.java
@@ -187,7 +187,7 @@ public class JsonPersistedV2Reader implements Callable<PollingResponse> {
         }
         
         // Resolve to a single property value
-        final Map<String, String> result = new HashMap<String, String>();
+        final Map<String, Object> result = new HashMap<String, Object>();
         for (Entry<String, List<ScopedValue>> entry : props.entrySet()) {
             result.put(entry.getKey(), valueResolver.resolve(entry.getKey(), entry.getValue()));
         }


### PR DESCRIPTION
This is very useful for the remote TypesafeConfigLoader, which I’m going to add in a different pull request. It makes it possible to enhance the config with objects of type `Duration`, `Date` and others.

Relates to https://github.com/Netflix/archaius/issues/403
