### PR TITLE
Fixing Javadoc duplicate with inheritDoc

### DIFF
--- a/archaius-core/src/main/java/com/netflix/config/DynamicListProperty.java
+++ b/archaius-core/src/main/java/com/netflix/config/DynamicListProperty.java
@@ -193,7 +193,7 @@ public abstract class DynamicListProperty<T> implements Property<List<T>> {
     protected abstract T from(String value);
     
     /**
-     * Getter for the property name
+     * {@inheritDoc}
      */
     @Override
     public String getName() {

--- a/archaius-core/src/main/java/com/netflix/config/DynamicSetProperty.java
+++ b/archaius-core/src/main/java/com/netflix/config/DynamicSetProperty.java
@@ -194,7 +194,7 @@ public abstract class DynamicSetProperty<T> implements Property<Set<T>> {
     protected abstract T from(String value);
 
     /**
-     * Getter for the property name
+     * {@inheritDoc}
      */
     @Override
     public String getName(){


### PR DESCRIPTION
I'm a PhD Student from University of Bordeaux working on documentation copy-pastes (duplicates).
I've noticed that your project does have a few documentation duplicates.
For my research work, i've tried to fix this duplicate and i'd love to have your feedback about it:

- Do you think that this duplicate documentation should co-evolve forever?
- Are you aware of copy-pastes in your documentation?
- If yes, how do you handle them?
- Were you aware of JavaDoc reuse features such as {@inheritdoc}?
- Would you like to have a tool that helps you maintain duplicate documentation?