### PR TITLE
1.x allow more than 1 dynamodb table as configuration source

### DIFF
--- a/archaius-aws/src/main/java/com/netflix/config/sources/DynamoDbConfigurationSource.java
+++ b/archaius-aws/src/main/java/com/netflix/config/sources/DynamoDbConfigurationSource.java
@@ -71,19 +71,21 @@ public class DynamoDbConfigurationSource extends AbstractDynamoDbConfigurationSo
     }
 
     @Override
-    protected synchronized Map<String, Object> loadPropertiesFromTable(String table) {
+    protected synchronized Map<String, Object> loadPropertiesFromTable(String tables) {
         Map<String, Object> propertyMap = new HashMap<String, Object>();
-        Map<String, AttributeValue> lastKeysEvaluated = null;
-        do {
-            ScanRequest scanRequest = new ScanRequest()
-                    .withTableName(table)
-                    .withExclusiveStartKey(lastKeysEvaluated);
-            ScanResult result = dbScanWithThroughputBackOff(scanRequest);
-            for (Map<String, AttributeValue> item : result.getItems()) {
-                propertyMap.put(item.get(keyAttributeName.get()).getS(), item.get(valueAttributeName.get()).getS());
-            }
-            lastKeysEvaluated = result.getLastEvaluatedKey();
-        } while (lastKeysEvaluated != null);
+        for (String table : tables.split(",")) {
+            Map<String, AttributeValue> lastKeysEvaluated = null;
+            do {
+                ScanRequest scanRequest = new ScanRequest()
+                        .withTableName(table)
+                        .withExclusiveStartKey(lastKeysEvaluated);
+                ScanResult result = dbScanWithThroughputBackOff(scanRequest);
+                for (Map<String, AttributeValue> item : result.getItems()) {
+                    propertyMap.put(item.get(keyAttributeName.get()).getS(), item.get(valueAttributeName.get()).getS());
+                }
+                lastKeysEvaluated = result.getLastEvaluatedKey();
+            } while (lastKeysEvaluated != null);
+        }
         return propertyMap;
     }
 


### PR DESCRIPTION
Using them same property com.netflix.config.dynamo.tableName with delimiter ,
eg: com.netflix.config.dynamo.tableName=CommingProperties,MyAppProperties

Use case: allow multiple modules to share configuration while separating private properties.