### PR TITLE
Fix issue with config proxies and Map values

### DIFF
--- a/archaius2-core/src/main/java/com/netflix/archaius/ConfigProxyFactory.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/ConfigProxyFactory.java
@@ -382,6 +382,11 @@ public class ConfigProxyFactory {
     private <T extends Map> MethodInvoker<T> createMapProperty(final String propName, final ParameterizedType type, Supplier<T> mapFactory, Supplier<T> next) {
         final Class<?> keyType = (Class<?>)type.getActualTypeArguments()[0];
         final Class<?> valueType = (Class<?>)type.getActualTypeArguments()[1];
+
+        Map<?, ?> defaultValue = next.get();
+        if (defaultValue == null) {
+            defaultValue = Collections.emptyMap();
+        }
         
         final Property<T> prop = propertyRepository
                 .get(propName, String.class)
@@ -394,7 +399,7 @@ public class ConfigProxyFactory {
                         .forEach(kv -> result.put(decoder.decode(keyType, kv[0]), decoder.decode(valueType, kv[1])));
                     return (T)Collections.unmodifiableMap(result);
                 }
-                ).orElse((T) Collections.unmodifiableMap(next.get()));
+                ).orElse((T) Collections.unmodifiableMap(defaultValue));
 
         return args -> Optional.ofNullable(prop.get()).orElseGet(mapFactory);
     }

--- a/archaius2-core/src/test/java/com/netflix/archaius/ProxyFactoryTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/ProxyFactoryTest.java
@@ -210,11 +210,25 @@ public class ProxyFactoryTest {
         Assert.assertEquals("value2",  withArgs.getProperty("b", 2));
         Assert.assertEquals("default", withArgs.getProperty("a", 2));
     }
-    
+
+    public interface ConfigWithEmptyMap {
+        Map<String, String> getMap();
+    }
+
+    @Test
+    public void testWithEmptyMap() {
+        SettableConfig config = new DefaultSettableConfig();
+        PropertyFactory factory = DefaultPropertyFactory.from(config);
+        ConfigProxyFactory proxy = new ConfigProxyFactory(config, config.getDecoder(), factory);
+        ConfigWithEmptyMap withArgs = proxy.newProxy(ConfigWithEmptyMap.class);
+
+        Assert.assertTrue(withArgs.getMap().isEmpty());
+    }
+
     public static interface ConfigWithLongMap {
         default Map<String, Long> getMap() { return Collections.singletonMap("default", 0L); }
     }
-    
+
     @Test
     public void testWithLongMap() {
         SettableConfig config = new DefaultSettableConfig();


### PR DESCRIPTION
Because the ConfigProxyFactory evaluates the default value eagerly, an NPE is thrown for
Map properties when a null value is passed into Collections.unmodifiableMap, even if the
configuration is actually present and therefore the default is not needed.