### PR TITLE
Add dynamic typesafe config provider, with support for Duration/ConfigMemorySize

### DIFF
--- a/archaius2-core/src/main/java/com/netflix/archaius/config/MapConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/MapConfig.java
@@ -41,10 +41,10 @@ public class MapConfig extends AbstractConfig {
      * @author elandau
      */
     public static class Builder {
-        Map<String, String> map = new HashMap<String, String>();
-        
+        Map<String, Object> map = new HashMap<String, Object>();
+
         public <T> Builder put(String key, T value) {
-            map.put(key, value.toString());
+            map.put(key, value);
             return this;
         }
         
@@ -60,19 +60,18 @@ public class MapConfig extends AbstractConfig {
     public static MapConfig from(Properties props) {
         return new MapConfig(props);
     }
-    
-    public static MapConfig from(Map<String, String> props) {
+
+    public static MapConfig from(Map<String, Object> props) {
         return new MapConfig(props);
     }
-    
-    private Map<String, String> props = new HashMap<String, String>();
-    
+
+    private Map<String, Object> props = new HashMap<String, Object>();
+
     /**
      * Construct a MapConfig as a copy of the provided Map
-     * @param name
      * @param props
      */
-    public MapConfig(Map<String, String> props) {
+    public MapConfig(Map<String, Object> props) {
         this.props.putAll(props);
         this.props = Collections.unmodifiableMap(this.props);
     }

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/PollingDynamicConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/PollingDynamicConfig.java
@@ -40,7 +40,7 @@ import com.netflix.archaius.config.polling.PollingResponse;
 public class PollingDynamicConfig extends AbstractConfig {
     private static final Logger LOG = LoggerFactory.getLogger(PollingDynamicConfig.class);
     
-    private volatile Map<String, String> current = new HashMap<String, String>();
+    private volatile Map<String, Object> current = new HashMap<String, Object>();
     private final AtomicBoolean busy = new AtomicBoolean();
     private final Callable<PollingResponse> reader;
     private final AtomicLong updateCounter = new AtomicLong();

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/polling/PollingResponse.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/polling/PollingResponse.java
@@ -5,10 +5,10 @@ import java.util.Collections;
 import java.util.Map;
 
 public abstract class PollingResponse {
-    public static PollingResponse forSnapshot(final Map<String, String> values) {
+    public static PollingResponse forSnapshot(final Map<String, Object> values) {
         return new PollingResponse() {
             @Override
-            public Map<String, String> getToAdd() {
+            public Map<String, Object> getToAdd() {
                 return values;
             }
 
@@ -28,7 +28,7 @@ public abstract class PollingResponse {
     public static PollingResponse noop() {
         return new PollingResponse() {
             @Override
-            public Map<String, String> getToAdd() {
+            public Map<String, Object> getToAdd() {
                 return Collections.emptyMap();
             }
 
@@ -44,7 +44,7 @@ public abstract class PollingResponse {
         };
     }
     
-    public abstract Map<String, String> getToAdd();
+    public abstract Map<String, Object> getToAdd();
     public abstract Collection<String> getToRemove();
     public abstract boolean hasData(); 
 }

--- a/archaius2-core/src/main/java/com/netflix/archaius/readers/PropertiesConfigReader.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/readers/PropertiesConfigReader.java
@@ -64,13 +64,13 @@ public class PropertiesConfigReader implements ConfigReader {
             try {
                 // Load properties into the single Properties object overriding any property
                 // that may already exist
-                Map<String, String> p = new URLConfigReader(url).call().getToAdd();
+                Map<String, Object> p = new URLConfigReader(url).call().getToAdd();
                 LOG.debug("Loaded : {}", url.toExternalForm());
                 props.putAll(p);
     
                 // Recursively load any files referenced by an @next property in the file
                 // Only one @next property is expected and the value may be a list of files
-                String next = p.get(INCLUDE_KEY);
+                String next = (String) p.get(INCLUDE_KEY);
                 if (next != null) {
                     p.remove(INCLUDE_KEY);
                     for (String urlString : next.split(",")) {

--- a/archaius2-core/src/main/java/com/netflix/archaius/readers/URLConfigReader.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/readers/URLConfigReader.java
@@ -69,7 +69,7 @@ public class URLConfigReader implements Callable<PollingResponse> {
     
     @Override
     public PollingResponse call() throws IOException {
-        final Map<String, String> map = new HashMap<String, String>();
+        final Map<String, Object> map = new HashMap<String, Object>();
         for (URL url: configUrls) {
             Properties props = new Properties();
             InputStream fin = url.openStream();
@@ -95,7 +95,7 @@ public class URLConfigReader implements Callable<PollingResponse> {
         }
         return new PollingResponse() {
             @Override
-            public Map<String, String> getToAdd() {
+            public Map<String, Object> getToAdd() {
                 return map;
             }
 

--- a/archaius2-core/src/test/java/com/netflix/archaius/config/PollingDynamicConfigTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/PollingDynamicConfigTest.java
@@ -46,7 +46,7 @@ public class PollingDynamicConfigTest {
                 server.getServerPathURI("/prop1").toURL()
                 );
         
-        Map<String, String> result;
+        Map<String, Object> result;
         
         prop1.setProperty("a", "a_value");
         result = reader.call().getToAdd();
@@ -72,7 +72,7 @@ public class PollingDynamicConfigTest {
         prop1.setProperty("a", "A");
         prop2.setProperty("b", "B");
         
-        Map<String, String> result = reader.call().getToAdd();
+        Map<String, Object> result = reader.call().getToAdd();
 
         Assert.assertEquals(2, result.size());
         Assert.assertEquals("A", result.get("a"));

--- a/archaius2-persisted2/src/main/java/com/netflix/archaius/persisted2/JsonPersistedV2Reader.java
+++ b/archaius2-persisted2/src/main/java/com/netflix/archaius/persisted2/JsonPersistedV2Reader.java
@@ -187,7 +187,7 @@ public class JsonPersistedV2Reader implements Callable<PollingResponse> {
         }
         
         // Resolve to a single property value
-        final Map<String, String> result = new HashMap<String, String>();
+        final Map<String, Object> result = new HashMap<String, Object>();
         for (Entry<String, List<ScopedValue>> entry : props.entrySet()) {
             result.put(entry.getKey(), valueResolver.resolve(entry.getKey(), entry.getValue()));
         }

--- a/archaius2-typesafe/build.gradle
+++ b/archaius2-typesafe/build.gradle
@@ -19,6 +19,8 @@ apply plugin: 'java'
 dependencies {
     compile     project(':archaius2-core')
     compile     'com.typesafe:config:1.2.1'
+
+    testCompile project(':archaius2-guice')
 }
 
 eclipse {

--- a/archaius2-typesafe/build.gradle
+++ b/archaius2-typesafe/build.gradle
@@ -18,10 +18,13 @@ apply plugin: 'java'
 
 dependencies {
     compile     project(':archaius2-core')
-    compile     'com.typesafe:config:1.2.1'
+    compile     'com.typesafe:config:1.3.0'
 
     testCompile project(':archaius2-guice')
 }
+
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 eclipse {
     classpath {

--- a/archaius2-typesafe/src/main/java/com/netflix/archaius/typesafe/dynamic/DefaultTypesafeClientConfig.java
+++ b/archaius2-typesafe/src/main/java/com/netflix/archaius/typesafe/dynamic/DefaultTypesafeClientConfig.java
@@ -1,0 +1,79 @@
+package com.netflix.archaius.typesafe.dynamic;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigParseOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.function.Supplier;
+
+public class DefaultTypesafeClientConfig implements TypesafeClientConfig {
+    private final Logger LOG = LoggerFactory.getLogger(DefaultTypesafeClientConfig.class);
+    private final String configFilePath;
+    private final int refreshIntervalMs;
+
+    public DefaultTypesafeClientConfig(Builder builder) {
+        this.configFilePath = builder.configFilePath;
+        this.refreshIntervalMs = builder.refreshIntervalMs;
+    }
+
+    public static class Builder {
+        private String configFilePath;
+        private int refreshIntervalMs;
+
+        public Builder withConfigFilePath(String configFilePath) {
+            this.configFilePath = configFilePath;
+            return this;
+        }
+
+        public Builder withRefreshIntervalMs(int refreshIntervalMs) {
+            this.refreshIntervalMs = refreshIntervalMs;
+            return this;
+        }
+
+        public DefaultTypesafeClientConfig build() {
+            return new DefaultTypesafeClientConfig(this);
+        }
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public int getRefreshRateMs() {
+        return refreshIntervalMs;
+    }
+
+    @Override
+    public String getTypesafeConfigPath() {
+        return configFilePath;
+    }
+
+    @Override
+    public Supplier<Config> getTypesafeConfigSupplier() {
+        return new Supplier<Config>() {
+            @Override
+            public Config get() {
+                String typesafeConfigPath = getTypesafeConfigPath();
+                LOG.info("Loading typesafe config from: {}", typesafeConfigPath);
+                try {
+                    return ConfigFactory.parseURL(new URL(typesafeConfigPath),
+                            ConfigParseOptions.defaults().setAllowMissing(false)).resolve();
+                } catch (MalformedURLException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+    }
+
+    @Override
+    public String toString() {
+        return "DefaultTypesafeClientConfig { configFilePath: " + configFilePath +
+                ", refreshIntervalMs: " + refreshIntervalMs + " }";
+    }
+}

--- a/archaius2-typesafe/src/main/java/com/netflix/archaius/typesafe/dynamic/TypesafeClientConfig.java
+++ b/archaius2-typesafe/src/main/java/com/netflix/archaius/typesafe/dynamic/TypesafeClientConfig.java
@@ -1,0 +1,31 @@
+package com.netflix.archaius.typesafe.dynamic;
+
+import com.typesafe.config.Config;
+
+import java.util.function.Supplier;
+
+/**
+ * Provides information on how to retrieve dynamic typesafe configs.
+ */
+public interface TypesafeClientConfig {
+    /**
+     * @return True if the client is enabled.  This is checked only once at startup.
+     */
+    boolean isEnabled();
+
+    /**
+     * @return Polling rate for getting updates
+     */
+    int getRefreshRateMs();
+
+    String getTypesafeConfigPath();
+
+    /**
+     *
+     * It's up to the user to decide what typesafe Config they want to inject in archaius.
+     * This method returns a Supplier. The Supplier<Config>.get() will be called on every polling iteration in order
+     * to retrieve the latest typesafe config.
+     *
+     */
+    Supplier<Config> getTypesafeConfigSupplier();
+}

--- a/archaius2-typesafe/src/main/java/com/netflix/archaius/typesafe/dynamic/TypesafeConfigLoader.java
+++ b/archaius2-typesafe/src/main/java/com/netflix/archaius/typesafe/dynamic/TypesafeConfigLoader.java
@@ -1,0 +1,56 @@
+package com.netflix.archaius.typesafe.dynamic;
+
+import com.netflix.archaius.config.polling.PollingResponse;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.function.Supplier;
+
+/**
+ * Loads typesafe configs.
+ */
+public class TypesafeConfigLoader implements Callable<PollingResponse> {
+    private final Logger LOG = LoggerFactory.getLogger(TypesafeConfigLoader.class);
+    private Supplier<Config> typesafeConfigSupplier;
+
+    public TypesafeConfigLoader(Supplier<Config> typesafeConfigSupplier) {
+        this.typesafeConfigSupplier = typesafeConfigSupplier;
+    }
+
+    public PollingResponse call() throws Exception {
+        final Map<String, Object> map = new HashMap<>();
+
+        Config typesafeConfig = typesafeConfigSupplier.get();
+
+        for (Map.Entry<String, ConfigValue> entry : typesafeConfig.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue().unwrapped();
+
+            map.put(key, value);
+        }
+
+        return new PollingResponse() {
+            @Override
+            public Map<String, Object> getToAdd() {
+                return map;
+            }
+
+            @Override
+            public Collection<String> getToRemove() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public boolean hasData() {
+                return map.size() > 0;
+            }
+        };
+    }
+}

--- a/archaius2-typesafe/src/main/java/com/netflix/archaius/typesafe/dynamic/TypesafeConfigProvider.java
+++ b/archaius2-typesafe/src/main/java/com/netflix/archaius/typesafe/dynamic/TypesafeConfigProvider.java
@@ -1,0 +1,80 @@
+package com.netflix.archaius.typesafe.dynamic;
+
+import com.netflix.archaius.api.Config;
+import com.netflix.archaius.config.EmptyConfig;
+import com.netflix.archaius.config.PollingDynamicConfig;
+import com.netflix.archaius.config.polling.FixedPollingStrategy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+import javax.inject.Provider;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Provider that sets up a Config which is backed up by a typesafe loader.
+ * Once injected the Config will poll the service for updated on a configurable
+ * interval.  Note that injection of this Config will block until the first
+ * set of properties has been fetched from the typesafe service.
+ *
+ * The provider must be bound to a specific config layer within the override
+ * hierarchy.
+ *
+ * For example, TypesafeClientConfig may bound to the OverrideLayer like this,
+ * <pre>
+ *   final TypesafeClientConfig config = new DefaultTypesafeClientConfig.Builder()
+ *          .withConfigFilePath("http://example.com/typesafe/reference.conf") // or file:///tmp/typesafe/reference.conf
+ *          .withRefreshIntervalMs(60 * 1000)
+ *          .build();
+ *
+ *   Guice.createInjector(
+ *      Modules
+ *          .override(new ArchaiusModule())
+ *          .with(new AbstractModule() {
+ *              @Override
+ *              protected void configureArchaius() {
+ *                  bind(TypesafeClientConfig.class).toInstance(config);
+ *                  bind(Config.class).annotatedWith(OverrideLayer.class).toProvider(TypesafeConfigProvider.class).in(Scopes.SINGLETON);
+ *                  // or bind to RemoteLayer
+ *                  // bind(Config.class).annotatedWith(RemoteLayer.class).toProvider(TypesafeConfigProvider.class).in(Scopes.SINGLETON);
+ *              }
+ *          })
+ *      )
+ * </pre>
+ *
+ */
+public class TypesafeConfigProvider implements Provider<Config> {
+    private final Logger LOG = LoggerFactory.getLogger(TypesafeConfigProvider.class);
+    
+    private volatile PollingDynamicConfig dynamicConfig;
+    private TypesafeClientConfig clientConfig;
+
+    @Inject
+    public TypesafeConfigProvider(TypesafeClientConfig clientConfig) throws Exception {
+        this.clientConfig = clientConfig;
+    }
+    
+    public Config get() {
+        if (!clientConfig.isEnabled()) {
+            LOG.info("Typesafe config is not enabled.");
+            return EmptyConfig.INSTANCE;
+        }
+
+        try {
+            return dynamicConfig = new PollingDynamicConfig(new TypesafeConfigLoader(clientConfig.getTypesafeConfigSupplier()),
+                    new FixedPollingStrategy(clientConfig.getRefreshRateMs(), TimeUnit.MILLISECONDS));
+        } catch (Exception e) {
+            LOG.error("Unable to initialize the dynamic typesafe config", e);
+            throw new RuntimeException(e);
+        }
+    }
+    
+    @PreDestroy
+    public void shutdown() {
+        LOG.info("Shutting down TypesafeConfigProvider: {}.", toString());
+        if (dynamicConfig != null) {
+            dynamicConfig.shutdown();
+        }
+    }
+}

--- a/archaius2-typesafe/src/test/java/com/netflix/archaius/typesafe/dynamic/DynamicTypesafeConfigTest.java
+++ b/archaius2-typesafe/src/test/java/com/netflix/archaius/typesafe/dynamic/DynamicTypesafeConfigTest.java
@@ -42,6 +42,8 @@ public class DynamicTypesafeConfigTest {
         assertEquals(true, appConfig.flag);
         assertEquals(111, appConfig.number.intValue());
         assertEquals(Lists.newArrayList(1, 2), appConfig.list);
+        assertEquals(300, appConfig.size.toBytes());
+        assertEquals(500, appConfig.duration.toMillis());
     }
 
     @Test
@@ -101,6 +103,9 @@ public class DynamicTypesafeConfigTest {
         assertEquals(false, updatedAppConfig.flag);
         assertEquals(222, updatedAppConfig.number.intValue());
         assertEquals(Lists.newArrayList(3, 4), updatedAppConfig.list);
+        // Removed keys in the updated config.
+        assertEquals(null, updatedAppConfig.duration);
+        assertEquals(null, updatedAppConfig.size);
     }
 
     private String getResourceUrl(String resourceName) {

--- a/archaius2-typesafe/src/test/java/com/netflix/archaius/typesafe/dynamic/DynamicTypesafeConfigTest.java
+++ b/archaius2-typesafe/src/test/java/com/netflix/archaius/typesafe/dynamic/DynamicTypesafeConfigTest.java
@@ -1,0 +1,109 @@
+package com.netflix.archaius.typesafe.dynamic;
+
+import com.google.common.collect.Lists;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Scopes;
+import com.netflix.archaius.api.Config;
+import com.netflix.archaius.api.exceptions.ConfigException;
+import com.netflix.archaius.api.inject.RemoteLayer;
+import com.netflix.archaius.guice.ArchaiusModule;
+import com.typesafe.config.ConfigFactory;
+import org.junit.Test;
+
+import java.util.function.Supplier;
+
+import static org.junit.Assert.assertEquals;
+
+public class DynamicTypesafeConfigTest {
+
+    @Test
+    public void test() throws ConfigException {
+        final TypesafeClientConfig config = new DefaultTypesafeClientConfig.Builder()
+                .withConfigFilePath(getResourceUrl("dynamic/reference.conf"))
+                .withRefreshIntervalMs(100)
+                .build();
+
+        Injector injector = Guice.createInjector(
+                new ArchaiusModule() {
+                    @Override
+                    protected void configureArchaius() {
+                        bind(TypesafeClientConfig.class).toInstance(config);
+                        bind(Config.class)
+                                .annotatedWith(RemoteLayer.class)
+                                .toProvider(TypesafeConfigProvider.class)
+                                .in(Scopes.SINGLETON);
+                    }
+                });
+
+        SampleAppConfig appConfig = injector.getInstance(SampleAppConfig.class);
+
+        assertEquals("app name", appConfig.name);
+        assertEquals(true, appConfig.flag);
+        assertEquals(111, appConfig.number.intValue());
+        assertEquals(Lists.newArrayList(1, 2), appConfig.list);
+    }
+
+    @Test
+    public void testDynamicConfigChange() throws ConfigException, InterruptedException {
+        String[] configPath = new String[]{"dynamic/reference.conf"};
+
+        final TypesafeClientConfig config = new TypesafeClientConfig() {
+            @Override
+            public boolean isEnabled() {
+                return true;
+            }
+
+            @Override
+            public int getRefreshRateMs() {
+                return 200;
+            }
+
+            @Override
+            public String getTypesafeConfigPath() {
+                return configPath[0];
+            }
+
+            @Override
+            public Supplier<com.typesafe.config.Config> getTypesafeConfigSupplier() {
+                return () -> {
+                    String typesafeConfigPath = getTypesafeConfigPath();
+                    System.out.println("Load from: " + typesafeConfigPath);
+                    return ConfigFactory.load(typesafeConfigPath);
+                };
+            }
+        };
+
+        Injector injector = Guice.createInjector(
+                new ArchaiusModule() {
+                    @Override
+                    protected void configureArchaius() {
+                        bind(TypesafeClientConfig.class).toInstance(config);
+                        bind(Config.class)
+                                .annotatedWith(RemoteLayer.class)
+                                .toProvider(TypesafeConfigProvider.class)
+                                .in(Scopes.SINGLETON);
+                    }
+                });
+
+        SampleAppConfig appConfig = injector.getInstance(SampleAppConfig.class);
+        assertEquals("app name", appConfig.name);
+        assertEquals(true, appConfig.flag);
+        assertEquals(111, appConfig.number.intValue());
+        assertEquals(Lists.newArrayList(1, 2), appConfig.list);
+
+        // Simulate configuration update at runtime.
+        configPath[0] = "dynamic/updated.conf";
+        Thread.sleep(400);
+
+        SampleAppConfig updatedAppConfig = injector.getInstance(SampleAppConfig.class);
+        assertEquals("updated app name", updatedAppConfig.name);
+        assertEquals(false, updatedAppConfig.flag);
+        assertEquals(222, updatedAppConfig.number.intValue());
+        assertEquals(Lists.newArrayList(3, 4), updatedAppConfig.list);
+    }
+
+    private String getResourceUrl(String resourceName) {
+        return "file://" + getClass().getClassLoader().getResource(resourceName).getPath();
+    }
+}

--- a/archaius2-typesafe/src/test/java/com/netflix/archaius/typesafe/dynamic/SampleAppConfig.java
+++ b/archaius2-typesafe/src/test/java/com/netflix/archaius/typesafe/dynamic/SampleAppConfig.java
@@ -1,0 +1,15 @@
+package com.netflix.archaius.typesafe.dynamic;
+
+import com.netflix.archaius.api.annotations.Configuration;
+
+import java.util.List;
+
+@Configuration(prefix = "app", allowFields = true)
+public class SampleAppConfig {
+
+    public String name;
+    public Boolean flag;
+    public Integer number;
+
+    public List<Integer> list;
+}

--- a/archaius2-typesafe/src/test/java/com/netflix/archaius/typesafe/dynamic/SampleAppConfig.java
+++ b/archaius2-typesafe/src/test/java/com/netflix/archaius/typesafe/dynamic/SampleAppConfig.java
@@ -1,7 +1,9 @@
 package com.netflix.archaius.typesafe.dynamic;
 
 import com.netflix.archaius.api.annotations.Configuration;
+import com.typesafe.config.ConfigMemorySize;
 
+import java.time.Duration;
 import java.util.List;
 
 @Configuration(prefix = "app", allowFields = true)
@@ -10,6 +12,7 @@ public class SampleAppConfig {
     public String name;
     public Boolean flag;
     public Integer number;
-
     public List<Integer> list;
+    public Duration duration;
+    public ConfigMemorySize size;
 }

--- a/archaius2-typesafe/src/test/resources/dynamic/reference.conf
+++ b/archaius2-typesafe/src/test/resources/dynamic/reference.conf
@@ -1,0 +1,7 @@
+app {
+    name: "app name"
+    flag: true
+    number: 111
+
+    list: [1,2]
+}

--- a/archaius2-typesafe/src/test/resources/dynamic/reference.conf
+++ b/archaius2-typesafe/src/test/resources/dynamic/reference.conf
@@ -4,4 +4,6 @@ app {
     number: 111
 
     list: [1,2]
+    duration: 500ms
+    size: 300bytes
 }

--- a/archaius2-typesafe/src/test/resources/dynamic/updated.conf
+++ b/archaius2-typesafe/src/test/resources/dynamic/updated.conf
@@ -1,0 +1,6 @@
+app {
+    name: "updated app name"
+    flag: false
+    number: 222
+    list: [3,4]
+}


### PR DESCRIPTION
Please review https://github.com/Netflix/archaius/pull/407 first. This adds on top of that.

This fixes issue https://github.com/Netflix/archaius/issues/403 with the added benefit that we're now able to poll for updated typesafe configs.

Note: Upgraded to the latest typesafe library (v1.3.0), which depends on JDK8. Added java 8 source compatibility only for the `archaius2-typesafe` module.
