### PR TITLE
New LayeredConfig API

### DIFF
--- a/archaius2-api/src/main/java/com/netflix/archaius/Layers.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/Layers.java
@@ -1,0 +1,18 @@
+package com.netflix.archaius;
+
+import com.netflix.archaius.api.Layer;
+
+public final class Layers {
+    public static Layer TEST        = Layer.of("test",        100, false);
+    public static Layer RUNTIME     = Layer.of("runtime",     200, false);
+    public static Layer SYSTEM      = Layer.of("system",      300, false);
+    public static Layer ENVIRONMENT = Layer.of("environment", 400, false);
+    public static Layer REMOTE      = Layer.of("remote",      500, false);
+    public static Layer APPLICATION_OVERRIDE = Layer.of("application-override", 600, true);
+    public static Layer APPLICATION = Layer.of("application", 700, true);
+    public static Layer LIBRARY     = Layer.of("library",     800, false);
+    public static Layer DEFAULT     = Layer.of("default",     900, false);
+    
+    private Layers() {
+    }
+}

--- a/archaius2-api/src/main/java/com/netflix/archaius/Layers.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/Layers.java
@@ -3,15 +3,15 @@ package com.netflix.archaius;
 import com.netflix.archaius.api.Layer;
 
 public final class Layers {
-    public static Layer TEST        = Layer.of("test",        100, false);
-    public static Layer RUNTIME     = Layer.of("runtime",     200, false);
-    public static Layer SYSTEM      = Layer.of("system",      300, false);
-    public static Layer ENVIRONMENT = Layer.of("environment", 400, false);
-    public static Layer REMOTE      = Layer.of("remote",      500, false);
-    public static Layer APPLICATION_OVERRIDE = Layer.of("application-override", 600, true);
-    public static Layer APPLICATION = Layer.of("application", 700, true);
-    public static Layer LIBRARY     = Layer.of("library",     800, false);
-    public static Layer DEFAULT     = Layer.of("default",     900, false);
+    public static Layer TEST        = Layer.of("test",        100);
+    public static Layer RUNTIME     = Layer.of("runtime",     200);
+    public static Layer SYSTEM      = Layer.of("system",      300);
+    public static Layer ENVIRONMENT = Layer.of("environment", 400);
+    public static Layer REMOTE      = Layer.of("remote",      500);
+    public static Layer APPLICATION_OVERRIDE = Layer.of("application-override", 600);
+    public static Layer APPLICATION = Layer.of("application", 700);
+    public static Layer LIBRARY     = Layer.of("library",     800);
+    public static Layer DEFAULT     = Layer.of("default",     900);
     
     private Layers() {
     }

--- a/archaius2-api/src/main/java/com/netflix/archaius/api/Layer.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/api/Layer.java
@@ -1,0 +1,80 @@
+
+package com.netflix.archaius.api;
+
+/**
+ * Key used to group and order {@link Config}s into layers (@see Layers).
+ * Layers are ordered by natural order such that lower order values have 
+ * precedence over a higher value.  Within a layer configurations are prioritized by
+ * insertion order (or reversed if 'reversed=true')
+ */
+public final class Layer {
+    private final String name;
+    private final int order;
+    private final boolean reversed;
+    
+    /**
+     * Construct an Layer key.  
+     * 
+     * @param name
+     * @param order
+     * @return
+     */
+    public static Layer of(String name, int order, boolean reversed) {
+        return new Layer(name, order, reversed);
+    }
+    
+    private Layer(String name, int order, boolean reversed) {
+        this.name = name;
+        this.order = order;
+        this.reversed = reversed;
+    }
+
+    public Layer withOrder(int order) {
+        return new Layer(name, order, reversed);
+    }
+    
+    public int getOrder() {
+        return order;
+    }
+    
+    public String getName() {
+        return name;
+    }
+    
+    public boolean isReversedOrder() {
+        return reversed;
+    }
+    
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        result = prime * result + order;
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        Layer other = (Layer) obj;
+        if (name == null) {
+            if (other.name != null)
+                return false;
+        } else if (!name.equals(other.name))
+            return false;
+        if (order != other.order)
+            return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "Key [layerName=" + name + ", layerOrder=" + order + "]";
+    }
+}

--- a/archaius2-api/src/main/java/com/netflix/archaius/api/Layer.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/api/Layer.java
@@ -4,13 +4,12 @@ package com.netflix.archaius.api;
 /**
  * Key used to group and order {@link Config}s into layers (@see Layers).
  * Layers are ordered by natural order such that lower order values have 
- * precedence over a higher value.  Within a layer configurations are prioritized by
- * insertion order (or reversed if 'reversed=true')
+ * precedence over a higher value.  Within a layer configurations are prioritized
+ * such that the last config wins.
  */
 public final class Layer {
     private final String name;
     private final int order;
-    private final boolean reversed;
     
     /**
      * Construct an Layer key.  
@@ -19,18 +18,17 @@ public final class Layer {
      * @param order
      * @return
      */
-    public static Layer of(String name, int order, boolean reversed) {
-        return new Layer(name, order, reversed);
+    public static Layer of(String name, int order) {
+        return new Layer(name, order);
     }
     
-    private Layer(String name, int order, boolean reversed) {
+    private Layer(String name, int order) {
         this.name = name;
         this.order = order;
-        this.reversed = reversed;
     }
 
     public Layer withOrder(int order) {
-        return new Layer(name, order, reversed);
+        return new Layer(name, order);
     }
     
     public int getOrder() {
@@ -39,10 +37,6 @@ public final class Layer {
     
     public String getName() {
         return name;
-    }
-    
-    public boolean isReversedOrder() {
-        return reversed;
     }
     
     @Override

--- a/archaius2-api/src/main/java/com/netflix/archaius/api/PropertySource.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/api/PropertySource.java
@@ -22,7 +22,7 @@ public interface PropertySource {
     /**
      * @return Name used to identify the source such as a filename.
      */
-    default String getName() { return "unknown"; }
+    default String getName() { return "unnamed"; }
 
     /**
      * @return True if empty or false otherwise.

--- a/archaius2-api/src/main/java/com/netflix/archaius/api/config/LayeredConfig.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/api/config/LayeredConfig.java
@@ -1,0 +1,47 @@
+package com.netflix.archaius.api.config;
+
+import com.netflix.archaius.api.Config;
+import com.netflix.archaius.api.Layer;
+import com.netflix.archaius.api.exceptions.ConfigException;
+
+import java.util.Collection;
+import java.util.Optional;
+
+/**
+ * Composite Config where the override order is driven by Layer keys.
+ */
+public interface LayeredConfig extends Config {
+    static interface LayeredVisitor<T> extends Visitor<T> {
+        /**
+         * Visit a Config at the specified layer.  visitConfig is called in override order
+         *
+         * @param layer
+         * @param child
+         * @return
+         */
+        T visitConfig(Layer layer, Config config);
+    }
+    
+    /**
+     * Add a Config at the specified Layer.
+     * 
+     * <p>
+     * This will trigger an onConfigUpdated event.
+     *
+     * @param layer
+     * @param child
+     * @throws ConfigException
+     */
+    void addConfig(Layer layer, Config config);
+    
+    void addConfig(Layer layer, Config config, int position);
+    
+    Optional<Config> removeConfig(Layer layer, String name);
+    
+    /**
+     * Return all property sources at a layer
+     * @param layer
+     * @return Immutable list of all property sources at the specified layer.
+     */
+    Collection<Config> getConfigsAtLayer(Layer layer);
+}

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/AbstractConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/AbstractConfig.java
@@ -15,16 +15,6 @@
  */
 package com.netflix.archaius.config;
 
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.function.BiConsumer;
-
 import com.netflix.archaius.DefaultDecoder;
 import com.netflix.archaius.api.Config;
 import com.netflix.archaius.api.ConfigListener;
@@ -35,6 +25,17 @@ import com.netflix.archaius.exceptions.ParseException;
 import com.netflix.archaius.interpolate.CommonsStrInterpolator;
 import com.netflix.archaius.interpolate.ConfigStrLookup;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
+
 public abstract class AbstractConfig implements Config {
 
     private final CopyOnWriteArrayList<ConfigListener> listeners = new CopyOnWriteArrayList<ConfigListener>();
@@ -42,11 +43,22 @@ public abstract class AbstractConfig implements Config {
     private Decoder decoder;
     private StrInterpolator interpolator;
     private String listDelimiter = ",";
+    private final String name;
     
-    public AbstractConfig() {
+    private static final AtomicInteger idCounter = new AtomicInteger();
+    protected static String generateUniqueName(String prefix) {
+        return prefix + idCounter.incrementAndGet();
+    }
+    
+    public AbstractConfig(String name) {
         this.decoder = new DefaultDecoder();
         this.interpolator = CommonsStrInterpolator.INSTANCE;
         this.lookup = ConfigStrLookup.from(this);
+        this.name = name == null ? generateUniqueName("unnamed-") : name;
+    }
+    
+    public AbstractConfig() {
+        this(generateUniqueName("unnamed-"));
     }
 
     protected CopyOnWriteArrayList<ConfigListener> getListeners() {
@@ -402,5 +414,10 @@ public abstract class AbstractConfig implements Config {
                 consumer.accept(key, value);
             }
         }
+    }
+
+    @Override
+    public String getName() { 
+        return name; 
     }
 }

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/DefaultLayeredConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/DefaultLayeredConfig.java
@@ -188,9 +188,7 @@ public class DefaultLayeredConfig extends AbstractConfig implements LayeredConfi
             }
         }
         
-        return o1.layer.isReversedOrder()
-                ? o1.internalOrder - o2.internalOrder
-                : o2.internalOrder - o1.internalOrder;                        
+        return o2.internalOrder - o1.internalOrder;
     };
 
     /**

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/DefaultLayeredConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/DefaultLayeredConfig.java
@@ -1,0 +1,258 @@
+package com.netflix.archaius.config;
+
+import com.netflix.archaius.api.Config;
+import com.netflix.archaius.api.ConfigListener;
+import com.netflix.archaius.api.Layer;
+import com.netflix.archaius.api.config.LayeredConfig;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+
+/**
+ * Composite Config with child sources ordered by {@link Layer}s where there can be 
+ * multiple configs in each layer, ordered by insertion order.  Layers form an override 
+ * hierarchy for property overrides.  Common hierarchies are, 
+ * 
+ *  Runtime -> Environment -> System -> Application -> Library -> Defaults
+ */
+public class DefaultLayeredConfig extends AbstractConfig implements LayeredConfig {
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultLayeredConfig.class);
+    
+    private final ConfigListener listener;
+    private volatile ImmutableCompositeState state = new ImmutableCompositeState(Collections.emptyList());
+    
+    public DefaultLayeredConfig() {
+        this(generateUniqueName("layered-"));
+    }
+    
+    public DefaultLayeredConfig(String name) {
+        super(name);
+        listener = new ConfigListener() {
+            @Override
+            public void onConfigAdded(Config config) {
+                refreshState();
+                notifyConfigUpdated(DefaultLayeredConfig.this);
+            }
+
+            @Override
+            public void onConfigRemoved(Config config) {
+                refreshState();
+                notifyConfigUpdated(DefaultLayeredConfig.this);
+            }
+
+            @Override
+            public void onConfigUpdated(Config config) {
+                refreshState();
+                notifyConfigUpdated(DefaultLayeredConfig.this);
+            }
+
+            @Override
+            public void onError(Throwable error, Config config) {
+                notifyError(error, DefaultLayeredConfig.this);
+            }
+        };
+    }
+    
+    private void refreshState() {
+        this.state = state.refresh();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return state.data.isEmpty();
+    }
+
+    @Override
+    public synchronized void addConfig(Layer layer, Config config) {
+        addConfig(layer, config, insertionOrderCounter.incrementAndGet());
+    }
+    
+    @Override
+    public synchronized void addConfig(Layer layer, Config child, int position) {
+        LOG.info("Adding property source '{}' at layer '{}'", child.getName(), layer);
+        
+        if (child == null) {
+            return;
+        }
+        
+        state = state.addChild(new LayerAndConfig(layer, child, position));
+        child.setStrInterpolator(getStrInterpolator());
+        child.setDecoder(getDecoder());
+        notifyConfigUpdated(this);
+        child.addListener(listener);
+    }
+    
+    @Override
+    public Collection<Config> getConfigsAtLayer(Layer layer) {
+        return state.children.stream()
+                .filter(holder -> holder.layer.equals(layer))
+                .map(holder -> holder.config)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public synchronized Optional<Config> removeConfig(Layer layer, String name) {
+        LOG.info("Removing property source '{}' from layer '{}'", name, layer);
+        Optional<Config> previous = state.findChild(layer, name);
+        if (previous.isPresent()) {
+            this.state = state.removeChild(layer, name);
+            this.notifyConfigUpdated(this);
+        }
+        return previous;
+    }
+
+    @Override
+    public void forEachProperty(BiConsumer<String, Object> consumer) {
+        this.state.data.forEach(consumer);
+    }
+    
+    private static final AtomicInteger insertionOrderCounter = new AtomicInteger(1);
+    
+    /**
+     * Instance of a single child Config within the composite structure
+     */
+    private static class LayerAndConfig {
+        private final Layer layer;
+        private final int internalOrder;
+        private final Config config;
+        
+        private LayerAndConfig(Layer layer, Config config, int internalOrder) {
+            this.layer = layer;
+            this.internalOrder = internalOrder;
+            this.config = config;
+        }
+        
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = 31 + ((config == null) ? 0 : config.hashCode());
+            result = prime * result + ((layer == null) ? 0 : layer.hashCode());
+            return result;
+        }
+
+        public Layer getLayer() {
+            return layer;
+        }
+        
+        public Config getConfig() {
+            return config;
+        }
+        
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            LayerAndConfig other = (LayerAndConfig) obj;
+            if (config == null) {
+                if (other.config != null)
+                    return false;
+            } else if (!config.equals(other.config))
+                return false;
+            if (layer == null) {
+                if (other.layer != null)
+                    return false;
+            } else if (!layer.equals(other.layer))
+                return false;
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            return "Element [layer=" + layer + ", id=" + internalOrder + ", value=" + config + "]";
+        }
+    }
+    
+    private static final Comparator<LayerAndConfig> ByPriorityAndInsertionOrder = (LayerAndConfig o1, LayerAndConfig o2) -> {
+        if (o1.layer != o2.layer) {
+            int result = o1.layer.getOrder() - o2.layer.getOrder();
+            if (result != 0) {
+                return result;
+            }
+        }
+        
+        return o1.layer.isReversedOrder()
+                ? o1.internalOrder - o2.internalOrder
+                : o2.internalOrder - o1.internalOrder;                        
+    };
+
+    /**
+     * Immutable composite state of the DefaultLayeredConfig.  A new instance of this
+     * will be created whenever a new Config is added or removed
+     */
+    private class ImmutableCompositeState {
+        private final List<LayerAndConfig> children;
+        private final Map<String, Object> data;
+        
+        ImmutableCompositeState(List<LayerAndConfig> entries) {
+            this.children = entries;
+            this.children.sort(ByPriorityAndInsertionOrder);
+            this.data = new HashMap<>();
+            this.children.forEach(child -> child.config.forEachProperty(data::putIfAbsent));
+        }
+        
+        public ImmutableCompositeState addChild(LayerAndConfig layerAndConfig) {
+            List<LayerAndConfig> newChildren = new ArrayList<>(this.children);
+            newChildren.add(layerAndConfig);
+            return new ImmutableCompositeState(newChildren);
+        }
+
+        public ImmutableCompositeState removeChild(Layer layer, String name) {
+            List<LayerAndConfig> newChildren = new ArrayList<>(this.children.size());
+            this.children.stream()
+                .filter(source -> !(source.getLayer().equals(layer) && source.getConfig().getName() != null))
+                .forEach(newChildren::add);
+            newChildren.sort(ByPriorityAndInsertionOrder);
+            return new ImmutableCompositeState(newChildren);
+        }
+        
+        public Optional<Config> findChild(Layer layer, String name) {
+            return children
+                    .stream()
+                    .filter(source -> source.layer.equals(layer) && source.config.getName().equals(name))
+                    .findFirst()
+                    .map(LayerAndConfig::getConfig);
+        }
+
+        ImmutableCompositeState refresh() {
+            return new ImmutableCompositeState(children);
+        }
+    }
+
+    @Override
+    public Optional<Object> getProperty(String key) {
+        return Optional.ofNullable(state.data.get(key));
+    }
+
+    @Override
+    public Object getRawProperty(String key) {
+        return state.data.get(key);
+    }
+
+    @Override
+    public boolean containsKey(String key) {
+        return state.data.containsKey(key);
+    }
+
+    @Override
+    public Iterator<String> getKeys() {
+        return state.data.keySet().iterator();
+    }
+}

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/DefaultSettableConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/DefaultSettableConfig.java
@@ -15,6 +15,9 @@
  */
 package com.netflix.archaius.config;
 
+import com.netflix.archaius.api.Config;
+import com.netflix.archaius.api.config.SettableConfig;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -23,11 +26,16 @@ import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.function.BiConsumer;
 
-import com.netflix.archaius.api.Config;
-import com.netflix.archaius.api.config.SettableConfig;
-
 public class DefaultSettableConfig extends AbstractConfig implements SettableConfig {
     private volatile Map<String, Object> props = Collections.emptyMap();
+    
+    public DefaultSettableConfig(String name) {
+        super(name);
+    }
+
+    public DefaultSettableConfig() {
+        super(generateUniqueName("settable-"));
+    }
     
     @Override
     public synchronized <T> void setProperty(String propName, T propValue) {

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/MapConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/MapConfig.java
@@ -42,14 +42,30 @@ public class MapConfig extends AbstractConfig {
      */
     public static class Builder {
         Map<String, String> map = new HashMap<String, String>();
+        String named;
         
         public <T> Builder put(String key, T value) {
             map.put(key, value.toString());
             return this;
         }
         
+        public <T> Builder putAll(Map<String, String> props) {
+            map.putAll(props);
+            return this;
+        }
+        
+        public <T> Builder putAll(Properties props) {
+            props.forEach((k, v) -> map.put(k.toString(), v.toString()));
+            return this;
+        }
+        
+        public Builder name(String name) {
+            this.named = name;
+            return this;
+        }
+        
         public MapConfig build() {
-            return new MapConfig(map);
+            return new MapConfig(named == null ? generateUniqueName("immutable-") : named, map);
         }
     }
     
@@ -67,12 +83,19 @@ public class MapConfig extends AbstractConfig {
     
     private Map<String, String> props = new HashMap<String, String>();
     
+    public MapConfig(String name, Map<String, String> props) {
+        super(name);
+        this.props.putAll(props);
+        this.props = Collections.unmodifiableMap(this.props);
+    }
+    
     /**
      * Construct a MapConfig as a copy of the provided Map
      * @param name
      * @param props
      */
     public MapConfig(Map<String, String> props) {
+        super(generateUniqueName("immutable-"));
         this.props.putAll(props);
         this.props = Collections.unmodifiableMap(this.props);
     }
@@ -83,6 +106,7 @@ public class MapConfig extends AbstractConfig {
      * @param props
      */
     public MapConfig(Properties props) {
+        super(generateUniqueName("immutable-"));
         for (Entry<Object, Object> entry : props.entrySet()) {
             this.props.put(entry.getKey().toString(), entry.getValue().toString());
         }

--- a/archaius2-core/src/test/java/com/netflix/archaius/config/DefaultLayeredConfigTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/DefaultLayeredConfigTest.java
@@ -1,0 +1,131 @@
+package com.netflix.archaius.config;
+
+import com.netflix.archaius.Layers;
+import com.netflix.archaius.api.ConfigListener;
+import com.netflix.archaius.api.config.LayeredConfig;
+import com.netflix.archaius.api.config.SettableConfig;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class DefaultLayeredConfigTest {
+    @Test
+    public void validateApiOnEmptyConfig() {
+        LayeredConfig config = new DefaultLayeredConfig();
+        
+        Assert.assertFalse(config.getProperty("propname").isPresent());
+        Assert.assertNull(config.getRawProperty("propname"));
+        
+        LayeredConfig.LayeredVisitor<String> visitor = Mockito.mock(LayeredConfig.LayeredVisitor.class);
+        config.accept(visitor);
+        Mockito.verify(visitor, Mockito.never()).visitConfig(Mockito.any(), Mockito.any());
+        Mockito.verify(visitor, Mockito.never()).visitKey(Mockito.any(), Mockito.any());
+    }
+    
+    @Test
+    public void validateListenerCalled() {
+        // Setup main config
+        ConfigListener listener = Mockito.mock(ConfigListener.class);
+        LayeredConfig config = new DefaultLayeredConfig();
+        config.addListener(listener);
+        
+        // Add a child
+        config.addConfig(Layers.APPLICATION, new DefaultSettableConfig());
+        
+        Mockito.verify(listener, Mockito.times(1)).onConfigUpdated(Mockito.any());
+    }
+    
+    @Test
+    public void validatePropertyUpdates() {
+        // Setup main config
+        ConfigListener listener = Mockito.mock(ConfigListener.class);
+        LayeredConfig config = new DefaultLayeredConfig();
+        config.addListener(listener);
+        
+        // Add a child
+        SettableConfig child = new DefaultSettableConfig();
+        child.setProperty("propname", "propvalue");
+        config.addConfig(Layers.APPLICATION, child);
+        
+        // Validate initial state
+        Assert.assertEquals("propvalue", config.getProperty("propname").get());
+        Assert.assertEquals("propvalue", config.getRawProperty("propname"));
+        
+        // Update the property value
+        child.setProperty("propname", "propvalue2");
+        
+        // Validate new state
+        Assert.assertEquals("propvalue2", config.getProperty("propname").get());
+        Assert.assertEquals("propvalue2", config.getRawProperty("propname"));
+        
+        Mockito.verify(listener, Mockito.times(2)).onConfigUpdated(Mockito.any());
+    }
+    
+    @Test
+    public void validateApiWhenRemovingChild() {
+        // Setup main config
+        ConfigListener listener = Mockito.mock(ConfigListener.class);
+        LayeredConfig config = new DefaultLayeredConfig();
+        config.addListener(listener);
+        
+        // Add a child
+        SettableConfig child = new DefaultSettableConfig();
+        child.setProperty("propname", "propvalue");
+        config.addConfig(Layers.APPLICATION, child);
+        Mockito.verify(listener, Mockito.times(1)).onConfigUpdated(Mockito.any());        
+        
+        // Validate initial state
+        Assert.assertEquals("propvalue", config.getProperty("propname").get());
+        Assert.assertEquals("propvalue", config.getRawProperty("propname"));
+        
+        // Remove the child
+        config.removeConfig(Layers.APPLICATION, child.getName());
+        
+        // Validate new state
+        Assert.assertFalse(config.getProperty("propname").isPresent());
+        Assert.assertNull(config.getRawProperty("propname"));
+        
+        Mockito.verify(listener, Mockito.times(2)).onConfigUpdated(Mockito.any());        
+    }
+    
+    @Test
+    public void validateOverrideOrder() {
+        MapConfig appConfig = MapConfig.builder()
+                .put("propname", Layers.APPLICATION.getName())
+                .name(Layers.APPLICATION.getName())
+                .build();
+        
+        MapConfig lib1Config = MapConfig.builder()
+                .put("propname", Layers.LIBRARY.getName() + "1")
+                .name(Layers.LIBRARY.getName() + "1")
+                .build();
+        
+        MapConfig lib2Config = MapConfig.builder()
+                .put("propname", Layers.LIBRARY.getName() + "2")
+                .name(Layers.LIBRARY.getName() + "2")
+                .build();
+        MapConfig runtimeConfig = MapConfig.builder()
+                .put("propname", Layers.RUNTIME.getName())
+                .name(Layers.RUNTIME.getName())
+                .build();
+        
+        LayeredConfig config = new DefaultLayeredConfig();
+        Assert.assertFalse(config.getProperty("propname").isPresent());
+
+        config.addConfig(Layers.LIBRARY, lib1Config);
+        Assert.assertEquals(lib1Config.getName(), config.getRawProperty("propname"));
+        
+        config.addConfig(Layers.LIBRARY, lib2Config);
+        Assert.assertEquals(lib2Config.getName(), config.getRawProperty("propname"));
+
+        config.addConfig(Layers.RUNTIME, runtimeConfig);
+        Assert.assertEquals(runtimeConfig.getName(), config.getRawProperty("propname"));
+        
+        config.addConfig(Layers.APPLICATION, appConfig);
+        Assert.assertEquals(runtimeConfig.getName(), config.getRawProperty("propname"));
+        
+        config.removeConfig(Layers.RUNTIME, runtimeConfig.getName());
+        Assert.assertEquals(appConfig.getName(), config.getRawProperty("propname"));
+    }
+}


### PR DESCRIPTION
LayeredConfig will eventually replace CompositeConfig as the top level container for properties.  LayeredConfig simplifies defining multiple override layers that may be added in any order while keeping a well-defined override order.  A set of common layers is defined in the Layers class but additional user defined layers may be defined and added at any time.

This PR is the first in the series of changes through which the LayeredConfig will eventually be the top level config API while keeping backwards compatibility in mind.  Once dependent libraries support a code path for LayeredConfig as the top level API, ArchaiusModule will be updated to use LayeredConfig instead of CompositeConfig.