### PR TITLE
fix: ConfigurationSource ordering

### DIFF
--- a/archaius2-guice/src/main/java/com/netflix/archaius/guice/ConfigurationInjectingListener.java
+++ b/archaius2-guice/src/main/java/com/netflix/archaius/guice/ConfigurationInjectingListener.java
@@ -17,6 +17,10 @@ import com.netflix.archaius.api.exceptions.ConfigException;
 import com.netflix.archaius.api.inject.LibrariesLayer;
 import com.netflix.archaius.cascade.NoCascadeStrategy;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,7 +72,9 @@ public class ConfigurationInjectingListener implements ProvisionListener {
             CascadeStrategy strategy = source.cascading() != ConfigurationSource.NullCascadeStrategy.class
                     ? injector.getInstance(source.cascading()) : getCascadeStrategy();
 
-            for (String resourceName : source.value()) {
+            List<String> sources = Arrays.asList(source.value());
+            Collections.reverse(sources);
+            for (String resourceName : sources) {
                 LOG.debug("Trying to loading configuration resource {}", resourceName);
                 try {
                     CompositeConfig loadedConfig = loader
@@ -95,7 +101,7 @@ public class ConfigurationInjectingListener implements ProvisionListener {
             try {
                 mapper.mapConfig(provision.provision(), config, new IoCContainer() {
                     @Override
-                    public <T> T getInstance(String name, Class<T> type) {
+                    public <S> S getInstance(String name, Class<S> type) {
                         return injector.getInstance(Key.get(type, Names.named(name)));
                     }
                 });

--- a/archaius2-guice/src/test/java/com/netflix/archaius/guice/ConfigurationInjectingListenerTest.java
+++ b/archaius2-guice/src/test/java/com/netflix/archaius/guice/ConfigurationInjectingListenerTest.java
@@ -1,0 +1,28 @@
+package com.netflix.archaius.guice;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.netflix.archaius.api.Config;
+import com.netflix.archaius.api.annotations.ConfigurationSource;
+import com.netflix.archaius.visitor.PrintStreamVisitor;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ConfigurationInjectingListenerTest {
+    
+    @ConfigurationSource({"moduleTest", "moduleTest-prod"}) 
+    public static class Foo {
+        
+    }
+    
+    @Test
+    public void confirmLoadOrder() {
+        Injector injector = Guice.createInjector(new ArchaiusModule());
+        injector.getInstance(Foo.class);
+        
+        Config config = injector.getInstance(Config.class);
+        config.accept(new PrintStreamVisitor());
+        Assert.assertEquals("prod", config.getString("moduleTest.value"));
+    }
+}

--- a/archaius2-guice/src/test/resources/moduleTest-prod.properties
+++ b/archaius2-guice/src/test/resources/moduleTest-prod.properties
@@ -15,3 +15,4 @@
 #
 
 moduleTest-prod.loaded=true
+moduleTest.value=prod

--- a/archaius2-guice/src/test/resources/moduleTest.properties
+++ b/archaius2-guice/src/test/resources/moduleTest.properties
@@ -16,3 +16,4 @@
 
 moduleTest.loaded=true
 moduleTest.prop1=fromFile
+moduleTest.value=default


### PR DESCRIPTION
Fix configuration load order being reversed when processing multiple sources in a ConfigurationSource annotation.  Last one should win.