### PR TITLE
Refactor Property to use java8 functional APIs

### DIFF
--- a/archaius2-api/src/main/java/com/netflix/archaius/api/Config.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/api/Config.java
@@ -157,4 +157,12 @@ public interface Config extends PropertySource {
      * @param visitor
      */
     <T> T accept(Visitor<T> visitor);
+    
+    default String resolve(String value) {
+        throw new UnsupportedOperationException();
+    }
+
+    default <T> T resolve(String value, Class<T> type) {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/archaius2-api/src/main/java/com/netflix/archaius/api/Property.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/api/Property.java
@@ -15,16 +15,23 @@
  */
 package com.netflix.archaius.api;
 
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
 /**
- * API to access latest cached value for a Property.  A Property is created from a PropertyFactory
- * that is normally bound to a top level configuration.  
+ * API for composeable property access with optional chaining with default value support
+ * as well as change notification.
+ * 
+ * A {@link PropertyFactory} implementation normally implements some level of caching
+ * to reduce the overhead of interpolating and converting values.
  * 
  * {@code 
  * class MyService {
  *     private final Property<String> prop;
  *     
  *     MyService(PropertyFactory factory) {
- *        prop = factory.getProperty("foo.prop").asString("defaultValue");
+ *        prop = factory.getProperty("foo.prop").orElse("defaultValue");
  *     }
  *     
  *     public void doSomething() {
@@ -33,14 +40,9 @@ package com.netflix.archaius.api;
  * }
  * }
  * 
- * TODO: Chain properties
- * TODO: Property validator
- * 
- * @author elandau
- *
  * @param <T>
  */
-public interface Property<T> {
+public interface Property<T> extends Supplier<T> {
     /**
      * Return the most recent value of the property.  
      * 
@@ -52,13 +54,75 @@ public interface Property<T> {
      * Add a listener that will be called whenever the property value changes
      * @param listener
      */
-    void addListener(PropertyListener<T> listener);
+    @Deprecated
+    default void addListener(PropertyListener<T> listener) {
+        onChange(new Consumer<T>() {
+            @Override
+            public void accept(T t) {
+                listener.accept(t);
+            }
+        });
+    }
 
     /**
      * Remove a listener previously registered by calling addListener
      * @param listener
      */
-    void removeListener(PropertyListener<T> listener);
+    @Deprecated
+    default void removeListener(PropertyListener<T> listener) {}
+    
+    /**
+     * Register for notification whenever the property value changes.
+     * {@link Property#onChange(Consumer)} should be called last when chaining properties
+     * since the notification only applies to the state of the chained property
+     * up until this point. Changes to subsequent Property objects returned from {@link Property#orElse} 
+     * or {@link Property#map(Function)} will not trigger calls to this consumer.
+     * @param consumer
+     * @return This property object
+     */
+    default void onChange(Consumer<T> consumer) {
+        addListener(new PropertyListener<T>() {
+            @Override
+            public void onChange(T value) {
+                consumer.accept(value);
+            }
+        });
+    }
+    
+    /**
+     * Create a new Property object that will return the specified defaultValue if
+     * this object's property is not found.
+     * @param defaultValue
+     * @return Newly constructed Property object
+     */
+    default Property<T> orElse(T defaultValue) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Create a new Property object that will fetch the property backed by the provided
+     * key.  The return value of the supplier will be cached until the configuration has changed
+     * 
+     * @param delegate
+     * @return Newly constructed Property object
+     */
+    default Property<T> orElseGet(String key) {
+        throw new UnsupportedOperationException();
+    }
+    
+    /**
+     * Create a new Property object that will map the current object's property value
+     * to a new type.  The return value of the mapper will be cached until the 
+     * configuration has changed.  
+     * 
+     * Note that no orElseGet() calls may be made on a mapped property
+     * 
+     * @param delegate
+     * @return Newly constructed Property object
+     */
+    default <S> Property<S> map(Function<T, S> mapper) {
+        throw new UnsupportedOperationException();
+    }
     
     /**
      * @return Key or path to the property 

--- a/archaius2-api/src/main/java/com/netflix/archaius/api/PropertyContainer.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/api/PropertyContainer.java
@@ -26,10 +26,8 @@ import java.util.function.Function;
  * of Property are non-blocking and optimize updating property values 
  * in the background so as not to incur any overhead during hot call
  * paths.
- * 
- * @author elandau
- *
  */
+@Deprecated
 public interface PropertyContainer {
     /**
      * Parse the property as a string 

--- a/archaius2-api/src/main/java/com/netflix/archaius/api/PropertyFactory.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/api/PropertyFactory.java
@@ -15,14 +15,14 @@
  */
 package com.netflix.archaius.api;
 
-
 /**
- * Factory of PropertyContainer objects.
+ * Factory of Property objects.
  * 
- * @see PropertyContainer
- * @author elandau
+ * @see Property
+ * @deprecated Deprecated in favor of using PropertyRepository
  */
-public interface PropertyFactory {
+@Deprecated
+public interface PropertyFactory extends PropertyRepository {
     /**
      * Create a property for the property name.  
      */

--- a/archaius2-api/src/main/java/com/netflix/archaius/api/PropertyListener.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/api/PropertyListener.java
@@ -15,27 +15,32 @@
  */
 package com.netflix.archaius.api;
 
+import java.util.function.Consumer;
+
 /**
  * Handler for property change notifications for a single property key
  * 
- * @see {@link DefaultAppConfig} for usage example
- * 
- * @author elandau
- *
  * @param <T>
  */
-public interface PropertyListener<T> {
+public interface PropertyListener<T> extends Consumer<T> {
     /**
      * Notification that the property value changed.  next=null indicates that the property
      * has been deleted.
      * 
      * @param value The new value for the property.
      */
-    public void onChange(T value);
+    @Deprecated
+    void onChange(T value);
+    
+    default void accept(T value) {
+        onChange(value);
+    }
     
     /**
      * Notification that a property update failed
      * @param error
+     * @deprecated This method isn't actually used by anyone.  Parse errors will be handled in Config
      */
-    public void onParseError(Throwable error);
+    @Deprecated
+    default void onParseError(Throwable error) {};
 }

--- a/archaius2-api/src/main/java/com/netflix/archaius/api/PropertyRepository.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/api/PropertyRepository.java
@@ -1,0 +1,16 @@
+package com.netflix.archaius.api;
+
+public interface PropertyRepository {
+    /**
+     * Fetch a property of a specific type.  A {@link Property} object is returned regardless of
+     * whether a key for it exists in the backing configuration.  The {@link Property} is attached
+     * to a dynamic configuration system and will have its value automatically updated
+     * whenever the backing configuration is updated.  Fallback properties and default values
+     * may be specified through the {@link Property} API.
+     * 
+     * @param key   Property name
+     * @param type  Type of property value
+     * @return
+     */
+    <T> Property<T> get(String key, Class<T> type);
+}

--- a/archaius2-core/src/main/java/com/netflix/archaius/DefaultPropertyFactory.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/DefaultPropertyFactory.java
@@ -1,17 +1,30 @@
 package com.netflix.archaius;
 
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.atomic.AtomicInteger;
-
 import com.netflix.archaius.api.Config;
 import com.netflix.archaius.api.ConfigListener;
+import com.netflix.archaius.api.Property;
 import com.netflix.archaius.api.PropertyContainer;
 import com.netflix.archaius.api.PropertyFactory;
-import com.netflix.archaius.property.DefaultPropertyContainer;
-import com.netflix.archaius.property.ListenerManager;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicStampedReference;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DefaultPropertyFactory implements PropertyFactory, ConfigListener {
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultPropertyFactory.class);
+    
     /**
      * Create a Property factory that is attached to a specific config
      * @param config
@@ -29,20 +42,20 @@ public class DefaultPropertyFactory implements PropertyFactory, ConfigListener {
     /**
      * Cache of properties so PropertyContainer may be re-used
      */
-    private final ConcurrentMap<String, PropertyContainer> cache = new ConcurrentHashMap<String, PropertyContainer>();
+    private final ConcurrentMap<KeyAndType<?>, Property<?>> properties = new ConcurrentHashMap<>();
     
     /**
      * Monotonically incrementing version number whenever a change in the Config
      * is identified.  This version is used as a global dirty flag indicating that
      * properties should be updated when fetched next.
      */
-    private final AtomicInteger version = new AtomicInteger();
+    private final AtomicInteger masterVersion = new AtomicInteger();
     
     /**
      * Array of all active callbacks.  ListenerWrapper#update will be called for any
      * change in config.  
      */
-    private final ListenerManager listeners = new ListenerManager();
+    private final List<Runnable> listeners = new CopyOnWriteArrayList<>();
     
     public DefaultPropertyFactory(Config config) {
         this.config = config;
@@ -51,16 +64,69 @@ public class DefaultPropertyFactory implements PropertyFactory, ConfigListener {
 
     @Override
     public PropertyContainer getProperty(String propName) {
-        PropertyContainer container = cache.get(propName);
-        if (container == null) {
-            container = new DefaultPropertyContainer(propName, config, version, listeners);
-            PropertyContainer existing = cache.putIfAbsent(propName, container);
-            if (existing != null) {
-                return existing;
+        return new PropertyContainer() {
+            @Override
+            public Property<String> asString(String defaultValue) {
+                return get(propName, String.class).orElse(defaultValue);
             }
-        }
-        
-        return container;
+
+            @Override
+            public Property<Integer> asInteger(Integer defaultValue) {
+                return get(propName, Integer.class).orElse(defaultValue);
+            }
+
+            @Override
+            public Property<Long> asLong(Long defaultValue) {
+                return get(propName, Long.class).orElse(defaultValue);
+            }
+
+            @Override
+            public Property<Double> asDouble(Double defaultValue) {
+                return get(propName, Double.class).orElse(defaultValue);
+            }
+
+            @Override
+            public Property<Float> asFloat(Float defaultValue) {
+                return get(propName, Float.class).orElse(defaultValue);
+            }
+
+            @Override
+            public Property<Short> asShort(Short defaultValue) {
+                return get(propName, Short.class).orElse(defaultValue);
+            }
+
+            @Override
+            public Property<Byte> asByte(Byte defaultValue) {
+                return get(propName, Byte.class).orElse(defaultValue);
+            }
+
+            @Override
+            public Property<Boolean> asBoolean(Boolean defaultValue) {
+                return get(propName, Boolean.class).orElse(defaultValue);
+            }
+
+            @Override
+            public Property<BigDecimal> asBigDecimal(BigDecimal defaultValue) {
+                return get(propName, BigDecimal.class).orElse(defaultValue);
+            }
+
+            @Override
+            public Property<BigInteger> asBigInteger(BigInteger defaultValue) {
+                return get(propName, BigInteger.class).orElse(defaultValue);
+            }
+
+            @Override
+            public <T> Property<T> asType(Class<T> type, T defaultValue) {
+                return get(propName, type).orElse(defaultValue);
+            }
+
+            @Override
+            public <T> Property<T> asType(Function<String, T> mapper, String defaultValue) {
+                return getFromSupplier(propName, null, () ->
+                    mapper.apply(Optional.ofNullable(config.getString(propName)).orElse(defaultValue))
+                );
+            }
+        };
     }
     
     @Override
@@ -86,15 +152,163 @@ public class DefaultPropertyFactory implements PropertyFactory, ConfigListener {
     public void invalidate() {
         // Incrementing the version will cause all PropertyContainer instances to invalidate their
         // cache on the next call to get
-        version.incrementAndGet();
+        masterVersion.incrementAndGet();
         
         // We expect a small set of callbacks and invoke all of them whenever there is any change
         // in the configuration regardless of change. The blanket update is done since we don't track
         // a dependency graph of replacements.
-        listeners.updateAll();
+        listeners.forEach(Runnable::run);
     }
     
     protected Config getConfig() {
         return this.config;
+    }
+
+    @Override
+    public <T> Property<T> get(String key, Class<T> type) {
+        return getFromSupplier(key, type, () -> config.get(type, key, null));
+    }
+    
+    private <T> Property<T> getFromSupplier(String key, Class<T> type, Supplier<T> supplier) {
+        return getFromSupplier(new KeyAndType<T>(key, type), supplier);
+    }
+        
+    @SuppressWarnings("unchecked")
+    private <T> Property<T> getFromSupplier(KeyAndType<T> keyAndType, Supplier<T> supplier) {
+        return (Property<T>) properties.computeIfAbsent(keyAndType, (ignore) -> new PropertyImpl<T>(keyAndType, supplier));
+    }
+    
+    private class PropertyImpl<T> implements Property<T> {
+        private final KeyAndType<T> keyAndType;
+        private final Supplier<T> supplier;
+        private final AtomicStampedReference<T> cache = new AtomicStampedReference<>(null, -1);
+
+        public PropertyImpl(KeyAndType<T> keyAndType, Supplier<T> supplier) {
+            this.keyAndType = keyAndType;
+            this.supplier = supplier;
+        }
+        
+        @Override
+        public T get() {
+            int cacheVersion = cache.getStamp();
+            int latestVersion  = masterVersion.get();
+            
+            if (cacheVersion != latestVersion) {
+                T currentValue = cache.getReference();
+                T newValue = null;
+                try {
+                    newValue = supplier.get();
+                } catch (Exception e) {
+                    LOG.warn("Unable to get current version of property '{}'", keyAndType.key, e);
+                }
+                
+                if (cache.compareAndSet(currentValue, newValue, cacheVersion, latestVersion)) {
+                    // Slight race condition here but not important enough to warrent locking
+                    return newValue;
+                }
+            }
+            return cache.getReference();
+        }
+
+        @Override
+        public String getKey() {
+            return keyAndType.key;
+        }
+        
+        @Override
+        public void onChange(Consumer<T> consumer) {
+            listeners.add(new Runnable() {
+                private T current = get();
+                @Override
+                public synchronized void run() {
+                    T newValue = get();
+                    if (current == newValue && current == null) {
+                        return;
+                    } else if (current == null) {
+                        current = newValue;
+                    } else if (newValue == null) {
+                        current = null;
+                    } else if (current.equals(newValue)) {
+                        return;
+                    } else {
+                        current = newValue;
+                    }
+                    consumer.accept(current);
+                }
+            });
+        }
+
+        @Override
+        public Property<T> orElse(T defaultValue) {
+            return new PropertyImpl<T>(keyAndType, () -> Optional.ofNullable(supplier.get()).orElse(defaultValue));
+        }
+        
+        @Override
+        public Property<T> orElseGet(String key) {
+            if (!keyAndType.hasType()) {
+                throw new IllegalStateException("Type information lost due to map() operation.  All calls to orElse[Get] must be made prior to calling map");
+            }
+            KeyAndType<T> keyAndType = this.keyAndType.withKey(key);
+            Property<T> next = DefaultPropertyFactory.this.get(key, keyAndType.type);
+            return new PropertyImpl<T>(keyAndType, () -> Optional.ofNullable(supplier.get()).orElseGet(next));
+        }
+        
+        @Override
+        public <S> Property<S> map(Function<T, S> mapper) {
+            return new PropertyImpl<S>(keyAndType.discardType(), () -> mapper.apply(supplier.get()));
+        }
+    }
+    
+    private static final class KeyAndType<T> {
+        private final String key;
+        private final Class<T> type;
+
+        public KeyAndType(String key, Class<T> type) {
+            this.key = key;
+            this.type = type;
+        }
+
+        public <S> KeyAndType<S> discardType() {
+            return new KeyAndType<S>(key, null);
+        }
+
+        public KeyAndType<T> withKey(String newKey) {
+            return new KeyAndType<T>(newKey, type);
+        }
+        
+        public boolean hasType() {
+            return type != null;
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + ((key == null) ? 0 : key.hashCode());
+            result = prime * result + ((type == null) ? 0 : type.hashCode());
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            KeyAndType other = (KeyAndType) obj;
+            if (key == null) {
+                if (other.key != null)
+                    return false;
+            } else if (!key.equals(other.key))
+                return false;
+            if (type == null) {
+                if (other.type != null)
+                    return false;
+            } else if (!type.equals(other.type))
+                return false;
+            return true;
+        }
     }
 }

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/AbstractConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/AbstractConfig.java
@@ -139,7 +139,7 @@ public abstract class AbstractConfig implements Config {
         }
 
         if (value instanceof String) {
-            return interpolator.create(getLookup()).resolve(value.toString());
+            return resolve((String)value);
         } else {
             return value.toString();
         }
@@ -153,7 +153,7 @@ public abstract class AbstractConfig implements Config {
         }
 
         if (value instanceof String) {
-            return interpolator.create(getLookup()).resolve(value.toString());
+            return resolve(value.toString());
         } else {
             return value.toString();
         }
@@ -254,17 +254,27 @@ public abstract class AbstractConfig implements Config {
         }
         if (rawProp instanceof String) {
             try {
-                String value = interpolator.create(getLookup()).resolve(rawProp.toString());
+                String value = resolve(rawProp.toString());
                 return decoder.decode(type, value);
             } catch (NumberFormatException e) {
                 return parseError(key, rawProp.toString(), e);
             }
-        } else if (type.isInstance(rawProp)) {
+        } else if (type.isInstance(rawProp) || type.isPrimitive()) {
             return (T)rawProp;
         } else {
             return parseError(key, rawProp.toString(),
                     new NumberFormatException("Property " + rawProp.toString() + " is of wrong format " + type.getCanonicalName()));
         }
+    }
+
+    @Override
+    public String resolve(String value) {
+        return interpolator.create(getLookup()).resolve(value);
+    }
+
+    @Override
+    public <T> T resolve(String value, Class<T> type) {
+        return getDecoder().decode(type, resolve(value));
     }
 
     @Override

--- a/archaius2-core/src/main/java/com/netflix/archaius/property/DefaultPropertyContainer.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/property/DefaultPropertyContainer.java
@@ -42,10 +42,8 @@ import java.util.function.Function;
  * 
  * Once created a PropertyContainer property cannot be removed.  However, listeners may be
  * added and removed. 
- * 
- * @author elandau
- *
  */
+@Deprecated
 public class DefaultPropertyContainer implements PropertyContainer {
     private final Logger LOG = LoggerFactory.getLogger(DefaultPropertyContainer.class);
     

--- a/archaius2-core/src/main/java/com/netflix/archaius/property/ListenerManager.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/property/ListenerManager.java
@@ -1,18 +1,16 @@
 package com.netflix.archaius.property;
 
+import com.netflix.archaius.api.PropertyListener;
+
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
-
-import com.netflix.archaius.api.PropertyListener;
 
 /**
  * Globally managed list of listeners.  Listeners are tracked globally as 
  * an optimization so it is not necessary to iterate through all property
  * containers when the listeners need to be invoked since the expectation
  * is to have far less listeners than property containers.
- * 
- * @author elandau
  */
 public class ListenerManager {
     public static interface ListenerUpdater {
@@ -35,8 +33,6 @@ public class ListenerManager {
     }
 
     public void updateAll() {
-        for (ListenerUpdater updater : updaters) {
-            updater.update();
-        }
+        updaters.forEach(ListenerUpdater::update);
     }
 }

--- a/archaius2-core/src/test/java/com/netflix/archaius/ProxyFactoryTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/ProxyFactoryTest.java
@@ -4,6 +4,15 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 
+import com.netflix.archaius.api.Config;
+import com.netflix.archaius.api.PropertyFactory;
+import com.netflix.archaius.api.annotations.Configuration;
+import com.netflix.archaius.api.annotations.DefaultValue;
+import com.netflix.archaius.api.annotations.PropertyName;
+import com.netflix.archaius.api.config.SettableConfig;
+import com.netflix.archaius.config.DefaultSettableConfig;
+import com.netflix.archaius.config.EmptyConfig;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -18,15 +27,6 @@ import javax.annotation.Nullable;
 
 import org.junit.Assert;
 import org.junit.Test;
-
-import com.netflix.archaius.api.Config;
-import com.netflix.archaius.api.PropertyFactory;
-import com.netflix.archaius.api.annotations.Configuration;
-import com.netflix.archaius.api.annotations.DefaultValue;
-import com.netflix.archaius.api.annotations.PropertyName;
-import com.netflix.archaius.api.config.SettableConfig;
-import com.netflix.archaius.config.DefaultSettableConfig;
-import com.netflix.archaius.config.EmptyConfig;
 
 public class ProxyFactoryTest {
     public static enum TestEnum {
@@ -177,6 +177,7 @@ public class ProxyFactoryTest {
         assertThat(a.getSubConfig().str(),      equalTo("str2"));
         assertThat(a.getSubConfigFromString().part1(), equalTo("a"));
         assertThat(a.getSubConfigFromString().part2(), equalTo("b"));
+        assertThat(a.getBaseBoolean(), equalTo(true));
 
         config.setProperty("prefix.subConfig.str", "str3");
         assertThat(a.getSubConfig().str(),      equalTo("str3"));

--- a/archaius2-core/src/test/java/com/netflix/archaius/property/PropertyTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/property/PropertyTest.java
@@ -15,13 +15,6 @@
  */
 package com.netflix.archaius.property;
 
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import org.junit.Assert;
-import org.junit.Test;
-
 import com.netflix.archaius.DefaultPropertyFactory;
 import com.netflix.archaius.api.Property;
 import com.netflix.archaius.api.PropertyFactory;
@@ -29,6 +22,18 @@ import com.netflix.archaius.api.PropertyListener;
 import com.netflix.archaius.api.config.SettableConfig;
 import com.netflix.archaius.api.exceptions.ConfigException;
 import com.netflix.archaius.config.DefaultSettableConfig;
+import com.netflix.archaius.config.MapConfig;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
 
 public class PropertyTest {
     static class MyService {
@@ -187,7 +192,7 @@ public class PropertyTest {
         DefaultPropertyFactory factory = DefaultPropertyFactory.from(config);
 
         Property<Integer> prop = factory.getProperty("foo").asInteger(123);
-        final AtomicInteger current = new AtomicInteger();
+        final AtomicReference<Integer> current = new AtomicReference<>();
         prop.addListener(new PropertyListener<Integer>() {
             @Override
             public void onChange(Integer value) {
@@ -200,14 +205,153 @@ public class PropertyTest {
         });
         current.set(prop.get());
 
-        Assert.assertEquals(123, current.intValue());
+        Assert.assertEquals(123, current.get().intValue());
         config.setProperty("foo", 1);
-        Assert.assertEquals(1, current.intValue());
+        Assert.assertEquals(1, current.get().intValue());
         config.setProperty("foo", 2);
-        Assert.assertEquals(2, current.intValue());
+        Assert.assertEquals(2, current.get().intValue());
         config.clearProperty("foo");
-        Assert.assertEquals(123, current.intValue());
+        Assert.assertEquals(123, current.get().intValue());
         config.setProperty("foo", "${goo}");
-        Assert.assertEquals(456, current.intValue());
+        Assert.assertEquals(456, current.get().intValue());
+    }
+
+    @Test
+    public void chainedPropertyNoneSet() {
+        MapConfig config = MapConfig.builder().build();
+        DefaultPropertyFactory factory = DefaultPropertyFactory.from(config);
+
+        Property<Integer> prop = factory
+                .get("first", Integer.class)
+                .orElseGet("second");
+        
+        Assert.assertNull(prop.get());
+    }
+    
+    @Test
+    public void chainedPropertyDefault() {
+        SettableConfig config = new DefaultSettableConfig();
+        DefaultPropertyFactory factory = DefaultPropertyFactory.from(config);
+
+        Property<Integer> prop = factory
+                .get("first", Integer.class)
+                .orElseGet("second")
+                .orElse(3);
+        
+        Assert.assertEquals(3, prop.get().intValue());
+    }
+    
+    @Test
+    public void chainedPropertySecondSet() {
+        MapConfig config = MapConfig.builder().put("second", 2).build();
+        DefaultPropertyFactory factory = DefaultPropertyFactory.from(config);
+
+        Property<Integer> prop = factory
+                .get("first", Integer.class)
+                .orElseGet("second")
+                .orElse(3);
+        
+        Assert.assertEquals(2, prop.get().intValue());
+    }
+    
+    @Test
+    public void chainedPropertyFirstSet() {
+        MapConfig config = MapConfig.builder().put("first", 1).build();
+        DefaultPropertyFactory factory = DefaultPropertyFactory.from(config);
+
+        Property<Integer> prop = factory
+                .get("first", Integer.class)
+                .orElseGet("second")
+                .orElse(3);
+        
+        Assert.assertEquals(1, prop.get().intValue());
+    }
+    
+    @Test
+    public void chainedPropertyNotification() {
+        SettableConfig config = new DefaultSettableConfig();
+        config.setProperty("first", 1);
+        DefaultPropertyFactory factory = DefaultPropertyFactory.from(config);
+
+        Consumer<Integer> consumer = Mockito.mock(Consumer.class);
+        
+        Property<Integer> prop = factory
+                .get("first", Integer.class)
+                .orElseGet("second")
+                .orElse(3);
+        
+        prop.onChange(consumer);
+        
+        // Should not be called on register
+        Mockito.verify(consumer, Mockito.never()).accept(Mockito.any());
+        
+        // First changed
+        config.setProperty("first", 11);
+        Mockito.verify(consumer, Mockito.times(1)).accept(11);
+
+        // Unrelated change ignored
+        config.setProperty("foo", 11);
+        Mockito.verify(consumer, Mockito.times(1)).accept(11);
+
+        // Second changed has no effect because first is set
+        config.setProperty("second", 2);
+        Mockito.verify(consumer, Mockito.times(1)).accept(11);
+
+        // First cleared, second becomes value
+        config.clearProperty("first");
+        Mockito.verify(consumer, Mockito.times(1)).accept(2);
+        
+        // First cleared, default becomes value
+        config.clearProperty("second");
+        Mockito.verify(consumer, Mockito.times(1)).accept(3);
+    }
+    
+    @Test
+    public void testCache() {
+        SettableConfig config = new DefaultSettableConfig();
+        config.setProperty("foo", "1");
+        DefaultPropertyFactory factory = DefaultPropertyFactory.from(config);
+        
+        Function<String, Integer> mapper = Mockito.spy(new Function<String, Integer>() {
+            @Override
+            public Integer apply(String t) {
+                return Integer.parseInt(t);
+            }
+        });
+        
+        Property<Integer> prop = factory.get("foo", String.class)
+                .map(mapper);
+        
+        Mockito.verify(mapper, Mockito.never()).apply(Mockito.anyString());
+        
+        Assert.assertEquals(1, prop.get().intValue());
+        Mockito.verify(mapper, Mockito.times(1)).apply("1");
+        
+        Assert.assertEquals(1, prop.get().intValue());
+        Mockito.verify(mapper, Mockito.times(1)).apply("1");
+
+        config.setProperty("foo", "2");
+        
+        Assert.assertEquals(2, prop.get().intValue());
+        Mockito.verify(mapper, Mockito.times(1)).apply("1");
+        Mockito.verify(mapper, Mockito.times(1)).apply("2");
+        
+        config.setProperty("bar", "3");
+        Assert.assertEquals(2, prop.get().intValue());
+        Mockito.verify(mapper, Mockito.times(1)).apply("1");
+        Mockito.verify(mapper, Mockito.times(2)).apply("2");
+    }
+    
+    @Test(expected=IllegalStateException.class)
+    public void mapDiscardsType() {
+        MapConfig config = MapConfig.builder().build();
+        DefaultPropertyFactory factory = DefaultPropertyFactory.from(config);
+        
+        Property<Integer> prop = factory
+                .get("first", String.class)
+                .orElseGet("second")
+                .map(Integer::parseInt)
+                .orElseGet("third")
+                ;
     }
 }

--- a/archaius2-guice/src/main/java/com/netflix/archaius/guice/InternalArchaiusModule.java
+++ b/archaius2-guice/src/main/java/com/netflix/archaius/guice/InternalArchaiusModule.java
@@ -17,6 +17,7 @@ import com.netflix.archaius.api.ConfigLoader;
 import com.netflix.archaius.api.ConfigReader;
 import com.netflix.archaius.api.Decoder;
 import com.netflix.archaius.api.PropertyFactory;
+import com.netflix.archaius.api.PropertyRepository;
 import com.netflix.archaius.api.config.CompositeConfig;
 import com.netflix.archaius.api.config.SettableConfig;
 import com.netflix.archaius.api.exceptions.ConfigException;
@@ -227,6 +228,12 @@ final class InternalArchaiusModule extends AbstractModule {
     @Singleton
     PropertyFactory getPropertyFactory(Config config) {
         return DefaultPropertyFactory.from(config);
+    }
+    
+    @Provides
+    @Singleton
+    PropertyRepository getPropertyRespository(PropertyFactory propertyFactory) {
+        return propertyFactory;
     }
 
     @Provides


### PR DESCRIPTION
## Overview
Refactor the Property/PropertyFactory API so it uses standard interfaces (Supplier, Consumer) and make it composable using an API very similar to Java's Optional.

## Sample usage

### Simple cached property
```
Property<Integer> prop = factory.get("property.name", Integer.class);
Integer currentValue = prop.get();
```

### Cached property with fallback
First looks for value of `property.name` and then `property.other` if null.  

```
Property<Integer> prop = factory
    .get("property.name", Integer.class)
    .orElseGet("property.other");
Integer currentValue = prop.get();
```

### Cached property with fallback and default
```
Property<Integer> prop = factory
    .get("property.name", Integer.class)
    .orElseGet("property.other")
    .orElse(1);
Integer currentValue = prop.get();
```

### Change listener
The listener will only be invoked if the actual value changed. 

```
Property<Integer> prop = factory
    .get("property.name", Integer.class)
    .orElseGet("property.other")
    .orElse(1);

prop.onChange(newValue -> System.out.println("New value : " + newValue));
```

## Additional changes needed,
- Introduce `Config#resolve` to interpolate any string directly.  This addresses some hacks around interpolating default values
- Deprecate PropertyContainer
- Deprecate PropertyFactory (replace with PropertyRepository)
- PropertyListener now extends Consumer<T> and onParseError is deprecated so PropertyListener can eventually become a functional interface

