### PR TITLE
fix inconsistent use of prefix in PrefixedViewConfig

### DIFF
--- a/archaius2-core/src/main/java/com/netflix/archaius/config/PrefixedViewConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/PrefixedViewConfig.java
@@ -47,32 +47,33 @@ public class PrefixedViewConfig extends AbstractConfig {
             data = new LinkedHashMap<String, Object>();
             config.forEachProperty((k, v) -> {
                 if (k.startsWith(prefix)) {
-                    data.put(k.substring(prefix.length()+1), v);
+                    data.put(k.substring(prefix.length()), v);
                 }
             });
         }
     }
     
     public PrefixedViewConfig(final String prefix, final Config config) {
+        final String normalizedPrefix = prefix.endsWith(".") ? prefix : prefix + ".";
+        this.prefix = normalizedPrefix;
         this.config = config;
-        this.prefix = prefix.endsWith(".") ? prefix : prefix + ".";
         this.nonPrefixedLookup = ConfigStrLookup.from(config);
-        this.state = new State(config, prefix);
+        this.state = new State(config, normalizedPrefix);
         
         this.config.addListener(new ConfigListener() {
             @Override
             public void onConfigAdded(Config config) {
-                state = new State(config, prefix);
+                state = new State(config, normalizedPrefix);
             }
 
             @Override
             public void onConfigRemoved(Config config) {
-                state = new State(config, prefix);
+                state = new State(config, normalizedPrefix);
             }
 
             @Override
             public void onConfigUpdated(Config config) {
-                state = new State(config, prefix);
+                state = new State(config, normalizedPrefix);
             }
 
             @Override

--- a/archaius2-core/src/test/java/com/netflix/archaius/config/PrefixedViewTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/PrefixedViewTest.java
@@ -11,6 +11,21 @@ import org.mockito.Mockito;
 
 public class PrefixedViewTest {
     @Test
+    public void confirmNormalizedPrefixOperation() throws ConfigException {
+        com.netflix.archaius.api.config.CompositeConfig config = DefaultCompositeConfig.builder()
+                .withConfig("foo", MapConfig.builder().put("foo.bar", "value").build())
+                .build();
+        
+        // this prefix does not end with a '.'
+        Config prefixWithOutDotConfig = config.getPrefixedView("foo");
+        Assert.assertEquals("value", prefixWithOutDotConfig.getString("bar"));
+        
+        // this prefix does end with a '.'
+        Config prefixWithDotConfig = config.getPrefixedView("foo.");
+        Assert.assertEquals("value", prefixWithDotConfig.getString("bar"));
+    }
+	
+    @Test
     public void confirmNotifactionOnAnyChange() throws ConfigException {
         com.netflix.archaius.api.config.CompositeConfig config = DefaultCompositeConfig.builder()
                 .withConfig("foo", MapConfig.builder().put("foo.bar", "value").build())


### PR DESCRIPTION
PrefixedViewConfig had inconsistent handling of the 'prefix' constructor arg; sometimes it used the raw value (passed into State) and sometimes it used the normalized value (modified to always end with a '.').  

Previously if the prefix constructor arg for PrefixedViewConfig ended with a '.', then property values returned via PrefixedViewConfig would be incorrect; too short by one character.