### PR TITLE
Upgrade guava version to 25 due to CVE-2018-10237

### DIFF
--- a/archaius-core/src/main/java/com/netflix/config/DefaultContextualPredicate.java
+++ b/archaius-core/src/main/java/com/netflix/config/DefaultContextualPredicate.java
@@ -68,4 +68,9 @@ public class DefaultContextualPredicate implements Predicate<Map<String, Collect
         return true;
 
     }
+
+    @Override
+    public boolean test(@Nullable Map<String, Collection<String>> input) {
+        return apply(input);
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ project(':archaius-core') {
     dependencies {
         compile 'commons-configuration:commons-configuration:1.8'
         compile 'org.slf4j:slf4j-api:1.6.4'
-        compile 'com.google.guava:guava:25.0'
+        compile 'com.google.guava:guava:25.1-jre'
         compile 'com.fasterxml.jackson.core:jackson-annotations:2.4.3'
         compile 'com.fasterxml.jackson.core:jackson-core:2.4.3'
         compile 'com.fasterxml.jackson.core:jackson-databind:2.4.3'
@@ -104,7 +104,7 @@ project(':archaius-etcd') {
 
     dependencies {
         compile project(':archaius-core')
-        compile 'com.google.guava:guava:25.0'
+        compile 'com.google.guava:guava:25.1-jre'
         compile 'io.fastjson:etcd-client:0.33'
         testCompile 'junit:junit:4.11'
         testCompile 'org.mockito:mockito-all:1.9.5'

--- a/build.gradle
+++ b/build.gradle
@@ -90,11 +90,11 @@ project(':archaius-zookeeper') {
             exclude group: 'com.sun.jmx', module: 'jmxri'
             exclude group: 'javax.jms', module: 'jms'
         }
-        compile 'org.apache.curator:curator-client:2.3.0'
-        compile 'org.apache.curator:curator-recipes:2.3.0'
+        compile 'org.apache.curator:curator-client:4.0.1'
+        compile 'org.apache.curator:curator-recipes:4.0.1'
         testCompile 'junit:junit:4.11'
         testCompile 'org.slf4j:slf4j-simple:1.6.4'
-        testCompile 'org.apache.curator:curator-test:2.3.0'
+        testCompile 'org.apache.curator:curator-test:4.0.1'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ project(':archaius-core') {
     dependencies {
         compile 'commons-configuration:commons-configuration:1.8'
         compile 'org.slf4j:slf4j-api:1.6.4'
-        compile 'com.google.guava:guava:16.0'
+        compile 'com.google.guava:guava:25.0'
         compile 'com.fasterxml.jackson.core:jackson-annotations:2.4.3'
         compile 'com.fasterxml.jackson.core:jackson-core:2.4.3'
         compile 'com.fasterxml.jackson.core:jackson-databind:2.4.3'

--- a/build.gradle
+++ b/build.gradle
@@ -104,7 +104,7 @@ project(':archaius-etcd') {
 
     dependencies {
         compile project(':archaius-core')
-        compile 'com.google.guava:guava:19.0'
+        compile 'com.google.guava:guava:25.0'
         compile 'io.fastjson:etcd-client:0.33'
         testCompile 'junit:junit:4.11'
         testCompile 'org.mockito:mockito-all:1.9.5'


### PR DESCRIPTION
There is a security vulnerability in guava, affecting all versions between 11.0 and 24.1 
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-10237