### PR TITLE
fix: prevent possible NPE

### DIFF
--- a/archaius-etcd/src/main/java/com/netflix/config/source/EtcdConfigurationSource.java
+++ b/archaius-etcd/src/main/java/com/netflix/config/source/EtcdConfigurationSource.java
@@ -68,6 +68,10 @@ public class EtcdConfigurationSource implements WatchedConfigurationSource {
     }
 
     private void cacheValues(Node configNode) {
+        if(configNode == null || configNode.getNodes() == null) {
+            return;
+        }
+
         for (Node valueNode : configNode.getNodes()) {
             final String etcdKey = valueNode.key();
             final String sourceKey = Iterables.getLast(keySplitter.split(etcdKey));


### PR DESCRIPTION
when etcd instance is empty (i.e. no keys configured) configNode.getNodes() returns null. This avoids throwing NPE, while preserving a consistent behavior
