### PR TITLE
Support netflixconfiguration.properties.nextLoad directive in properties files

### DIFF
--- a/archaius2-core/src/test/java/com/netflix/archaius/loaders/PropertyConfigReaderTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/loaders/PropertyConfigReaderTest.java
@@ -67,4 +67,16 @@ public class PropertyConfigReaderTest {
 
         Assert.assertEquals("test-us-east-1.properties", config.getString("cascaded.property"));
     }
+    
+    @Test
+    public void loadMultipleAtNext() throws ConfigException {
+        PropertiesConfigReader reader = new PropertiesConfigReader();
+        Config mainConfig = MapConfig.builder().put("@region",  "us-east-1").build();
+        
+        Config config = reader.load(null, "override", CommonsStrInterpolator.INSTANCE, ConfigStrLookup.from(mainConfig));
+        config.accept(new PrintStreamVisitor());
+
+        Assert.assertEquals("200", config.getString("cascaded.property"));
+        Assert.assertEquals("true", config.getString("override.internal.style.next"));
+    }
 }

--- a/archaius2-core/src/test/resources/override-internal-style-next.properties
+++ b/archaius2-core/src/test/resources/override-internal-style-next.properties
@@ -14,6 +14,4 @@
 # limitations under the License.
 #
 
-cascaded.property=100
-@next=override.${@region}.properties
-netflixconfiguration.properties.nextLoad=override-internal-style-next.properties
+override.internal.style.next=true


### PR DESCRIPTION
Add support for the Netflix internal 'netflixconfiguration.properties.nextLoad' directive when loading property files in addition to @next.