### PR TITLE
StaticArchaiusBridgeModule debug error

### DIFF
--- a/archaius2-archaius1-bridge/build.gradle
+++ b/archaius2-archaius1-bridge/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     compile  project(':archaius2-core')
     compile  project(':archaius2-guice')
     compile  project(':archaius2-commons-configuration')
-    compile  'com.netflix.archaius:archaius-core:0.7.3'
+    compile  'com.netflix.archaius:archaius-core:0.7.5'
 }
 
 eclipse {

--- a/archaius2-archaius1-bridge/src/main/java/com/netflix/archaius/bridge/StaticAbstractConfiguration.java
+++ b/archaius2-archaius1-bridge/src/main/java/com/netflix/archaius/bridge/StaticAbstractConfiguration.java
@@ -43,13 +43,12 @@ public class StaticAbstractConfiguration extends AbstractConfiguration implement
         if (staticConfig == null) {
             UnsupportedOperationException cause = new UnsupportedOperationException("**** Remove static reference to ConfigurationManager or FastProperty in this call stack ****");
             cause.setStackTrace(ConfigurationManager.getStaticInitializationSource());
-            throw new RuntimeException("Trying to use bridge but hasn't been configured yet!!!." +
-                "  Please do not call ConfigurationManager.getConfigInstance()", cause);
+            throw new IllegalStateException("Archaius2 bridge not usable because ConfigurationManager was initialized too early.  See stack trace below.", cause);
         }
         
         AbstractConfiguration actualConfig = ConfigurationManager.getConfigInstance();
         if (!actualConfig.equals(staticConfig)) {
-            throw new RuntimeException("Not using expected bridge!!! " + actualConfig.getClass() + " instead of " + staticConfig.getClass());
+            throw new IllegalStateException("Not using expected bridge!!! " + actualConfig.getClass() + " instead of " + staticConfig.getClass());
         }
         
         DynamicPropertyFactory.initWithConfigurationSource((AbstractConfiguration)staticConfig);

--- a/archaius2-archaius1-bridge/src/main/java/com/netflix/archaius/bridge/StaticAbstractConfiguration.java
+++ b/archaius2-archaius1-bridge/src/main/java/com/netflix/archaius/bridge/StaticAbstractConfiguration.java
@@ -1,5 +1,14 @@
 package com.netflix.archaius.bridge;
 
+import com.netflix.config.AggregatedConfiguration;
+import com.netflix.config.ConfigurationManager;
+import com.netflix.config.DynamicPropertyFactory;
+import com.netflix.config.DynamicPropertySupport;
+import com.netflix.config.PropertyListener;
+
+import org.apache.commons.configuration.AbstractConfiguration;
+import org.apache.commons.configuration.Configuration;
+
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -7,15 +16,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-
-import org.apache.commons.configuration.AbstractConfiguration;
-import org.apache.commons.configuration.Configuration;
-
-import com.netflix.config.AggregatedConfiguration;
-import com.netflix.config.ConfigurationManager;
-import com.netflix.config.DynamicPropertyFactory;
-import com.netflix.config.DynamicPropertySupport;
-import com.netflix.config.PropertyListener;
 
 /**
  * @see StaticArchaiusBridgeModule
@@ -41,7 +41,10 @@ public class StaticAbstractConfiguration extends AbstractConfiguration implement
         
         // Additional check to make sure archaius actually created the bridge.
         if (staticConfig == null) {
-            throw new RuntimeException("Trying to use bridge but hasn't been configured yet!!!");
+            UnsupportedOperationException cause = new UnsupportedOperationException("**** Remove static reference to ConfigurationManager or FastProperty in this call stack ****");
+            cause.setStackTrace(ConfigurationManager.getStaticInitializationSource());
+            throw new RuntimeException("Trying to use bridge but hasn't been configured yet!!!." +
+                "  Please do not call ConfigurationManager.getConfigInstance()", cause);
         }
         
         AbstractConfiguration actualConfig = ConfigurationManager.getConfigInstance();

--- a/archaius2-archaius1-bridge/src/test/java/com/netflix/archaius/bridge/AbstractConfigurationBridgeFailureTest.java
+++ b/archaius2-archaius1-bridge/src/test/java/com/netflix/archaius/bridge/AbstractConfigurationBridgeFailureTest.java
@@ -1,0 +1,54 @@
+package com.netflix.archaius.bridge;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.netflix.archaius.guice.ArchaiusModule;
+import com.netflix.config.ConfigurationManager;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+public class AbstractConfigurationBridgeFailureTest {
+    public static class TestModule extends AbstractModule {
+        @Override
+        protected void configure() {
+            install(new StaticArchaiusBridgeModule());
+            install(new ArchaiusModule());
+        }
+    }
+    
+    public static class BadModule extends AbstractModule {
+        public static String value = ConfigurationManager.getConfigInstance().getString("foo", "default");
+        
+        @Override
+        protected void configure() {
+        }
+    }
+    
+    @Before
+    public void before() throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
+        StaticAbstractConfiguration.reset();
+        StaticDeploymentContext.reset();
+    }
+    
+    @Test
+    public void testStaticInModule() {
+        try {
+            Guice.createInjector(
+                new TestModule(),
+                new BadModule());
+            Assert.fail();
+        } catch (Exception e) { 
+            StringWriter sw = new StringWriter();
+            e.printStackTrace(new PrintWriter(sw));
+            String stack = sw.toString();
+            
+            Assert.assertTrue(stack.contains("com.netflix.archaius.bridge.AbstractConfigurationBridgeFailureTest$BadModule"));
+            Assert.assertTrue(stack.contains("**** Remove static reference"));
+        }
+    }
+}


### PR DESCRIPTION
Provide detailed source of how ConfigurationManager was initialized when there was a failure initializing StaticArchaiusBridgeModule.

Stack trace would contain a root cause like this,

```java
Caused by: java.lang.UnsupportedOperationException: **** Remove static reference to ConfigurationManager or FastProperty in this call stack ****
	at java.lang.Thread.getStackTrace(Thread.java:1552)
	at com.netflix.config.ConfigurationManager.<clinit>(ConfigurationManager.java:91)
	at com.netflix.archaius.bridge.AbstractConfigurationBridgeFailureTest$BadModule.<clinit>(AbstractConfigurationBridgeFailureTest.java:25)
	at com.netflix.archaius.bridge.AbstractConfigurationBridgeFailureTest.testStaticInModule(AbstractConfigurationBridgeFailureTest.java:43)
	... 24 more
```