### PR TITLE
Support configuration interface default method

### DIFF
--- a/archaius2-core/src/main/java/com/netflix/archaius/ConfigProxyFactory.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/ConfigProxyFactory.java
@@ -10,7 +10,6 @@ import com.netflix.archaius.api.annotations.PropertyName;
 
 import org.apache.commons.lang3.text.StrSubstitutor;
 
-import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationHandler;
@@ -184,6 +183,10 @@ public class ConfigProxyFactory {
                 
                 Object defaultValue = null;
                 if (m.getAnnotation(DefaultValue.class) != null) {
+                    if (m.isDefault()) {
+                        throw new IllegalArgumentException("@DefaultValue cannot be defined on a method with a default implementation for method "
+                                + m.getDeclaringClass().getName() + "#" + m.getName());
+                    }
                     String value = m.getAnnotation(DefaultValue.class).value();
                     if (m.getReturnType() == String.class) {
                         defaultValue = config.getString("*", value);
@@ -216,6 +219,7 @@ public class ConfigProxyFactory {
             }
         }
         
+        // Hack so that default interface methods may be called from a proxy
         final MethodHandles.Lookup temp;
         try {
             Constructor<MethodHandles.Lookup> constructor = MethodHandles.Lookup.class

--- a/archaius2-core/src/main/java/com/netflix/archaius/ConfigProxyFactory.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/ConfigProxyFactory.java
@@ -43,6 +43,25 @@ import javax.inject.Inject;
  * }
  * </pre>
  * 
+ * Default values may be set by adding a {@literal @}DefaultValue with a default value string.  Note
+ * that the default value type is a string to allow for interpolation.  Alternatively, methods can  
+ * provide a default method implementation.  Note that {@literal @}DefaultValue cannot be added to a default
+ * method as it would introduce ambiguity as to which mechanism wins.
+ * 
+ * For example,
+ * <pre>
+ * {@code
+ * {@literal @}Configuration(prefix="foo")
+ * interface FooConfiguration {
+ *    @DefaultValue("1000")
+ *    int getReadTimeout();     // maps to "foo.timeout"
+ *    
+ *    default int getWriteTimeout() {
+ *        return 1000;
+ *    }
+ * }
+ * }
+ * 
  * To create a proxy instance,
  * <pre>
  * {@code 

--- a/archaius2-guice/src/test/java/com/netflix/archaius/guice/ProxyTest.java
+++ b/archaius2-guice/src/test/java/com/netflix/archaius/guice/ProxyTest.java
@@ -9,6 +9,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.Provides;
+import com.google.inject.ProvisionException;
 import com.netflix.archaius.ConfigProxyFactory;
 import com.netflix.archaius.api.annotations.Configuration;
 import com.netflix.archaius.api.annotations.DefaultValue;
@@ -99,5 +100,38 @@ public class ProxyTest {
         Assert.assertEquals("bar", config.getString());
         Assert.assertEquals(1, config.getInteger());
         
+    }
+    
+    public static interface DefaultMethodWithAnnotation {
+        @DefaultValue("fromAnnotation")
+        default String getValue() {
+            return "fromDefault";
+        }
+    }
+    
+    @Test
+    public void annotationAndDefaultImplementationNotAllowed() throws ConfigException {
+        try {
+            Injector injector = Guice.createInjector(
+                new ArchaiusModule() {
+                    @Override
+                    protected void configureArchaius() {
+                    }
+                    
+                    @Provides
+                    @Singleton
+                    public DefaultMethodWithAnnotation getMyConfig(ConfigProxyFactory factory) {
+                        return factory.newProxy(DefaultMethodWithAnnotation.class);
+                    }
+                });
+            
+            injector.getInstance(DefaultMethodWithAnnotation.class);
+            Assert.fail("Exepcted ProvisionException");
+        } catch (ProvisionException e) {
+            e.printStackTrace();
+            Assert.assertEquals(IllegalArgumentException.class, e.getCause().getCause().getClass());
+        } catch (Exception e) {
+            Assert.fail("Expected ProvisionException");
+        }
     }
 }

--- a/archaius2-guice/src/test/java/com/netflix/archaius/guice/ProxyTest.java
+++ b/archaius2-guice/src/test/java/com/netflix/archaius/guice/ProxyTest.java
@@ -25,6 +25,10 @@ public class ProxyTest {
         String getString();
         
         MySubConfig getSubConfig();
+        
+        default String getDefault() {
+            return getInteger() + "-" + getString();
+        }
     }
     
     public static interface MySubConfig {
@@ -66,7 +70,7 @@ public class ProxyTest {
         Assert.assertEquals("bar", config.getString());
         Assert.assertEquals(1, config.getInteger());
         Assert.assertEquals(2, config.getSubConfig().getInteger());
-        
+        Assert.assertEquals("1-bar", config.getDefault());
         cfg.setProperty("subConfig.integer", 3);
         
         Assert.assertEquals(3, config.getSubConfig().getInteger());


### PR DESCRIPTION
Support invoking the an interface method's default implementation when no configuration value is found.

For example,

```java
interface MyConfig {
   default int getTimeout() { 
       return 1000;
   }
}
```
Note that a method may only have a default implementation or a @DefaultValue annotation but not both. An IllegalArgumentException will be thrown if both are present.
