### PR TITLE
Fixed PrefixedViewConfig#containsKey (fixes #505)

### DIFF
--- a/archaius2-core/src/main/java/com/netflix/archaius/config/PrefixedViewConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/PrefixedViewConfig.java
@@ -88,7 +88,7 @@ public class PrefixedViewConfig extends AbstractConfig {
 
     @Override
     public boolean containsKey(String key) {
-        return state.data.containsKey(prefix + key);
+        return state.data.containsKey(key);
     }
 
     @Override


### PR DESCRIPTION
## Problem

`containsKey` isn't consistent with other `state.data` accessing methods in `PrefixedViewConfig` as it prefixes the provided `key` with `prefix`.