### PR TITLE
Fix Race Condition for null getProperty

### DIFF
--- a/archaius-core/src/main/java/com/netflix/config/DynamicProperty.java
+++ b/archaius-core/src/main/java/com/netflix/config/DynamicProperty.java
@@ -559,6 +559,16 @@ public class DynamicProperty {
         return updateValue(newValue);
     }
 
+    private void setStatusForValues() {
+        cachedStringValue.isCached = false;
+        booleanValue.isCached = false;
+        integerValue.isCached = false;
+        floatValue.isCached = false;
+        classValue.isCached = false;
+        doubleValue.isCached = false;
+        longValue.isCached = false;
+    }
+
     // return true iff the value actually changed
     boolean updateValue(Object newValue) {
         String nv = (newValue == null) ? null : newValue.toString();
@@ -568,13 +578,7 @@ public class DynamicProperty {
                 return false;
             }
             stringValue = nv;
-            cachedStringValue.flush();
-            booleanValue.flush();
-            integerValue.flush();
-            floatValue.flush();
-            classValue.flush();
-            doubleValue.flush();
-            longValue.flush();
+            setStatusForValues();
             changedTime = System.currentTimeMillis();
             return true;
         }


### PR DESCRIPTION
This PR is in accordance with this ISSUE: https://github.com/Netflix/archaius/issues/362
I have tried to resolve the issue by setting `isCached` property for the all properties to false, instead of actually doing `flush` for all the properties.