### PR TITLE
Archaius 0.x is not compatible with Java 6/7

### DIFF
--- a/archaius-core/src/main/java/com/netflix/config/ConcurrentMapConfiguration.java
+++ b/archaius-core/src/main/java/com/netflix/config/ConcurrentMapConfiguration.java
@@ -55,7 +55,7 @@ import com.netflix.config.validation.ValidationException;
  *
  */
 public class ConcurrentMapConfiguration extends AbstractConfiguration {
-    protected ConcurrentHashMap<String,Object> map;
+    protected Map<String,Object> map;
     private Collection<ConfigurationListener> listeners = new CopyOnWriteArrayList<ConfigurationListener>();    
     private Collection<ConfigurationErrorListener> errorListeners = new CopyOnWriteArrayList<ConfigurationErrorListener>();    
     private static final Logger logger = LoggerFactory.getLogger(ConcurrentMapConfiguration.class);


### PR DESCRIPTION
_The following issue is currently causing issues in the spring-cloud project, since spring-cloud is currently based on spring 4.x which maintains compatibility with Java 7._

Archaius 0.x claims to be compatible with Java 6 (source and target versions are set to 1.6) but when calling `com.netflix.config.ConcurrentMapConfiguration.getKeys` under Java 7 the following exception occurs:

`Caused by: java.lang.NoSuchMethodError: java.util.concurrent.ConcurrentHashMap.keySet()Ljava/util/concurrent/ConcurrentHashMap$KeySetView; at com.netflix.config.ConcurrentMapConfiguration.getKeys(ConcurrentMapConfiguration.java:152)`

This is caused by the fact that Archaius 0.x is compiled using a JDK 8 with source/target set to 1.6 but without a bootclasspath set to 1.6. Therefore you'll run into this issue: https://gist.github.com/AlainODea/1375759b8720a3f9f094

I see three solutions:
- Switch to using JDK 1.6 or 1.7 entirely. This involves updating the Travis build config.
- Stay on JDK 8 but specify a bootclasspath. Dunno if this is possible with Travis.
- The quick 'n dirty fix in this PR, based on the idea set forth in https://gist.github.com/AlainODea/1375759b8720a3f9f094