### PR TITLE
add timeout for URLConfigurationSource when retrieving configurations

### DIFF
--- a/archaius-core/src/main/java/com/netflix/config/sources/URLConfigurationSource.java
+++ b/archaius-core/src/main/java/com/netflix/config/sources/URLConfigurationSource.java
@@ -18,6 +18,7 @@ package com.netflix.config.sources;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.net.URLConnection;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -184,7 +185,10 @@ public class URLConfigurationSource implements PolledConfigurationSource {
         }
         Map<String, Object> map = new HashMap<String, Object>();
         for (URL url: configUrls) {
-            InputStream fin = url.openStream();
+            URLConnection conn = url.openConnection();
+            conn.setConnectTimeout(5000);
+            conn.setReadTimeout(5000);
+            InputStream fin = conn.getInputStream();
             Properties props = ConfigurationUtils.loadPropertiesFromInputStream(fin);
             for (Entry<Object, Object> entry: props.entrySet()) {
                 map.put((String) entry.getKey(), entry.getValue());


### PR DESCRIPTION
Hi, thanks for this great lib.

For this PR, I think we need to add a basic timeout when retrieving configurations in URLConfigurationSource. Because `openStream` method of `java.net.URL` will open a connection to the target URL without connection timeout or read timeout. If the target website or the connection have some issue, the thread using to poll configurations dynamically may be blocked forever and there's no any error log to let people notice this.

The hardcoding timeout value may seems inappropriate but I think it's OK because mostly archaius will be used in a stable environment with good network so this timeout is just a safety net and we don't even need to adjust it.