### PR TITLE
A way to disable default PropertiesConfigReader

### DIFF
--- a/archaius2-guice/src/main/java/com/netflix/archaius/guice/ArchaiusModule.java
+++ b/archaius2-guice/src/main/java/com/netflix/archaius/guice/ArchaiusModule.java
@@ -18,14 +18,17 @@ package com.netflix.archaius.guice;
 import java.util.Properties;
 
 import com.google.inject.AbstractModule;
+import com.google.inject.Scopes;
 import com.google.inject.binder.LinkedBindingBuilder;
 import com.google.inject.multibindings.Multibinder;
 import com.google.inject.name.Names;
 import com.netflix.archaius.api.CascadeStrategy;
 import com.netflix.archaius.api.Config;
+import com.netflix.archaius.api.ConfigReader;
 import com.netflix.archaius.api.inject.DefaultLayer;
 import com.netflix.archaius.api.inject.RemoteLayer;
 import com.netflix.archaius.config.MapConfig;
+import com.netflix.archaius.readers.PropertiesConfigReader;
 
 /**
  * Guice Module for enabling archaius and making its components injectable.  Installing this
@@ -239,8 +242,33 @@ public class ArchaiusModule extends AbstractModule {
         Multibinder.newSetBinder(binder(), String.class, ApplicationOverrideResources.class).permitDuplicates().addBinding().toInstance(overrideResource);
     }
 
+    /**
+     * Binding ConfigReaders has been removed from InternalArchaiusModule class which is locked for modification and it has been added to configure as overridable method.
+     * <br /><br />
+     * <b>For example to disable default PropertyConfigReader and add TypesafeConfigReader</b>
+     * <br />
+     * <code>
+     *     <pre>
+     * install(new ArchaiusModule() {
+     *    {@literal @}Override
+     *    protected void bindDefaultReaders() {}
+     *
+     *    {@literal @}Override
+     *    protected void configureArchaius() {
+     *          Multibinder.newSetBinder(this.binder(), ConfigReader.class).addBinding().to(TypesafeConfigReader.class).asEagerSingleton();
+     *    }
+     * });
+     * </pre>
+     * </code>
+     */
+    protected void bindDefaultReaders()  {
+        Multibinder.newSetBinder(binder(), ConfigReader.class)
+            .addBinding().to(PropertiesConfigReader.class).in(Scopes.SINGLETON);
+    }
+
     @Override
     protected final void configure() {
+        bindDefaultReaders();
         install(new InternalArchaiusModule());
       
         configureArchaius();

--- a/archaius2-guice/src/main/java/com/netflix/archaius/guice/InternalArchaiusModule.java
+++ b/archaius2-guice/src/main/java/com/netflix/archaius/guice/InternalArchaiusModule.java
@@ -33,6 +33,8 @@ import com.netflix.archaius.config.SystemConfig;
 import com.netflix.archaius.interpolate.ConfigStrLookup;
 import com.netflix.archaius.readers.PropertiesConfigReader;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -65,9 +67,6 @@ final class InternalArchaiusModule extends AbstractModule {
         bind(ConfigurationInjectingListener.class).toInstance(listener);
         requestStaticInjection(ConfigurationInjectingListener.class);
         bindListener(Matchers.any(), listener);
-        
-        Multibinder.newSetBinder(binder(), ConfigReader.class)
-            .addBinding().to(PropertiesConfigReader.class).in(Scopes.SINGLETON);
     }
 
     @Provides

--- a/archaius2-guice/src/main/java/com/netflix/archaius/guice/InternalArchaiusModule.java
+++ b/archaius2-guice/src/main/java/com/netflix/archaius/guice/InternalArchaiusModule.java
@@ -3,21 +3,13 @@ package com.netflix.archaius.guice;
 import com.google.inject.AbstractModule;
 import com.google.inject.Inject;
 import com.google.inject.Provides;
-import com.google.inject.Scopes;
 import com.google.inject.Singleton;
 import com.google.inject.matcher.Matchers;
-import com.google.inject.multibindings.Multibinder;
 import com.netflix.archaius.ConfigProxyFactory;
 import com.netflix.archaius.DefaultConfigLoader;
 import com.netflix.archaius.DefaultDecoder;
 import com.netflix.archaius.DefaultPropertyFactory;
-import com.netflix.archaius.api.CascadeStrategy;
-import com.netflix.archaius.api.Config;
-import com.netflix.archaius.api.ConfigLoader;
-import com.netflix.archaius.api.ConfigReader;
-import com.netflix.archaius.api.Decoder;
-import com.netflix.archaius.api.PropertyFactory;
-import com.netflix.archaius.api.PropertyRepository;
+import com.netflix.archaius.api.*;
 import com.netflix.archaius.api.config.CompositeConfig;
 import com.netflix.archaius.api.config.SettableConfig;
 import com.netflix.archaius.api.exceptions.ConfigException;
@@ -31,15 +23,11 @@ import com.netflix.archaius.config.DefaultSettableConfig;
 import com.netflix.archaius.config.EnvironmentConfig;
 import com.netflix.archaius.config.SystemConfig;
 import com.netflix.archaius.interpolate.ConfigStrLookup;
-import com.netflix.archaius.readers.PropertiesConfigReader;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.inject.Named;
 import javax.inject.Provider;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 final class InternalArchaiusModule extends AbstractModule {
     static final String CONFIG_NAME_KEY         = "archaius.config.name";


### PR DESCRIPTION
I find myself unable to disable default PropertiesConfigReader reader in InternalArchaiusModule which is package private and final.

I think more suitable place for default reader config is in ArchaiusModule as protected method.

So when I want to change PropertiesConfigReader for TypesafeConfigReader it would look like this:
```
install(new ArchaiusModule() {
@Override
protected void bindDefaultReaders() {}
@Override
protected void configureArchaius() {    Multibinder.newSetBinder(this.binder(),ConfigReader.class).addBinding().to(TypesafeConfigReader.class).asEagerSingleton();
}
});
```

Well I have another fix for TypesafeConfigReader that support Lists,Maps and Sets