### PR TITLE
Property proxying of Map type

### DIFF
--- a/archaius2-core/src/main/java/com/netflix/archaius/ConfigProxyFactory.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/ConfigProxyFactory.java
@@ -1,5 +1,14 @@
 package com.netflix.archaius;
 
+import com.netflix.archaius.api.Config;
+import com.netflix.archaius.api.Decoder;
+import com.netflix.archaius.api.Property;
+import com.netflix.archaius.api.PropertyFactory;
+import com.netflix.archaius.api.PropertyRepository;
+import com.netflix.archaius.api.annotations.Configuration;
+import com.netflix.archaius.api.annotations.DefaultValue;
+import com.netflix.archaius.api.annotations.PropertyName;
+
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Constructor;
@@ -27,15 +36,6 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 
 import org.apache.commons.lang3.text.StrSubstitutor;
-
-import com.netflix.archaius.api.Config;
-import com.netflix.archaius.api.Decoder;
-import com.netflix.archaius.api.Property;
-import com.netflix.archaius.api.PropertyFactory;
-import com.netflix.archaius.api.PropertyRepository;
-import com.netflix.archaius.api.annotations.Configuration;
-import com.netflix.archaius.api.annotations.DefaultValue;
-import com.netflix.archaius.api.annotations.PropertyName;
 
 /**
  * Factory for binding a configuration interface to properties in a {@link PropertyFactory}
@@ -386,16 +386,12 @@ public class ConfigProxyFactory {
                 .map(s -> {
                     if (s == null) 
                         return null;
-                    T result = Arrays
+                    T result = mapFactory.get();
+                    Arrays
                         .stream(s.split("\\s*,\\s*"))
                         .filter(pair -> !pair.isEmpty())
                         .map(pair -> pair.split("\\s*=\\s*"))
-                        .collect(Collectors.toMap(
-                                a -> decoder.decode(keyType, a[0]), 
-                                a -> decoder.decode(valueType, a[1]), 
-                                (v1, v2) -> v2,
-                                mapFactory
-                                ));
+                        .forEach(kv -> result.put(decoder.decode(keyType, kv[0]), decoder.decode(valueType, kv[1])));
                     return (T)Collections.unmodifiableMap(result);
                 }
                 ).orElse((T) Collections.unmodifiableMap(next.get()));

--- a/archaius2-core/src/main/java/com/netflix/archaius/ConfigProxyFactory.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/ConfigProxyFactory.java
@@ -1,14 +1,5 @@
 package com.netflix.archaius;
 
-import com.netflix.archaius.api.Config;
-import com.netflix.archaius.api.Decoder;
-import com.netflix.archaius.api.Property;
-import com.netflix.archaius.api.PropertyFactory;
-import com.netflix.archaius.api.PropertyRepository;
-import com.netflix.archaius.api.annotations.Configuration;
-import com.netflix.archaius.api.annotations.DefaultValue;
-import com.netflix.archaius.api.annotations.PropertyName;
-
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Constructor;
@@ -19,22 +10,32 @@ import java.lang.reflect.Proxy;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
 import org.apache.commons.lang3.text.StrSubstitutor;
+
+import com.netflix.archaius.api.Config;
+import com.netflix.archaius.api.Decoder;
+import com.netflix.archaius.api.Property;
+import com.netflix.archaius.api.PropertyFactory;
+import com.netflix.archaius.api.PropertyRepository;
+import com.netflix.archaius.api.annotations.Configuration;
+import com.netflix.archaius.api.annotations.DefaultValue;
+import com.netflix.archaius.api.annotations.PropertyName;
 
 /**
  * Factory for binding a configuration interface to properties in a {@link PropertyFactory}
@@ -313,10 +314,8 @@ public class ConfigProxyFactory {
     
                 propertyNames.put(m, propName);
                 
-                // For sub-interfaces create a proxy instance where the same proxy instance is returned but its
-                // methods can still return dynamic values
                 if (returnType.equals(Map.class)) {
-                    invoker = createMapProperty(propName, (ParameterizedType)m.getGenericReturnType(), immutable, defaultSupplier);
+                    invoker = createMapProperty(propName, (ParameterizedType)m.getGenericReturnType(), LinkedHashMap::new, defaultSupplier);
                 } else if (returnType.equals(Set.class)) {
                     invoker = createCollectionProperty(propName, (ParameterizedType)m.getGenericReturnType(), LinkedHashSet::new, defaultSupplier);
                 } else if (returnType.equals(SortedSet.class)) {
@@ -351,76 +350,59 @@ public class ConfigProxyFactory {
     }
     
     private static <T> Supplier<T> memoize(T value) {
-    	return () -> value;
+        return () -> value;
     }
     
     @SuppressWarnings({ "rawtypes", "unchecked" })
-	private <T> MethodInvoker<T> createCollectionProperty(String propName, ParameterizedType type, Supplier<Collection> collectionFactory, Supplier<T> next) {
-        final Class<?> valueType = (Class<?>)type.getActualTypeArguments()[0];
+	private <T> MethodInvoker<T> createCollectionProperty(String propName, ParameterizedType type, Supplier<Collection<T>> collectionFactory, Supplier<T> next) {
+        final Class valueType = (Class) type.getActualTypeArguments()[0];
         final Property<T> prop = propertyRepository
                 .get(propName, String.class)
-                .map(s -> { 
-                  if (s != null) {
-                      Collection list = collectionFactory.get();
-                      if (!s.isEmpty()) {
-                          Arrays.asList(s.split("\\s*,\\s*")).forEach(v -> {
-                              if (!v.isEmpty() || valueType == String.class) { 
-                                  list.add(decoder.decode(valueType, v));
-                              }
-                          });
-                      }
-                      return (T)list;
-                  } else {
-                      return null;
-                  }
-              });
-        
-        return new MethodInvoker<T>() {
-			@Override
-            public T invoke(Object[] args) {
-                T value = prop.get();
-                if (value == null) {
-                    value = next.get();
-                }
-                if (value == null) {
-                    value = (T) collectionFactory.get();
-                }
-                return value;
-            }
-        };
-    }
-
-    @SuppressWarnings("unchecked")
-    private <T> MethodInvoker<T> createMapProperty(final String propName, final ParameterizedType type, final boolean immutable, Supplier<T> next) {
-        final Class<?> valueType = (Class<?>)type.getActualTypeArguments()[1];
-        Map<String, Object> map;
-        // This is a map for String -> Interface so create a proxy for any value
-        if (valueType.isInterface()) {
-            map = new ReadOnlyMap<String, Object>() {
-                Map<String, Object> lookup = new ConcurrentHashMap<String, Object>();
-                @Override
-                public Object get(final Object key) {
-                    return lookup.computeIfAbsent((String) key, new Function<String, Object>() {
-                        @Override
-                        public Object apply(String key) {
-                            return newProxy(valueType, propName + "." + key, immutable);
+                .map(s -> {
+                    if (s != null) {
+                        Collection list = collectionFactory.get();
+                        if (!s.isEmpty()) {
+                            Arrays.asList(s.split("\\s*,\\s*")).forEach(v -> {
+                                if (!v.isEmpty() || valueType == String.class) {
+                                    list.add(decoder.decode(valueType, v));
+                                }
+                            });
                         }
-                    });
-                }
-            };
-        } else {
-        // This is a map of String -> DecodableType (i.e. String, Long, etc...) 
-            map = new ReadOnlyMap<String, Object>() {
-                @Override
-                public Object get(final Object key) {
-                    return config.get(valueType, propName + "." + key);
-                }
-            };
-        }
+                        return (T) list;
+                    } else {
+                        return next.get();
+                    }
+                });
         
-        return (MethodInvoker<T>) createInterfaceProperty(propName, map, (Supplier<Map<String, Object>>)next);
+        return args -> Optional.ofNullable(prop.get()).orElseGet((Supplier<? extends T>) collectionFactory);
     }
 
+    private <T extends Map> MethodInvoker<T> createMapProperty(final String propName, final ParameterizedType type, Supplier<T> mapFactory, Supplier<T> next) {
+        final Class<?> keyType = (Class<?>)type.getActualTypeArguments()[0];
+        final Class<?> valueType = (Class<?>)type.getActualTypeArguments()[1];
+        
+        final Property<T> prop = propertyRepository
+                .get(propName, String.class)
+                .map(s -> {
+                    if (s == null) 
+                        return null;
+                    T result = Arrays
+                        .stream(s.split("\\s*,\\s*"))
+                        .filter(pair -> !pair.isEmpty())
+                        .map(pair -> pair.split("\\s*=\\s*"))
+                        .collect(Collectors.toMap(
+                                a -> decoder.decode(keyType, a[0]), 
+                                a -> decoder.decode(valueType, a[1]), 
+                                (v1, v2) -> v2,
+                                mapFactory
+                                ));
+                    return (T)Collections.unmodifiableMap(result);
+                }
+                ).orElse((T) Collections.unmodifiableMap(next.get()));
+
+        return args -> Optional.ofNullable(prop.get()).orElseGet(mapFactory);
+    }
+    
     protected <T> Supplier<T> defaultValueFromString(Class<T> type, String defaultValue) {
         return () -> decoder.decode(type, defaultValue);
     }
@@ -440,16 +422,7 @@ public class ConfigProxyFactory {
 
     protected <T> MethodInvoker<T> createScalarProperty(final Class<T> type, final String propName, Supplier<T> next) {
         final Property<T> prop = propertyRepository.get(propName, type);
-        return new MethodInvoker<T>() {
-            @Override
-            public T invoke(Object[] args) {
-                T result = prop.get();
-                if (result == null) {
-                    result = next.get();
-                }
-                return result;
-            }
-        };
+        return args -> Optional.ofNullable(prop.get()).orElseGet(next);
     }
     
     protected <T> MethodInvoker<T> createParameterizedProperty(final Class<T> returnType, final String propName, final String nameAnnot, Supplier<T> next) {


### PR DESCRIPTION
The ConfigProxyFactory currently attempts to bind a Map to multiple properties where the key is the next name part of a property prefix and the value maps to one or more properties.  This implementation turned out to be very error-prone and confusing to use.  

This PR making binding to Maps just like all other collections where the Map is parsed from a single property values with the format. `k1=v1,k2=v2,...`.