### PR TITLE
Changed strings that contain Unicode values to corresponding \u-notation

### DIFF
--- a/archaius-core/src/test/java/com/netflix/config/ConfigurationManagerTest.java
+++ b/archaius-core/src/test/java/com/netflix/config/ConfigurationManagerTest.java
@@ -65,7 +65,7 @@ public class ConfigurationManagerTest {
     @Test
     public void testLoadChineseProperties() throws Exception {
         ConfigurationManager.loadPropertiesFromResources("test-chinese.properties");
-        assertEquals("中文测试", ConfigurationManager.getConfigInstance().getProperty("subject"));
+        assertEquals("\u4E2D\u6587\u6D4B\u8BD5", ConfigurationManager.getConfigInstance().getProperty("subject"));
     }
     
     @Test

--- a/archaius-core/src/test/java/com/netflix/config/DynamicURLConfigurationTestWithFileURL.java
+++ b/archaius-core/src/test/java/com/netflix/config/DynamicURLConfigurationTestWithFileURL.java
@@ -68,7 +68,7 @@ public class DynamicURLConfigurationTestWithFileURL {
     @Test
     public void testChineseCharacters(){
         DynamicURLConfiguration config = new DynamicURLConfiguration();
-        Assert.assertEquals("中文测试", config.getString("com.netflix.test-subject"));
+        Assert.assertEquals("\u4E2D\u6587\u6D4B\u8BD5", config.getString("com.netflix.test-subject"));
     }
 
     private void populateFile(File temporary, String prop1, String prop2) throws IOException {


### PR DESCRIPTION
When I tried to build the project it turned out that the build is system-codepage dependant. In particular given two tests have failed. In can be fixed by telling Java that source files are in given encoding (`javac -encoding utf8`), but perhaps it would be more reliable to use Unicode escaping.