### PR TITLE
Allow for interpolation in default values

### DIFF
--- a/archaius2-core/src/main/java/com/netflix/archaius/interpolate/CommonsStrInterpolator.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/interpolate/CommonsStrInterpolator.java
@@ -35,6 +35,7 @@ public final class CommonsStrInterpolator implements StrInterpolator {
                       return lookup.lookup(key);
                   }
               }, "${", "}", '$').setValueDelimiter(":");
+        sub.setEnableSubstitutionInVariables(true);
 
         return new Context() {
             @Override

--- a/archaius2-core/src/test/java/com/netflix/archaius/config/InterpolationTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/InterpolationTest.java
@@ -96,4 +96,39 @@ public class InterpolationTest {
         Assert.assertEquals(123, prefixedConfig.getInteger("key1").intValue());
     }
 
+    @Test
+    public void nestedInterpolations() {
+        Config config = MapConfig.builder()
+                .put("a", "A")
+                .put("b", "${c:${a}}")
+                .build();
+
+        Assert.assertEquals("A", config.getString("b"));
+    }
+
+    @Test
+    public void nestedInterpolationsWithResolve() {
+        Config config = MapConfig.builder()
+                .put("a", "A")
+                .build();
+
+        Assert.assertEquals("A", config.resolve("${b:${c:${a}}}"));
+    }
+    
+    @Test(expected=IllegalStateException.class)
+    public void failOnCircularResolve() {
+        Config config = MapConfig.builder()
+                .build();
+
+        config.resolve("${b:${c:${b}}}");
+    }
+    
+    @Test
+    public void returnStringOnMissingInterpolation() {
+        Config config = MapConfig.builder()
+                .build();
+
+        Assert.assertEquals("${c}", config.resolve("${b:${c}}"));
+        
+    }
 }


### PR DESCRIPTION
This change enables interpolation of other properties in addition to static defaults.  For example, the property value `${someProperty:${someOtherProperty:staticDefault}}` will first replace the value of `someProperty`, if not found, will use the value of `someOtherProperty` and if that's not found replace with the static value `staticDefault`