### PR TITLE
Guava 2x compatibility in archaius-etcd project

### DIFF
--- a/archaius-etcd/src/main/java/com/netflix/config/source/EtcdConfigurationSource.java
+++ b/archaius-etcd/src/main/java/com/netflix/config/source/EtcdConfigurationSource.java
@@ -1,6 +1,6 @@
 package com.netflix.config.source;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
@@ -57,7 +57,7 @@ public class EtcdConfigurationSource implements WatchedConfigurationSource {
      */
     public EtcdConfigurationSource(Etcd etcd, String configPath) {
         this.etcd = etcd;
-        this.configPath = Objects.firstNonNull(configPath, "").replaceAll("^/+","");
+        this.configPath = MoreObjects.firstNonNull(configPath, "").replaceAll("^/+","");
         init();
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -104,6 +104,7 @@ project(':archaius-etcd') {
 
     dependencies {
         compile project(':archaius-core')
+        compile 'com.google.guava:guava:19.0'
         compile 'io.fastjson:etcd-client:0.33'
         testCompile 'junit:junit:4.11'
         testCompile 'org.mockito:mockito-all:1.9.5'


### PR DESCRIPTION
Change usage of deprected class com.google.common.base.Object class to com.google.common.base.MoreObjects in archaius-etcd project. Reason of api changes after guava:21.0 released.

MoreObjects from v19 is backward comaptible with guava 16.0 what the archaius-core project uses

Guava release notes:
https://github.com/google/guava/wiki/Release21

Deprecation notification in Objects class:
https://github.com/google/guava/blob/v19.0/guava/src/com/google/common/base/Objects.java#L185