### PR TITLE
Fix wiki link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Archaius includes a set of configuration management APIs used by Netflix. It pro
 
 Documentation
 --------------
-Please see [wiki] (https://github.com/Netflix/archaius/wiki) for detail documentations.
+Please see [wiki](https://github.com/Netflix/archaius/wiki) for detail documentations.
 
 Origin
 ------


### PR DESCRIPTION
It won't render correctly with the space between the `]` and `(`.