### PR TITLE
Align dynamic config example with the actual API

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,7 @@ directly for fine grained configuration sources, such as ZooKeeper, which suppor
 at the individual property granularity.
 
 ```java
-config.addConfig(new PollingDynamicConfg(
-            "REMOTE", 
+config.addConfig("REMOTE", new PollingDynamicConfg(
             new URLConfigReader("http://remoteconfigservice/snapshot"), 
             new FixedPollingStrategy(30, TimeUnit.SECONDS)) 
 ```


### PR DESCRIPTION
The example shows how to register a dynamic config, yet the example differs from the actual API.
The config name should be provided to "addConfig", not to PollingDynamicConfig instantiation.