### PR TITLE
Support multiline values for URL configuration sources

### DIFF
--- a/archaius-core/src/test/java/com/netflix/config/sources/URLConfigurationSourceTest.java
+++ b/archaius-core/src/test/java/com/netflix/config/sources/URLConfigurationSourceTest.java
@@ -1,0 +1,34 @@
+package com.netflix.config.sources;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.IOException;
+import java.net.URL;
+
+import org.junit.Test;
+
+import com.netflix.config.PollResult;
+
+/**
+ * Description.
+ * @author Your Name
+ */
+public class URLConfigurationSourceTest {
+
+    
+    @Test
+    public void testMultilineKey() throws IOException {
+        URL multilineProperties = Thread.currentThread().getContextClassLoader().getResource("multiline.properties");
+        
+        URLConfigurationSource configSource = new URLConfigurationSource(multilineProperties);
+        
+        PollResult pollResult = configSource.poll(true, null);
+        
+        assertNotNull(pollResult);
+        Object multipleLine = pollResult.getComplete().get("multiline.key");
+        Object multipleValue = pollResult.getComplete().get("multivalue.key");
+        
+        assertEquals(multipleLine, multipleValue);
+    }
+}

--- a/archaius-core/src/test/resources/multiline.properties
+++ b/archaius-core/src/test/resources/multiline.properties
@@ -1,0 +1,5 @@
+multiline.key=one
+multiline.key=two
+multiline.key=three
+
+multivalue.key=one,two,three


### PR DESCRIPTION
Implemented multiline support (#477)

Adds support for multiline values for url configuration sources only. Each url source supports multiple values across multiple lines for the same key. Multiple lines from different sources are not conjoined. Used the `PropertiesConfiguration` from commons-config instead of `Properties` from the JDK.