### PR TITLE
Property performance improvement

### DIFF
--- a/archaius2-api/src/main/java/com/netflix/archaius/api/PropertyFactory.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/api/PropertyFactory.java
@@ -20,7 +20,6 @@ package com.netflix.archaius.api;
  * Factory of PropertyContainer objects.
  * 
  * @see PropertyContainer
- * @author elandau
  */
 public interface PropertyFactory {
     /**

--- a/archaius2-core/src/main/java/com/netflix/archaius/property/DefaultPropertyContainer.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/property/DefaultPropertyContainer.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Iterator;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -42,14 +43,11 @@ import java.util.function.Function;
  * 
  * Once created a PropertyContainer property cannot be removed.  However, listeners may be
  * added and removed. 
- * 
- * @author elandau
- *
  */
 public class DefaultPropertyContainer implements PropertyContainer {
     private final Logger LOG = LoggerFactory.getLogger(DefaultPropertyContainer.class);
     
-    enum Type {
+    enum CacheType {
         INTEGER     (int.class,     Integer.class),
         BYTE        (byte.class,    Byte.class),
         SHORT       (short.class,   Short.class),
@@ -64,12 +62,12 @@ public class DefaultPropertyContainer implements PropertyContainer {
         
         private final Class<?>[] types;
         
-        Type(Class<?> ... type) {
+        CacheType(Class<?> ... type) {
             types = type;
         }
         
-        static Type fromClass(Class<?> clazz) {
-            for (Type type : values()) {
+        static CacheType fromClass(Class<?> clazz) {
+            for (CacheType type : values()) {
                 for (Class<?> cls : type.types) {
                     if (cls.equals(clazz)) {
                         return type;
@@ -116,15 +114,61 @@ public class DefaultPropertyContainer implements PropertyContainer {
         this.masterVersion = version;
     }
 
-    abstract class CachedProperty<T> implements Property<T> {
+    class PropertyWithDefault<T> implements Property<T> {
+        private CachedProperty<T> delegate;
+        private T defaultValue;
+
+        public PropertyWithDefault(CachedProperty<T> delegate, T defaultValue) {
+            this.defaultValue = defaultValue;
+            this.delegate = delegate;
+        }
+        
+        @Override
+        public T get() {
+            T value = delegate.get();
+            return value != null ? value : defaultValue;
+        }
+
+        @Override
+        public void addListener(PropertyListener<T> listener) {
+            listeners.add(listener, new ListenerUpdater() {
+                private AtomicReference<T> last = new AtomicReference<T>(null);
+                
+                @Override
+                public void update() {
+                    final T prev = last.get();
+                    final T value;
+                    
+                    try {
+                        value = get();
+                    } catch (Exception e) {
+                        listener.onParseError(e);
+                        return;
+                    }
+
+                    if (prev != value && last.compareAndSet(prev, value)) {
+                        listener.onChange(value != null ? value : defaultValue);
+                    }
+                }
+            });
+        }
+
+        @Override
+        public void removeListener(PropertyListener<T> listener) {
+            listeners.remove(listener);
+        }
+
+        @Override
+        public String getKey() {
+            return delegate.getKey();
+        }
+    }
+    
+    abstract class CachedProperty<T> {
 
         @Override
         public int hashCode() {
-            final int prime = 31;
-            int result = 1;
-            result = prime * result + ((defaultValue == null) ? 0 : defaultValue.hashCode());
-            result = prime * result + type;
-            return result;
+            return type;
         }
 
         @Override
@@ -136,64 +180,24 @@ public class DefaultPropertyContainer implements PropertyContainer {
             if (getClass() != obj.getClass())
                 return false;
             CachedProperty other = (CachedProperty) obj;
-            if (defaultValue == null) {
-                if (other.defaultValue != null)
-                    return false;
-            } else if (!defaultValue.equals(other.defaultValue))
-                return false;
-            if (type != other.type)
-                return false;
-            return true;
+            return type != other.type;
         }
         private final AtomicStampedReference<T> cache = new AtomicStampedReference<>(null, -1);
         private final int type;
-        private final T defaultValue;
         
-        CachedProperty(Type type, T defaultValue) {
-            this.type = type.ordinal();
-            this.defaultValue = defaultValue;
+        CachedProperty(int type) {
+            this.type = type;
         }
         
-        public void addListener(final PropertyListener<T> listener) {
-            listeners.add(listener, new ListenerUpdater() {
-                private AtomicReference<T> last = new AtomicReference<T>(null);
-                
-                @Override
-                public void update() {
-                    final T prev = last.get();
-                    final T value;
-                    
-                    try {
-                        value = get();
-                    }
-                    catch (Exception e) {
-                        listener.onParseError(e);
-                        return;
-                    }
-
-                    if (prev != value) {
-                        if (last.compareAndSet(prev, value)) {
-                            listener.onChange(value);
-                        }
-                    }
-                }
-            });
-        }
-        
-        @Override
         public String getKey() {
             return DefaultPropertyContainer.this.key;
         }
 
-        public void removeListener(PropertyListener<T> listener) {
-            listeners.remove(listener);
-        }
-        
         /**
          * Fetch the latest version of the property.  If not up to date then resolve to the latest
          * value, inline.
          * 
-         * TODO: Make resolving property value an offline task
+         * TODO: Make resolving property value an background task
          * 
          * @return
          */
@@ -213,29 +217,22 @@ public class DefaultPropertyContainer implements PropertyContainer {
                 if (cache.compareAndSet(currentValue, newValue, cacheVersion, latestVersion)) {
                     // Slight race condition here but not important enough to warrent locking
                     lastUpdateTimeInMillis = System.currentTimeMillis();
-                    return firstNonNull(newValue, defaultValue);
+                    return newValue;
                 }
             }
-            return firstNonNull(cache.getReference(), defaultValue);
+            return cache.getReference();
         }
         
         public long getLastUpdateTime(TimeUnit units) {
             return units.convert(lastUpdateTimeInMillis, TimeUnit.MILLISECONDS);
         }
 
-        private T firstNonNull(T first, T second) {
-            return first == null ? second : first;
-        }
         /**
          * Resolve to the most recent value
          * @return
          * @throws Exception
          */
         protected abstract T resolveCurrent() throws Exception;
-
-        private DefaultPropertyContainer getOuterType() {
-            return DefaultPropertyContainer.this;
-        }
     }
 
     /**
@@ -245,118 +242,153 @@ public class DefaultPropertyContainer implements PropertyContainer {
      * @return
      */
     @SuppressWarnings("unchecked")
-    private <T> CachedProperty<T> add(final CachedProperty<T> newProperty) {
-        // TODO(nikos): This while() looks like it's redundant
-        // since we are only calling add() after a get().
-        while (!cache.add(newProperty)) {
-            for (CachedProperty<?> property : cache) {
-                if (property.equals(newProperty)) {
-                    return (CachedProperty<T>) property;
+    private <T> Property<T> add(final int type, final Function<Integer, CachedProperty<T>> creator, final T defaultValue) {
+        do {
+            Iterator<CachedProperty<?>> iter = cache.iterator();
+            while (iter.hasNext()) {
+                CachedProperty<?> element = iter.next();
+                if (element.type == type) {
+                    return new PropertyWithDefault<T>((CachedProperty<T>)element, defaultValue);
                 }
             }
-        }
-        
-        return newProperty;
+            
+            // TODO(nikos): This while() looks like it's redundant
+            // since we are only calling add() after a get().
+            CachedProperty<T> cachedProperty = creator.apply(type);
+            if (cache.addIfAbsent(cachedProperty)) {
+                return new PropertyWithDefault<T>(cachedProperty, defaultValue);
+            }
+        } while (true);
     }
     
     @Override
     public Property<String> asString(final String defaultValue) {
-        return add(new CachedProperty<String>(Type.STRING, defaultValue) {
-            @Override
-            protected String resolveCurrent() throws Exception {
-                return config.getString(key, null);
-            }
-        });
+        return add(
+            CacheType.STRING.ordinal(), 
+            type -> new CachedProperty<String>(type) {
+                @Override
+                protected String resolveCurrent() throws Exception {
+                    return config.getString(key, null);
+                }
+            }, 
+            defaultValue);
     }
 
     @Override
     public Property<Integer> asInteger(final Integer defaultValue) {
-        return add(new CachedProperty<Integer>(Type.INTEGER, defaultValue) {
-            @Override
-            protected Integer resolveCurrent() throws Exception {
-                return config.getInteger(key, null);
-            }
-        });
-    }
+        return add(
+            CacheType.INTEGER.ordinal(), 
+            type -> new CachedProperty<Integer>(type) {
+                @Override
+                protected Integer resolveCurrent() throws Exception {
+                    return config.getInteger(key, null);
+                }
+            }, 
+            defaultValue);
+        }
 
     @Override
     public Property<Long> asLong(final Long defaultValue) {
-        return add(new CachedProperty<Long>(Type.LONG, defaultValue) {
-            @Override
-            protected Long resolveCurrent() throws Exception {
-                return config.getLong(key, null);
-            }
-        });
+        return add(
+            CacheType.LONG.ordinal(), 
+            type -> new CachedProperty<Long>(type) {
+                @Override
+                protected Long resolveCurrent() throws Exception {
+                    return config.getLong(key, null);
+                }
+            },
+            defaultValue);
     }
 
     @Override
     public Property<Double> asDouble(final Double defaultValue) {
-        return add(new CachedProperty<Double>(Type.DOUBLE, defaultValue) {
-            @Override
-            protected Double resolveCurrent() throws Exception {
-                return config.getDouble(key, null);
-            }
-        });
+        return add(
+            CacheType.DOUBLE.ordinal(), 
+            type -> new CachedProperty<Double>(type) {
+                @Override
+                protected Double resolveCurrent() throws Exception {
+                    return config.getDouble(key, null);
+                }
+            },
+            defaultValue);
     }
 
     @Override
     public Property<Float> asFloat(final Float defaultValue) {
-        return add(new CachedProperty<Float>(Type.FLOAT, defaultValue) {
-            @Override
-            protected Float resolveCurrent() throws Exception {
-                return config.getFloat(key, null);
-            }
-        });
+        return add(
+            CacheType.FLOAT.ordinal(), 
+            type -> new CachedProperty<Float>(type) {
+                @Override
+                protected Float resolveCurrent() throws Exception {
+                    return config.getFloat(key, null);
+                }
+            },
+            defaultValue);
     }
 
     @Override
     public Property<Short> asShort(final Short defaultValue) {
-        return add(new CachedProperty<Short>(Type.SHORT, defaultValue) {
-            @Override
-            protected Short resolveCurrent() throws Exception {
-                return config.getShort(key, null);
-            }
-        });
+        return add(
+            CacheType.SHORT.ordinal(), 
+            type -> new CachedProperty<Short>(type) {
+                @Override
+                protected Short resolveCurrent() throws Exception {
+                    return config.getShort(key, null);
+                }
+            },
+            defaultValue);
     }
 
     @Override
     public Property<Byte> asByte(final Byte defaultValue) {
-        return add(new CachedProperty<Byte>(Type.BYTE, defaultValue) {
-            @Override
-            protected Byte resolveCurrent() throws Exception {
-                return config.getByte(key, defaultValue);
-            }
-        });
+        return add(
+            CacheType.BYTE.ordinal(), 
+            type -> new CachedProperty<Byte>(type) {
+                @Override
+                protected Byte resolveCurrent() throws Exception {
+                    return config.getByte(key, null);
+                }
+            },
+            defaultValue);
     }
 
     @Override
     public Property<BigDecimal> asBigDecimal(final BigDecimal defaultValue) {
-        return add(new CachedProperty<BigDecimal>(Type.BIG_DECIMAL, defaultValue) {
-            @Override
-            protected BigDecimal resolveCurrent() throws Exception {
-                return config.getBigDecimal(key, defaultValue);
-            }
-        });
+        return add(
+            CacheType.BIG_DECIMAL.ordinal(), 
+            type -> new CachedProperty<BigDecimal>(type) {
+                @Override
+                protected BigDecimal resolveCurrent() throws Exception {
+                    return config.getBigDecimal(key, null);
+                }
+            },
+            defaultValue);
     }
     
     @Override
     public Property<Boolean> asBoolean(final Boolean defaultValue) {
-        return add(new CachedProperty<Boolean>(Type.BOOLEAN, defaultValue) {
-            @Override
-            protected Boolean resolveCurrent() throws Exception {
-                return config.getBoolean(key, defaultValue);
-            }
-        });
+        return add(
+            CacheType.BOOLEAN.ordinal(), 
+            type -> new CachedProperty<Boolean>(type) {
+                @Override
+                protected Boolean resolveCurrent() throws Exception {
+                    return config.getBoolean(key, null);
+                }
+            },
+            defaultValue);
     }
 
     @Override
     public Property<BigInteger> asBigInteger(final BigInteger defaultValue) {
-        return add(new CachedProperty<BigInteger>(Type.BIG_INTEGER, defaultValue) {
-            @Override
-            protected BigInteger resolveCurrent() throws Exception {
-                return config.getBigInteger(key, defaultValue);
-            }
-        });
+        return add(
+            CacheType.BIG_INTEGER.ordinal(),
+            type -> new CachedProperty<BigInteger>(type) {
+                @Override
+                protected BigInteger resolveCurrent() throws Exception {
+                    return config.getBigInteger(key, null);
+                }
+            },
+            defaultValue);
     }
     
     /**
@@ -365,7 +397,7 @@ public class DefaultPropertyContainer implements PropertyContainer {
     @SuppressWarnings("unchecked")
     @Override
     public <T> Property<T> asType(final Class<T> type, final T defaultValue) {
-        switch (Type.fromClass(type)) {
+        switch (CacheType.fromClass(type)) {
         case INTEGER:
             return (Property<T>) asInteger((Integer)defaultValue);
         case BYTE:
@@ -386,25 +418,29 @@ public class DefaultPropertyContainer implements PropertyContainer {
             return (Property<T>) asBigDecimal((BigDecimal)defaultValue);
         case BIG_INTEGER:
             return (Property<T>) asBigInteger((BigInteger)defaultValue);
-        default: {
-                CachedProperty<T> prop = add(new CachedProperty<T>(Type.CUSTOM, defaultValue) {
+        default:
+            return add(
+                CacheType.CUSTOM.ordinal(),
+                t -> new CachedProperty<T>(t) {
                     @Override
                     protected T resolveCurrent() throws Exception {
-                        return config.get(type, key, defaultValue);
+                        return config.get(type, key, null);
                     }
-                });
-                return prop;
-            }
+                },
+                defaultValue);
         }
     }
 
     @Override
     public <T> Property<T> asType(Function<String, T> type, String defaultValue) {
-        return add(new CachedProperty<T>(Type.CUSTOM, null) {
-            @Override
-            protected T resolveCurrent() throws Exception {
-                return type.apply(config.getString(key, defaultValue));
-            }
-        });
+        return add(
+            CacheType.CUSTOM.ordinal(),
+            t -> new CachedProperty<T>(t) {
+                @Override
+                protected T resolveCurrent() throws Exception {
+                    return type.apply(config.getString(key, defaultValue));
+                }
+            },
+            type.apply(defaultValue));
     }
 }

--- a/archaius2-core/src/main/java/com/netflix/archaius/property/ListenerManager.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/property/ListenerManager.java
@@ -11,8 +11,6 @@ import com.netflix.archaius.api.PropertyListener;
  * an optimization so it is not necessary to iterate through all property
  * containers when the listeners need to be invoked since the expectation
  * is to have far less listeners than property containers.
- * 
- * @author elandau
  */
 public class ListenerManager {
     public static interface ListenerUpdater {

--- a/archaius2-core/src/test/java/com/netflix/archaius/property/PropertyTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/property/PropertyTest.java
@@ -15,13 +15,6 @@
  */
 package com.netflix.archaius.property;
 
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import org.junit.Assert;
-import org.junit.Test;
-
 import com.netflix.archaius.DefaultPropertyFactory;
 import com.netflix.archaius.api.Property;
 import com.netflix.archaius.api.PropertyFactory;
@@ -29,6 +22,13 @@ import com.netflix.archaius.api.PropertyListener;
 import com.netflix.archaius.api.config.SettableConfig;
 import com.netflix.archaius.api.exceptions.ConfigException;
 import com.netflix.archaius.config.DefaultSettableConfig;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class PropertyTest {
     static class MyService {
@@ -208,5 +208,14 @@ public class PropertyTest {
         Assert.assertEquals(123, current.intValue());
         config.setProperty("foo", "${goo}");
         Assert.assertEquals(456, current.intValue());
+    }
+    
+    @Test
+    public void testDifferentDefaults() {
+        SettableConfig config = new DefaultSettableConfig();
+
+        DefaultPropertyFactory factory = DefaultPropertyFactory.from(config);
+        Assert.assertFalse(factory.getProperty("foo").asBoolean(false).get());
+        Assert.assertTrue(factory.getProperty("foo").asBoolean(true).get());
     }
 }


### PR DESCRIPTION
Fix performance issue with DefaultPropertyContainer where not caching the Property in user code would result in excessive operations on the CopyOnWriteArrayList backing the property cache.  The fix also address the problem of having multiple Property objects for the same types but each with a different default value.  Each Property can now have a different default value.