### PR TITLE
Amazon sdk version bumped to 1.11.15

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,9 +53,9 @@ project(':archaius-core') {
 project(':archaius-aws') {
     dependencies {
         compile project(':archaius-core')
-        compile 'com.amazonaws:aws-java-sdk-core:1.9.3'
-        compile 'com.amazonaws:aws-java-sdk-dynamodb:1.9.3'
-        compile 'com.amazonaws:aws-java-sdk-s3:1.9.3'
+        compile 'com.amazonaws:aws-java-sdk-core:1.11.15'
+        compile 'com.amazonaws:aws-java-sdk-dynamodb:1.11.15'
+        compile 'com.amazonaws:aws-java-sdk-s3:1.11.15'
         testCompile 'junit:junit:4.11'
         testCompile 'org.mockito:mockito-all:1.9.5'
         testCompile 'org.slf4j:slf4j-simple:1.6.4'


### PR DESCRIPTION
Module archaius-aws uses obsolete amazon sdk version. This pull request bumps it to latest-greatest.