### PR TITLE
@Provides method configuration loading

### DIFF
--- a/archaius2-api/src/main/java/com/netflix/archaius/api/annotations/ConfigurationSource.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/api/annotations/ConfigurationSource.java
@@ -36,7 +36,7 @@ import java.util.List;
  * @author elandau
  *
  */
-@Target(ElementType.TYPE)
+@Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ConfigurationSource {
     /**

--- a/archaius2-guice/src/main/java/com/netflix/archaius/guice/ConfigurationInjectingListener.java
+++ b/archaius2-guice/src/main/java/com/netflix/archaius/guice/ConfigurationInjectingListener.java
@@ -4,6 +4,7 @@ import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.ProvisionException;
 import com.google.inject.name.Names;
+import com.google.inject.spi.ElementSource;
 import com.google.inject.spi.ProvisionListener;
 import com.netflix.archaius.ConfigMapper;
 import com.netflix.archaius.api.CascadeStrategy;
@@ -19,6 +20,8 @@ import com.netflix.archaius.cascade.NoCascadeStrategy;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Method;
 
 import javax.inject.Inject;
 
@@ -56,9 +59,22 @@ public class ConfigurationInjectingListener implements ProvisionListener {
         Class<?> clazz = provision.getBinding().getKey().getTypeLiteral().getRawType();
         
         //
-        // Configuration Loading
+        // Configuration Loading via @ConfigurationSource.  @Configuration source may be annotated
+        // on either a class or a @Provides method
         //
-        final ConfigurationSource source = clazz.getDeclaredAnnotation(ConfigurationSource.class);
+        ConfigurationSource source = clazz.getDeclaredAnnotation(ConfigurationSource.class);
+        if (source == null) {
+            if (provision.getBinding().getSource() instanceof ElementSource) {
+                ElementSource elementSource = (ElementSource)provision.getBinding().getSource();
+                if (elementSource.getDeclaringSource() instanceof Method) {
+                    Method method = (Method)elementSource.getDeclaringSource();
+                    if (method != null) {
+                        source = method.getDeclaredAnnotation(ConfigurationSource.class);
+                    }
+                }
+            }
+        }
+        
         if (source != null) {
             if (injector == null) {
                 LOG.warn("Can't inject configuration into {} until ConfigurationInjectingListener has been initialized", clazz.getName());

--- a/archaius2-guice/src/test/java/com/netflix/archaius/guice/ArchaiusModuleTest.java
+++ b/archaius2-guice/src/test/java/com/netflix/archaius/guice/ArchaiusModuleTest.java
@@ -15,15 +15,6 @@
  */
 package com.netflix.archaius.guice;
 
-import java.util.Properties;
-
-import javax.inject.Inject;
-
-import com.netflix.archaius.DefaultConfigLoader;
-import com.netflix.archaius.api.exceptions.ConfigException;
-import org.junit.Assert;
-import org.junit.Test;
-
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -47,6 +38,13 @@ import com.netflix.archaius.cascade.ConcatCascadeStrategy;
 import com.netflix.archaius.config.MapConfig;
 import com.netflix.archaius.exceptions.MappingException;
 import com.netflix.archaius.visitor.PrintStreamVisitor;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Properties;
+
+import javax.inject.Inject;
 
 public class ArchaiusModuleTest {
     
@@ -357,5 +355,26 @@ public class ArchaiusModuleTest {
         Assert.assertEquals("b_value_no_override", config.getString("b"));
         Assert.assertEquals("a_value_override", config.getString("a"));
         Assert.assertEquals("c_value_override", config.getString("c"));
+    }
+    
+    @Test
+    public void testAnnotatedProvidesMethod() {
+        Injector injector = Guice.createInjector(new ArchaiusModule() {
+            @Override
+            protected void configureArchaius() {
+            }
+            
+            @Provides
+            @Singleton
+            @ConfigurationSource("moduleTest")
+            String getFoo() {
+                return "foo";
+            }
+        });
+        
+        String str = injector.getInstance(String.class);
+        Config config = injector.getInstance(Config.class);
+        Assert.assertEquals(config.getString("moduleTest.loaded"), "true");
+
     }
 }


### PR DESCRIPTION
Support configuration loading by annotating an @Provides method with @ConfigurationSource.

For example, to load foo.properties before getFoo() is called,

```java
new ArchaiusModule() {
    @Override
    protected void configureArchaius() {
    }

    @Provides
    @Singleton
    @ConfigurationSource("foo")
    Foo getFoo() {
          return new Foo();
    }
}
```
