### PR TITLE
API to unsubscribe to property change notifications

### DIFF
--- a/archaius2-api/src/main/java/com/netflix/archaius/api/Property.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/api/Property.java
@@ -44,6 +44,14 @@ import java.util.function.Supplier;
  */
 public interface Property<T> extends Supplier<T> {
     /**
+     * Token returned when calling onChange through which change notification can be
+     * unsubscribed.  
+     */
+    interface Subscription {
+        void unsubscribe();
+    }
+    
+    /**
      * Return the most recent value of the property.  
      * 
      * @return  Most recent value for the property
@@ -77,16 +85,20 @@ public interface Property<T> extends Supplier<T> {
      * since the notification only applies to the state of the chained property
      * up until this point. Changes to subsequent Property objects returned from {@link Property#orElse} 
      * or {@link Property#map(Function)} will not trigger calls to this consumer.
+
      * @param consumer
-     * @return This property object
+     * @return Subscription that may be unsubscribed to no longer get change notifications
      */
-    default void onChange(Consumer<T> consumer) {
-        addListener(new PropertyListener<T>() {
+    default Subscription onChange(Consumer<T> consumer) {
+        PropertyListener<T> listener = new PropertyListener<T>() {
             @Override
             public void onChange(T value) {
                 consumer.accept(value);
             }
-        });
+        };
+        
+        addListener(listener);
+        return () -> removeListener(listener);
     }
     
     /**

--- a/archaius2-api/src/main/java/com/netflix/archaius/api/Property.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/api/Property.java
@@ -80,7 +80,16 @@ public interface Property<T> extends Supplier<T> {
     default void removeListener(PropertyListener<T> listener) {}
     
     /**
-     * Register for notification whenever the property value changes.
+     * @deprecated Use {@link Property#subscribe(Consumer)}
+     * @param consumer
+     */
+    @Deprecated
+    default Subscription onChange(Consumer<T> consumer) {
+        return subscribe(consumer);
+    }
+    
+    /**
+     * Subscribe for notification whenever the property value changes.
      * {@link Property#onChange(Consumer)} should be called last when chaining properties
      * since the notification only applies to the state of the chained property
      * up until this point. Changes to subsequent Property objects returned from {@link Property#orElse} 
@@ -89,7 +98,7 @@ public interface Property<T> extends Supplier<T> {
      * @param consumer
      * @return Subscription that may be unsubscribed to no longer get change notifications
      */
-    default Subscription onChange(Consumer<T> consumer) {
+    default Subscription subscribe(Consumer<T> consumer) {
         PropertyListener<T> listener = new PropertyListener<T>() {
             @Override
             public void onChange(T value) {

--- a/archaius2-core/src/main/java/com/netflix/archaius/DefaultPropertyFactory.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/DefaultPropertyFactory.java
@@ -228,7 +228,7 @@ public class DefaultPropertyFactory implements PropertyFactory, ConfigListener {
         }
         
         @Override
-        public Subscription onChange(Consumer<T> consumer) {
+        public Subscription subscribe(Consumer<T> consumer) {
             Runnable action = new Runnable() {
                 private T current = get();
                 @Override


### PR DESCRIPTION
Sample usage

```
Property<Integer> prop = registry.get("foo", Integer.class);
Subscription subscription = prop.onChange((newValue) -> System.out.println("new value: " + newValue));
```
To unsubscribe

````
subscription.unsubscribe();
```