### PR TITLE
Load multiple resources with the same resource name

### DIFF
--- a/archaius2-core/src/main/java/com/netflix/archaius/readers/PropertiesConfigReader.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/readers/PropertiesConfigReader.java
@@ -15,23 +15,29 @@
  */
 package com.netflix.archaius.readers;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.URL;
-import java.net.URLDecoder;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
+import com.netflix.archaius.api.Config;
+import com.netflix.archaius.api.ConfigReader;
+import com.netflix.archaius.api.StrInterpolator;
+import com.netflix.archaius.api.config.CompositeConfig;
+import com.netflix.archaius.api.exceptions.ConfigException;
+import com.netflix.archaius.config.DefaultCompositeConfig;
+import com.netflix.archaius.config.DefaultCompositeConfig.Builder;
+import com.netflix.archaius.config.MapConfig;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.netflix.archaius.api.Config;
-import com.netflix.archaius.api.ConfigReader;
-import com.netflix.archaius.api.StrInterpolator;
-import com.netflix.archaius.config.MapConfig;
-import com.netflix.archaius.api.exceptions.ConfigException;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
 
 public class PropertiesConfigReader implements ConfigReader {
     private static final Logger LOG = LoggerFactory.getLogger(PropertiesConfigReader.class);
@@ -41,11 +47,19 @@ public class PropertiesConfigReader implements ConfigReader {
     
     @Override
     public Config load(ClassLoader loader, String resourceName, StrInterpolator strInterpolator, StrInterpolator.Lookup lookup) throws ConfigException {
-        URL url = getResource(loader, resourceName);
-        if (url == null) {
-            throw new ConfigException("Unable to resolve URL for resource " + resourceName);
+        Builder builder = DefaultCompositeConfig.builder();
+        int id = 0;
+        for (URL url : getResource(loader, resourceName)) {
+            builder.withConfig(url.toString(), load(loader, url, strInterpolator, lookup));
         }
-        return load(loader, url, strInterpolator, lookup);
+        
+        CompositeConfig config = builder.build();
+        if (config.getConfigNames().isEmpty()) {
+            throw new ConfigException("No resources found for '" + resourceName + SUFFIX + "'");
+        }
+        
+        
+        return config;
     }
 
     @Override
@@ -74,8 +88,7 @@ public class PropertiesConfigReader implements ConfigReader {
                 if (next != null) {
                     p.remove(INCLUDE_KEY);
                     for (String urlString : next.split(",")) {
-                        URL nextUrl = getResource(loader, strInterpolator.create(lookup).resolve(urlString));
-                        if (nextUrl != null) {
+                        for (URL nextUrl : getResource(loader, strInterpolator.create(lookup).resolve(urlString))) {
                             internalLoad(props, seenUrls, loader, nextUrl, strInterpolator, lookup);
                         }
                     }
@@ -99,32 +112,41 @@ public class PropertiesConfigReader implements ConfigReader {
         return uri.getPath().endsWith(SUFFIX);
     }
 
-    private static URL getResource(ClassLoader loader, String resourceName) {
+    private static Collection<URL> getResource(ClassLoader loader, String resourceName) {
+        LinkedHashSet<URL> resources = new LinkedHashSet<URL>();
         if (!resourceName.endsWith(SUFFIX)) {
             resourceName += SUFFIX;
         }
         
-        URL url = null;
         // attempt to load from the context classpath
         if (loader == null) {
             loader = Thread.currentThread().getContextClassLoader();
         }
         
         if (loader != null) {
-            url = loader.getResource(resourceName);
-        }
-        if (url == null) {
-            // attempt to load from the system classpath
-            url = ClassLoader.getSystemResource(resourceName);
-        }
-        if (url == null) {
             try {
-                resourceName = URLDecoder.decode(resourceName, "UTF-8");
-                url = (new File(resourceName)).toURI().toURL();
-            } catch (Exception e) {
-
+                resources.addAll(Collections.list(loader.getResources(resourceName)));
+            } catch (IOException e) {
+                LOG.debug("Failed to load resources for {}", resourceName, e);
             }
         }
-        return url;
+        
+        try {
+            resources.addAll(Collections.list(ClassLoader.getSystemResources(resourceName)));
+        } catch (IOException e) {
+            LOG.debug("Failed to load resources for {}", resourceName, e);
+        }
+        
+        try {
+            resourceName = URLDecoder.decode(resourceName, "UTF-8");
+            File file = new File(resourceName);
+            if (file.exists()) {
+                resources.add(file.toURI().toURL());
+            }
+        } catch (Exception e) {
+            LOG.debug("Failed to load resources for {}", resourceName, e);
+        }
+        
+        return resources;
     }
 }


### PR DESCRIPTION
Currently property file loading will stop only at the first file is found.  This can be very problematic when the same property exists in multiple places on the classpath.  Since the file loading order is non deterministic its reasonable to simply load all found resources into a single CompositeConfig.  It is however possible for the same property to be defined in multiple files in which case the first loaded will win.
