### PR TITLE
Improved support for collection types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-- oraclejdk8
+- openjdk8
 sudo: false
 install: ./installViaTravis.sh
 script: ./buildViaTravis.sh

--- a/archaius2-api/src/main/java/com/netflix/archaius/api/Config.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/api/Config.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.archaius.api;
 
+import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Iterator;
@@ -25,7 +26,7 @@ import java.util.Optional;
  * Core API for reading a configuration.  The API is read only.
  */
 public interface Config extends PropertySource {
-    public interface Visitor<T> {
+    interface Visitor<T> {
         T visitKey(String key, Object value);
     }
     
@@ -115,7 +116,17 @@ public interface Config extends PropertySource {
      */
     <T> T get(Class<T> type, String key);
     <T> T get(Class<T> type, String key, T defaultValue);
-    
+
+    /**
+     * Get the property from the Decoder.  All basic data types as well any type
+     * will a valueOf or String contructor will be supported.
+     * @param type
+     * @param key
+     * @return
+     */
+    <T> T get(Type type, String key);
+    <T> T get(Type type, String key, T defaultValue);
+
     /**
      * @param key
      * @return True if the key is contained within this or any of it's child configurations

--- a/archaius2-api/src/main/java/com/netflix/archaius/api/Decoder.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/api/Decoder.java
@@ -27,7 +27,11 @@ public interface Decoder {
 	<T> T decode(Class<T> type, String encoded);
 
 	default <T> T decode(Type type, String value) {
-		return decode((Class<T>)type, value);
+		if (type instanceof Class) {
+			return decode((Class<T>)type, value);
+		} else {
+			throw new UnsupportedOperationException("This decoder " + getClass() + " does not support Type");
+		}
 	}
 
 }

--- a/archaius2-api/src/main/java/com/netflix/archaius/api/Decoder.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/api/Decoder.java
@@ -15,11 +15,19 @@
  */
 package com.netflix.archaius.api;
 
+import java.lang.reflect.Type;
+
 /**
  * API for decoding properties to arbitrary types.
  *
  * @author spencergibb
  */
 public interface Decoder {
+	@Deprecated
 	<T> T decode(Class<T> type, String encoded);
+
+	default <T> T decode(Type type, String value) {
+		return decode((Class<T>)type, value);
+	}
+
 }

--- a/archaius2-api/src/main/java/com/netflix/archaius/api/PropertyRepository.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/api/PropertyRepository.java
@@ -1,5 +1,7 @@
 package com.netflix.archaius.api;
 
+import java.lang.reflect.Type;
+
 public interface PropertyRepository {
     /**
      * Fetch a property of a specific type.  A {@link Property} object is returned regardless of
@@ -13,4 +15,6 @@ public interface PropertyRepository {
      * @return
      */
     <T> Property<T> get(String key, Class<T> type);
+
+    <T> Property<T> get(String key, Type type);
 }

--- a/archaius2-api/src/main/java/com/netflix/archaius/api/TypeConverter.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/api/TypeConverter.java
@@ -1,0 +1,33 @@
+package com.netflix.archaius.api;
+
+import java.lang.reflect.Type;
+import java.util.Optional;
+
+/**
+ * Encapsulates conversion of a single string value to a type
+ * @param <T>
+ */
+public interface TypeConverter<T> {
+    /**
+     * High level container from which to resolve a Type to a TypeConverter.  A repository normally contains
+     * several {@link TypeConverter.Factory}s
+     */
+    interface Registry {
+        Optional<TypeConverter<?>> get(Type type);
+    }
+
+    /**
+     * Factory used to resolve a type to a TypeConverter.  Multiple factories may be used to support different
+     * types, including generics.
+     */
+    interface Factory {
+        Optional<TypeConverter<?>> get(Type type, Registry registry);
+    }
+
+    /**
+     * Convert a string to the requested type
+     * @param value
+     * @return
+     */
+    T convert(String value);
+}

--- a/archaius2-core/src/main/java/com/netflix/archaius/ConfigProxyFactory.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/ConfigProxyFactory.java
@@ -16,11 +16,13 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Proxy;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
@@ -36,6 +38,8 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 
 import org.apache.commons.lang3.text.StrSubstitutor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Factory for binding a configuration interface to properties in a {@link PropertyFactory}
@@ -98,6 +102,7 @@ import org.apache.commons.lang3.text.StrSubstitutor;
  * @see {@literal }@Configuration
  */
 public class ConfigProxyFactory {
+    private static final Logger LOG = LoggerFactory.getLogger(ConfigProxyFactory.class);
 
     /**
      * The decoder is used for the purpose of decoding any @DefaultValue annotation
@@ -165,7 +170,7 @@ public class ConfigProxyFactory {
      *
      * @param <T>
      */
-    static interface MethodInvoker<T> {
+    interface MethodInvoker<T> {
         /**
          * Invoke the method with the provided arguments
          * @param args
@@ -213,7 +218,17 @@ public class ConfigProxyFactory {
             return result;
         }
     }
-    
+
+    private static Map<Type, Supplier<?>> knownCollections = new HashMap<>();
+
+    static {
+        knownCollections.put(Map.class, Collections::emptyMap);
+        knownCollections.put(Set.class, Collections::emptySet);
+        knownCollections.put(SortedSet.class, Collections::emptySortedSet);
+        knownCollections.put(List.class, Collections::emptyList);
+        knownCollections.put(LinkedList.class, LinkedList::new);
+    }
+
     @SuppressWarnings({ "rawtypes", "unchecked" })
     <T> T newProxy(final Class<T> type, final String initialPrefix, boolean immutable) {
         Configuration annot = type.getAnnotation(Configuration.class);
@@ -286,7 +301,7 @@ public class ConfigProxyFactory {
                 
                 final Class<?> returnType = m.getReturnType();
                 
-                Supplier defaultSupplier = () -> null;
+                Supplier defaultSupplier = knownCollections.getOrDefault(returnType, () -> null);
                 
                 if (m.getAnnotation(DefaultValue.class) != null) {
                     if (m.isDefault()) {
@@ -319,17 +334,7 @@ public class ConfigProxyFactory {
     
                 propertyNames.put(m, propName);
                 
-                if (returnType.equals(Map.class)) {
-                    invoker = createMapProperty(propName, (ParameterizedType)m.getGenericReturnType(), LinkedHashMap::new, defaultSupplier);
-                } else if (returnType.equals(Set.class)) {
-                    invoker = createCollectionProperty(propName, (ParameterizedType)m.getGenericReturnType(), LinkedHashSet::new, defaultSupplier);
-                } else if (returnType.equals(SortedSet.class)) {
-                    invoker = createCollectionProperty(propName, (ParameterizedType)m.getGenericReturnType(), TreeSet::new, defaultSupplier);
-                } else if (returnType.equals(List.class)) {
-                    invoker = createCollectionProperty(propName, (ParameterizedType)m.getGenericReturnType(), ArrayList::new, defaultSupplier);
-                } else if (returnType.equals(LinkedList.class)) {
-                    invoker = createCollectionProperty(propName, (ParameterizedType)m.getGenericReturnType(), LinkedList::new, defaultSupplier);
-                } else if (returnType.isInterface()) {
+                if (!knownCollections.containsKey(returnType) && returnType.isInterface()) {
                     invoker = createInterfaceProperty(propName, newProxy(returnType, propName, immutable));
                 } else if (m.getParameterTypes() != null && m.getParameterTypes().length > 0) {
                     if (nameAnnot == null) {
@@ -337,7 +342,7 @@ public class ConfigProxyFactory {
                     }
                     invoker = createParameterizedProperty(returnType, propName, nameAnnot.name(), defaultSupplier);
                 } else {
-                    invoker = createScalarProperty(returnType, propName, defaultSupplier);
+                    invoker = createScalarProperty(m.getGenericReturnType(), propName, defaultSupplier);
                 }
                 
                 if (immutable) {
@@ -358,70 +363,19 @@ public class ConfigProxyFactory {
         return () -> value;
     }
     
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-	private <T> MethodInvoker<T> createCollectionProperty(String propName, ParameterizedType type, Supplier<Collection<T>> collectionFactory, Supplier<T> next) {
-        final Class valueType = (Class) type.getActualTypeArguments()[0];
-        final Property<T> prop = propertyRepository
-                .get(propName, String.class)
-                .map(s -> {
-                    Collection list = collectionFactory.get();
-                    if (!s.isEmpty()) {
-                        Arrays.asList(s.split("\\s*,\\s*")).forEach(v -> {
-                            if (!v.isEmpty() || valueType == String.class) {
-                                list.add(decoder.decode(valueType, v));
-                            }
-                        });
-                    }
-                    return (T) list;
-                })
-                .orElse(next.get());
-        
-        return args -> Optional.ofNullable(prop.get()).orElseGet((Supplier<? extends T>) collectionFactory);
-    }
-
-    private <T extends Map> MethodInvoker<T> createMapProperty(final String propName, final ParameterizedType type, Supplier<T> mapFactory, Supplier<T> next) {
-        final Class<?> keyType = (Class<?>)type.getActualTypeArguments()[0];
-        final Class<?> valueType = (Class<?>)type.getActualTypeArguments()[1];
-        
-        final Property<T> prop = propertyRepository
-                .get(propName, String.class)
-                .map(s -> {
-                    T result = mapFactory.get();
-                    Arrays
-                        .stream(s.split("\\s*,\\s*"))
-                        .filter(pair -> !pair.isEmpty())
-                        .map(pair -> pair.split("\\s*=\\s*"))
-                        .forEach(kv -> result.put(decoder.decode(keyType, kv[0]), decoder.decode(valueType, kv[1])));
-                    return (T)Collections.unmodifiableMap(result);
-                }
-                ).orElse((T) Collections.unmodifiableMap(next.get()));
-
-        return args -> Optional.ofNullable(prop.get()).orElseGet(mapFactory);
-    }
-    
-    protected <T> Supplier<T> defaultValueFromString(Class<T> type, String defaultValue) {
-        return () -> decoder.decode(type, defaultValue);
-    }
-    
-    protected <T> MethodInvoker<T> createInterfaceProperty(String propName, final T proxy, Supplier<T> next) {
-        return new PropertyMethodInvoker<T>(propName, next) {
-            @Override
-            public T get() {
-                return proxy;
-            }
-        };
-    }
-    
     protected <T> MethodInvoker<T> createInterfaceProperty(String propName, final T proxy) {
+        LOG.debug("Creating interface property `{}` for type `{}`", propName, proxy.getClass());
         return (args) -> proxy;
     }
 
-    protected <T> MethodInvoker<T> createScalarProperty(final Class<T> type, final String propName, Supplier<T> next) {
+    protected <T> MethodInvoker<T> createScalarProperty(final Type type, final String propName, Supplier<T> next) {
+        LOG.debug("Creating scalar property `{}` for type `{}`", propName, type.getClass());
         final Property<T> prop = propertyRepository.get(propName, type);
         return args -> Optional.ofNullable(prop.get()).orElseGet(next);
     }
     
     protected <T> MethodInvoker<T> createParameterizedProperty(final Class<T> returnType, final String propName, final String nameAnnot, Supplier<T> next) {
+        LOG.debug("Creating parameterized property `{}` for type `{}`", propName, returnType);
         return new MethodInvoker<T>() {
             @Override
             public T invoke(Object[] args) {

--- a/archaius2-core/src/main/java/com/netflix/archaius/DefaultDecoder.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/DefaultDecoder.java
@@ -15,128 +15,125 @@
  */
 package com.netflix.archaius;
 
-import java.lang.reflect.Array;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.time.Duration;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.OffsetDateTime;
-import java.time.OffsetTime;
-import java.time.Period;
-import java.time.ZonedDateTime;
-import java.util.BitSet;
-import java.util.Currency;
-import java.util.Date;
-import java.util.IdentityHashMap;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Function;
-
-import javax.inject.Singleton;
-import javax.xml.bind.DatatypeConverter;
-
 import com.netflix.archaius.api.Decoder;
+import com.netflix.archaius.api.TypeConverter;
+import com.netflix.archaius.converters.ArrayTypeConverterFactory;
+import com.netflix.archaius.converters.DefaultCollectionsTypeConverterFactory;
+import com.netflix.archaius.converters.DefaultTypeConverterFactory;
+import com.netflix.archaius.converters.EnumTypeConverterFactory;
 import com.netflix.archaius.exceptions.ParseException;
 
-/**
- * @author Spencer Gibb
- */
+import javax.inject.Singleton;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
+
 @Singleton
-public class DefaultDecoder implements Decoder {
-    private Map<Class<?>, Function<String, ?>> decoderRegistry;
+public class DefaultDecoder implements Decoder, TypeConverter.Registry {
+    private Map<Type, TypeConverter> cache = new ConcurrentHashMap<>();
+
+    private final List<TypeConverter.Factory> factories = new ArrayList<>();
 
     public static DefaultDecoder INSTANCE = new DefaultDecoder();
-    
-    {
-        decoderRegistry = new IdentityHashMap<>(75);
-        decoderRegistry.put(String.class, v->v);
-        decoderRegistry.put(boolean.class, v->{
-            if (v.equalsIgnoreCase("true") || v.equalsIgnoreCase("yes") || v.equalsIgnoreCase("on")) {
-                return Boolean.TRUE;
-            }
-            else if (v.equalsIgnoreCase("false") || v.equalsIgnoreCase("no") || v.equalsIgnoreCase("off")) {
-                return Boolean.FALSE;
-            }
-            throw new ParseException("Error parsing value '" + v + "'", new Exception("Expected one of [true, yes, on, false, no, off]"));
 
-        });
-        decoderRegistry.put(Boolean.class, decoderRegistry.get(boolean.class));
-        decoderRegistry.put(Integer.class, Integer::valueOf);
-        decoderRegistry.put(int.class, Integer::valueOf);
-        decoderRegistry.put(long.class, Long::valueOf);
-        decoderRegistry.put(Long.class, Long::valueOf);
-        decoderRegistry.put(short.class, Short::valueOf);
-        decoderRegistry.put(Short.class, Short::valueOf);
-        decoderRegistry.put(byte.class, Byte::valueOf);
-        decoderRegistry.put(Byte.class, Byte::valueOf);
-        decoderRegistry.put(double.class, Double::valueOf);
-        decoderRegistry.put(Double.class, Double::valueOf);
-        decoderRegistry.put(float.class, Float::valueOf);
-        decoderRegistry.put(Float.class, Float::valueOf);
-        decoderRegistry.put(BigInteger.class, BigInteger::new);
-        decoderRegistry.put(BigDecimal.class, BigDecimal::new);
-        decoderRegistry.put(AtomicInteger.class, s->new AtomicInteger(Integer.parseInt(s)));
-        decoderRegistry.put(AtomicLong.class, s->new AtomicLong(Long.parseLong(s)));
-        decoderRegistry.put(Duration.class, Duration::parse);
-        decoderRegistry.put(Period.class, Period::parse);
-        decoderRegistry.put(LocalDateTime.class, LocalDateTime::parse);
-        decoderRegistry.put(LocalDate.class, LocalDate::parse);
-        decoderRegistry.put(LocalTime.class, LocalTime::parse);
-        decoderRegistry.put(OffsetDateTime.class, OffsetDateTime::parse);
-        decoderRegistry.put(OffsetTime.class, OffsetTime::parse);
-        decoderRegistry.put(ZonedDateTime.class, ZonedDateTime::parse);
-        decoderRegistry.put(Instant.class, v->Instant.from(OffsetDateTime.parse(v)));
-        decoderRegistry.put(Date.class, v->new Date(Long.parseLong(v)));
-        decoderRegistry.put(Currency.class, Currency::getInstance);
-        decoderRegistry.put(BitSet.class, v->BitSet.valueOf(DatatypeConverter.parseHexBinary(v)));
+    private DefaultDecoder() {
+        factories.add(DefaultTypeConverterFactory.INSTANCE);
+        factories.add(DefaultCollectionsTypeConverterFactory.INSTANCE);
+        factories.add(ArrayTypeConverterFactory.INSTANCE);
+        factories.add(EnumTypeConverterFactory.INSTANCE);
     }
-    
-    
-    @SuppressWarnings("unchecked")
+
     @Override
     public <T> T decode(Class<T> type, String encoded) {
-        if (encoded == null) {
+        return decode((Type)type, encoded);
+    }
+
+    @Override
+    public <T> T decode(Type type, String encoded) {
+        try {
+            if (encoded == null) {
+                return null;
+            }
+            return (T)getOrCreateConverter(type).convert(encoded);
+        } catch (Exception e) {
+            throw new ParseException("Error decoding type `" + type.getTypeName() + "`", e);
+        }
+    }
+
+    @Override
+    public Optional<TypeConverter<?>> get(Type type) {
+        return Optional.ofNullable(getOrCreateConverter(type));
+    }
+
+    private TypeConverter<?> getOrCreateConverter(Type type) {
+        TypeConverter<?> converter = cache.get(type);
+        if (converter == null) {
+            converter = resolve(type);
+            if (converter == null) {
+                throw new RuntimeException("No converter found for type '" + type + "'");
+            }
+            cache.put(type, converter);
+        }
+        return converter;
+    }
+
+    /**
+     * Iterate through all TypeConverter#Factory's and return the first TypeConverter that matches
+     * @param type
+     * @return
+     */
+    private TypeConverter<?> resolve(Type type) {
+        return factories.stream()
+                .flatMap(factory -> factory.get(type, this).map(Stream::of).orElseGet(Stream::empty))
+                .findFirst()
+                .orElseGet(() -> findValueOfTypeConverter((Class)type));
+    }
+
+    /**
+     * @param type
+     * @param <T>
+     * @return Return a converter that uses reflection on either a static valueOf or ctor(String) to convert a string value to the
+     *     type.  Will return null if neither is found
+     */
+    private static <T> TypeConverter<T> findValueOfTypeConverter(Type type) {
+        if (!(type instanceof Class)) {
             return null;
         }
-        if (decoderRegistry.containsKey(type)) {
-            return (T)decoderRegistry.get(type).apply(encoded);
-        }
-        
-        if (type.isArray()) {
-            String[] elements = encoded.split(",");
-            T[] ar = (T[]) Array.newInstance(type.getComponentType(), elements.length);
-            for (int i = 0; i < elements.length; i++) {
-                ar[i] = (T) decode(type.getComponentType(), elements[i]);
-            }
-            return (T) ar;
-        }
+
+        Class cls = (Class)type;
 
         // Next look a valueOf(String) static method
+        Method method;
         try {
-            Method method;
-            try {
-                method = type.getMethod("valueOf", String.class);
-                return (T) method.invoke(null, encoded);
-            } catch (NoSuchMethodException e1) {
-                // Next look for a T(String) constructor
-                Constructor<T> c;
+            method = cls.getMethod("valueOf", String.class);
+            return value -> {
                 try {
-                    c = type.getConstructor(String.class);
-                    return c.newInstance(encoded);
+                    return (T)method.invoke(null, value);
+                } catch (Exception e) {
+                    throw new ParseException("Error converting value '" + value + "' to '" + type.getTypeName() + "'", e);
                 }
-                catch (NoSuchMethodException e) {
-                    throw new RuntimeException(type.getCanonicalName() + " has no String constructor or valueOf static method");
-                }
+            };
+        } catch (NoSuchMethodException e1) {
+            // Next look for a T(String) constructor
+            Constructor c;
+            try {
+                c = cls.getConstructor(String.class);
+                return value -> {
+                    try {
+                        return (T)c.newInstance(value);
+                    } catch (Exception e) {
+                        throw new ParseException("Error converting value", e);
+                    }
+                };
+            } catch (NoSuchMethodException e) {
+                return null;
             }
-        }
-        catch (Exception e) {
-            throw new RuntimeException("Unable to instantiate value of type " + type.getCanonicalName(), e);
         }
     }
 }

--- a/archaius2-core/src/main/java/com/netflix/archaius/converters/ArrayTypeConverterFactory.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/converters/ArrayTypeConverterFactory.java
@@ -25,6 +25,10 @@ public final class ArrayTypeConverterFactory implements TypeConverter.Factory {
 
     private static TypeConverter<?> create(TypeConverter elementConverter, Class type) {
         return value -> {
+            value = value.trim();
+            if (value.isEmpty()) {
+                return Array.newInstance(type, 0);
+            }
             String[] elements = value.split(",");
             Object[] ar = (Object[]) Array.newInstance(type, elements.length);
 

--- a/archaius2-core/src/main/java/com/netflix/archaius/converters/ArrayTypeConverterFactory.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/converters/ArrayTypeConverterFactory.java
@@ -1,0 +1,37 @@
+package com.netflix.archaius.converters;
+
+import com.netflix.archaius.api.TypeConverter;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Type;
+import java.util.Optional;
+
+public final class ArrayTypeConverterFactory implements TypeConverter.Factory {
+    public static final ArrayTypeConverterFactory INSTANCE = new ArrayTypeConverterFactory();
+
+    private ArrayTypeConverterFactory() {}
+
+    @Override
+    public Optional<TypeConverter<?>> get(Type type, TypeConverter.Registry registry) {
+        Class clsType = (Class) type;
+
+        if (clsType.isArray()) {
+            TypeConverter elementConverter = registry.get(clsType.getComponentType()).orElseThrow(() -> new RuntimeException());
+            return Optional.of(create(elementConverter, clsType.getComponentType()));
+        }
+
+        return Optional.empty();
+    }
+
+    private static TypeConverter<?> create(TypeConverter elementConverter, Class type) {
+        return value -> {
+            String[] elements = value.split(",");
+            Object[] ar = (Object[]) Array.newInstance(type, elements.length);
+
+            for (int i = 0; i < elements.length; i++) {
+                ar[i] = elementConverter.convert(elements[i]);
+            }
+            return ar;
+        };
+    }
+}

--- a/archaius2-core/src/main/java/com/netflix/archaius/converters/DefaultCollectionsTypeConverterFactory.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/converters/DefaultCollectionsTypeConverterFactory.java
@@ -1,0 +1,99 @@
+package com.netflix.archaius.converters;
+
+import com.netflix.archaius.api.TypeConverter;
+import com.netflix.archaius.exceptions.ConverterNotFoundException;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.function.Supplier;
+
+public final class DefaultCollectionsTypeConverterFactory implements TypeConverter.Factory {
+    public static final DefaultCollectionsTypeConverterFactory INSTANCE = new DefaultCollectionsTypeConverterFactory();
+
+    private static final Set<Type> collectionTypes = new HashSet<>(Arrays.asList(Map.class, List.class, SortedMap.class, SortedSet.class, LinkedList.class));
+
+    private DefaultCollectionsTypeConverterFactory() {}
+
+    @Override
+    public Optional<TypeConverter<?>> get(Type type, TypeConverter.Registry registry) {
+        if (type instanceof ParameterizedType) {
+            ParameterizedType parameterizedType = (ParameterizedType)type;
+            if (parameterizedType.getRawType().equals(Map.class)) {
+                return Optional.of(createMapTypeConverter(
+                        registry.get(parameterizedType.getActualTypeArguments()[0]).orElseThrow(() -> new ConverterNotFoundException("No converter found")),
+                        registry.get(parameterizedType.getActualTypeArguments()[1]).orElseThrow(() -> new ConverterNotFoundException("No converter found")),
+                        LinkedHashMap::new));
+            } else if (parameterizedType.getRawType().equals(Set.class)) {
+                return Optional.of(createCollectionTypeConverter(
+                        parameterizedType.getActualTypeArguments()[0],
+                        registry,
+                        LinkedHashSet::new));
+            } else if (parameterizedType.getRawType().equals(SortedSet.class)) {
+                return Optional.of(createCollectionTypeConverter(
+                        parameterizedType.getActualTypeArguments()[0],
+                        registry,
+                        TreeSet::new));
+            } else if (parameterizedType.getRawType().equals(List.class)) {
+                return Optional.of(createCollectionTypeConverter(
+                        parameterizedType.getActualTypeArguments()[0],
+                        registry,
+                        ArrayList::new));
+            } else if (parameterizedType.getRawType().equals(LinkedList.class)) {
+                return Optional.of(createCollectionTypeConverter(
+                        parameterizedType.getActualTypeArguments()[0],
+                        registry,
+                        LinkedList::new));
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private <T> TypeConverter<?> createCollectionTypeConverter(final Type type, TypeConverter.Registry registry, final Supplier<Collection<T>> collectionFactory) {
+        TypeConverter elementConverter = registry.get(type).orElseThrow(() -> new ConverterNotFoundException("No converter found"));
+
+        boolean ignoreEmpty = !String.class.equals(type);
+
+        return value -> {
+            final Collection collection = collectionFactory.get();
+            if (!value.isEmpty()) {
+                Arrays.asList(value.split("\\s*,\\s*")).forEach(v -> {
+                    if (!v.isEmpty() || !ignoreEmpty) {
+                        collection.add(elementConverter.convert(v));
+                    }
+                });
+            }
+            return collection;
+        };
+    }
+
+    private TypeConverter<?> createMapTypeConverter(final TypeConverter<?> keyConverter, final TypeConverter<?> valueConverter, final Supplier<Map> mapFactory) {
+        return s -> {
+            Map result = mapFactory.get();
+            Arrays
+                    .stream(s.split("\\s*,\\s*"))
+                    .filter(pair -> !pair.isEmpty())
+                    .map(pair -> pair.split("\\s*=\\s*"))
+                    .forEach(kv -> result.put(
+                            keyConverter.convert(kv[0]),
+                            valueConverter.convert(kv[1])));
+            return Collections.unmodifiableMap(result);
+        };
+    }
+}

--- a/archaius2-core/src/main/java/com/netflix/archaius/converters/DefaultTypeConverterFactory.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/converters/DefaultTypeConverterFactory.java
@@ -1,0 +1,94 @@
+package com.netflix.archaius.converters;
+
+import com.netflix.archaius.api.TypeConverter;
+import com.netflix.archaius.exceptions.ParseException;
+
+import javax.xml.bind.DatatypeConverter;
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.Period;
+import java.time.ZonedDateTime;
+import java.util.BitSet;
+import java.util.Currency;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+
+public final class DefaultTypeConverterFactory implements TypeConverter.Factory {
+    public static final DefaultTypeConverterFactory INSTANCE = new DefaultTypeConverterFactory();
+
+    private static Boolean convertBoolean(String value) {
+        if (value.equalsIgnoreCase("true") || value.equalsIgnoreCase("yes") || value.equalsIgnoreCase("on")) {
+            return Boolean.TRUE;
+        }
+        else if (value.equalsIgnoreCase("false") || value.equalsIgnoreCase("no") || value.equalsIgnoreCase("off")) {
+            return Boolean.FALSE;
+        }
+        throw new ParseException("Error parsing value '" + value + "'", new Exception("Expected one of [true, yes, on, false, no, off]"));
+    };
+
+    private Map<Type, TypeConverter<?>> converters = new HashMap<>();
+
+    private DefaultTypeConverterFactory() {
+        converters.put(String.class, create(Function.identity()));
+        converters.put(boolean.class, create(DefaultTypeConverterFactory::convertBoolean));
+        converters.put(Boolean.class, create(DefaultTypeConverterFactory::convertBoolean));
+        converters.put(Integer.class, create(Integer::valueOf));
+        converters.put(int.class, create(Integer::valueOf));
+        converters.put(long.class, create(Long::valueOf));
+        converters.put(Long.class, create(Long::valueOf));
+        converters.put(short.class, create(Short::valueOf));
+        converters.put(Short.class, create(Short::valueOf));
+        converters.put(byte.class, create(Byte::valueOf));
+        converters.put(Byte.class, create(Byte::valueOf));
+        converters.put(double.class, create(Double::valueOf));
+        converters.put(Double.class, create(Double::valueOf));
+        converters.put(float.class, create(Float::valueOf));
+        converters.put(Float.class, create(Float::valueOf));
+        converters.put(BigInteger.class, create(BigInteger::new));
+        converters.put(BigDecimal.class, create(BigDecimal::new));
+        converters.put(AtomicInteger.class, create(v -> new AtomicInteger(Integer.parseInt(v))));
+        converters.put(AtomicLong.class, create(v -> new AtomicLong(Long.parseLong(v))));
+        converters.put(Duration.class, create(Duration::parse));
+        converters.put(Period.class, create(Period::parse));
+        converters.put(LocalDateTime.class, create(LocalDateTime::parse));
+        converters.put(LocalDate.class, create(LocalDate::parse));
+        converters.put(LocalTime.class, create(LocalTime::parse));
+        converters.put(OffsetDateTime.class, create(OffsetDateTime::parse));
+        converters.put(OffsetTime.class, create(OffsetTime::parse));
+        converters.put(ZonedDateTime.class, create(ZonedDateTime::parse));
+        converters.put(Instant.class, create(v -> Instant.from(OffsetDateTime.parse(v))));
+        converters.put(Date.class, create(v -> new Date(Long.parseLong(v))));
+        converters.put(Currency.class, create(Currency::getInstance));
+        converters.put(BitSet.class, create(v -> BitSet.valueOf(DatatypeConverter.parseHexBinary(v))));
+    }
+
+    private static <T> TypeConverter<T> create(Function<String, T> func) {
+        assert func != null;
+        return s -> func.apply(s);
+    }
+
+    @Override
+    public Optional<TypeConverter<?>> get(Type type, TypeConverter.Registry registry) {
+        assert type != null;
+        assert registry != null;
+        for (Map.Entry<Type, TypeConverter<?>> entry : converters.entrySet()) {
+            if (entry.getKey().equals(type)) {
+                return Optional.of(entry.getValue());
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/archaius2-core/src/main/java/com/netflix/archaius/converters/EnumTypeConverterFactory.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/converters/EnumTypeConverterFactory.java
@@ -1,0 +1,27 @@
+package com.netflix.archaius.converters;
+
+import com.netflix.archaius.api.TypeConverter;
+
+import java.lang.reflect.Type;
+import java.util.Optional;
+
+public final class EnumTypeConverterFactory implements TypeConverter.Factory {
+    public static final EnumTypeConverterFactory INSTANCE = new EnumTypeConverterFactory();
+
+    private EnumTypeConverterFactory() {}
+
+    @Override
+    public Optional<TypeConverter<?>> get(Type type, TypeConverter.Registry registry) {
+        Class clsType = (Class) type;
+
+        if (clsType.isEnum()) {
+            return Optional.of(create(clsType));
+        }
+
+        return Optional.empty();
+    }
+
+    private static TypeConverter<?> create(Class clsType) {
+        return value -> Enum.valueOf(clsType, value);
+    }
+}

--- a/archaius2-core/src/main/java/com/netflix/archaius/exceptions/ConverterNotFoundException.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/exceptions/ConverterNotFoundException.java
@@ -1,0 +1,10 @@
+package com.netflix.archaius.exceptions;
+
+public class ConverterNotFoundException extends RuntimeException {
+    public ConverterNotFoundException(String message) {
+        super(message);
+    }
+    public ConverterNotFoundException(String message, Exception e) {
+        super(message, e);
+    }
+}

--- a/archaius2-core/src/test/java/com/netflix/archaius/DefaultDecoderTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/DefaultDecoderTest.java
@@ -86,5 +86,4 @@ public class DefaultDecoderTest {
         Assert.assertEquals(BitSet.valueOf(DatatypeConverter.parseHexBinary("DEADBEEF00DEADBEEF")), decoder.decode(BitSet.class, "DEADBEEF00DEADBEEF"));
         Assert.assertEquals("testString", decoder.decode(String.class, "testString"));
     }
-    
 }

--- a/archaius2-core/src/test/java/com/netflix/archaius/DefaultDecoderTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/DefaultDecoderTest.java
@@ -43,7 +43,7 @@ import com.netflix.archaius.DefaultDecoder;
 public class DefaultDecoderTest {
     @Test
     public void testJavaNumbers() {
-        DefaultDecoder decoder = new DefaultDecoder();
+        DefaultDecoder decoder = DefaultDecoder.INSTANCE;
         
         boolean flag = decoder.decode(boolean.class, "true");
         Assert.assertEquals(true, flag);
@@ -64,7 +64,7 @@ public class DefaultDecoderTest {
     
     @Test
     public void testJavaDateTime() {
-        DefaultDecoder decoder = new DefaultDecoder();
+        DefaultDecoder decoder = DefaultDecoder.INSTANCE;
         
         Assert.assertEquals(Duration.parse("PT20M30S"), decoder.decode(Duration.class, "PT20M30S"));
         Assert.assertEquals(Period.of(1, 2, 25), decoder.decode(Period.class, "P1Y2M3W4D"));
@@ -81,7 +81,7 @@ public class DefaultDecoderTest {
     
     @Test
     public void testJavaMiscellaneous() {
-        DefaultDecoder decoder = new DefaultDecoder();
+        DefaultDecoder decoder = DefaultDecoder.INSTANCE;
         Assert.assertEquals(Currency.getInstance("USD"), decoder.decode(Currency.class, "USD"));
         Assert.assertEquals(BitSet.valueOf(DatatypeConverter.parseHexBinary("DEADBEEF00DEADBEEF")), decoder.decode(BitSet.class, "DEADBEEF00DEADBEEF"));
         Assert.assertEquals("testString", decoder.decode(String.class, "testString"));

--- a/archaius2-core/src/test/java/com/netflix/archaius/ProxyFactoryTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/ProxyFactoryTest.java
@@ -29,7 +29,7 @@ import com.netflix.archaius.config.DefaultSettableConfig;
 import com.netflix.archaius.config.EmptyConfig;
 
 public class ProxyFactoryTest {
-    public static enum TestEnum {
+    public enum TestEnum {
         NONE,
         A, 
         B,
@@ -71,7 +71,10 @@ public class ProxyFactoryTest {
         
         @DefaultValue("default1:default2")
         SubConfigFromString getSubConfigFromString();
-        
+
+        @DefaultValue("")
+        Integer[] getIntArray();
+
         int getRequiredValue();
     }
     
@@ -113,7 +116,7 @@ public class ProxyFactoryTest {
         assertThat(c.getValueWithDefault(), equalTo("default"));
         assertThat(c.getValueWithoutDefault2(), equalTo("default2"));
         assertThat(c.getValueWithoutDefault1(), nullValue());
-        
+
         config.setProperty("valueWithDefault", "newValue");
         assertThat(c.getValueWithDefault(), equalTo("default"));
     }
@@ -134,7 +137,8 @@ public class ProxyFactoryTest {
         assertThat(a.getSubConfigFromString().part1(),  equalTo("default1"));
         assertThat(a.getSubConfigFromString().part2(),  equalTo("default2"));
         assertThat(a.getNullable(),                     nullValue());
-        assertThat(a.getBaseBoolean(), nullValue());
+        assertThat(a.getBaseBoolean(),                  nullValue());
+        assertThat(a.getIntArray(),                     equalTo(new Integer[]{}));
     }
     
     @Test
@@ -153,7 +157,8 @@ public class ProxyFactoryTest {
         assertThat(a.getSubConfigFromString().part1(),  equalTo("default1"));
         assertThat(a.getSubConfigFromString().part2(),  equalTo("default2"));
         assertThat(a.getNullable(),                     nullValue());
-        assertThat(a.getBaseBoolean(), nullValue());
+        assertThat(a.getBaseBoolean(),                  nullValue());
+        assertThat(a.getIntArray(),                     equalTo(new Integer[]{}));
     }
     
     @Test
@@ -165,19 +170,21 @@ public class ProxyFactoryTest {
         config.setProperty("prefix.subConfigFromString", "a:b");
         config.setProperty("prefix.subConfig.str", "str2");
         config.setProperty("prefix.baseBoolean", true);
-        
+        config.setProperty("prefix.intArray", "0,1,2,3");
+
         PropertyFactory factory = DefaultPropertyFactory.from(config);
         ConfigProxyFactory proxy = new ConfigProxyFactory(config, config.getDecoder(), factory);
         
         RootConfig a = proxy.newProxy(RootConfig.class, "prefix");
         
-        assertThat(a.getStr(),      equalTo("str1"));
-        assertThat(a.getInteger(),  equalTo(1));
-        assertThat(a.getEnum(),     equalTo(TestEnum.A));
-        assertThat(a.getSubConfig().str(),      equalTo("str2"));
-        assertThat(a.getSubConfigFromString().part1(), equalTo("a"));
-        assertThat(a.getSubConfigFromString().part2(), equalTo("b"));
-        assertThat(a.getBaseBoolean(), equalTo(true));
+        assertThat(a.getStr(),                          equalTo("str1"));
+        assertThat(a.getInteger(),                      equalTo(1));
+        assertThat(a.getEnum(),                         equalTo(TestEnum.A));
+        assertThat(a.getSubConfig().str(),              equalTo("str2"));
+        assertThat(a.getSubConfigFromString().part1(),  equalTo("a"));
+        assertThat(a.getSubConfigFromString().part2(),  equalTo("b"));
+        assertThat(a.getBaseBoolean(),                  equalTo(true));
+        assertThat(a.getIntArray(),                     equalTo(new Integer[]{0,1,2,3}));
 
         config.setProperty("prefix.subConfig.str", "str3");
         assertThat(a.getSubConfig().str(),      equalTo("str3"));
@@ -432,7 +439,6 @@ public class ProxyFactoryTest {
         ConfigProxyFactory proxy = new ConfigProxyFactory(config, config.getDecoder(), factory);
         FailingError c = proxy.newProxy(FailingError.class);
         c.getValue();
-        
     }
     
     @Test

--- a/archaius2-core/src/test/java/com/netflix/archaius/ProxyFactoryTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/ProxyFactoryTest.java
@@ -37,7 +37,7 @@ public class ProxyFactoryTest {
     }
     
     @Configuration(immutable=true)
-    public static interface ImmutableConfig {
+    public interface ImmutableConfig {
         @DefaultValue("default")
         String getValueWithDefault();
         
@@ -46,7 +46,7 @@ public class ProxyFactoryTest {
         String getValueWithoutDefault2();
     }
     
-    public static interface BaseConfig {
+    public interface BaseConfig {
         @DefaultValue("basedefault")
         String getStr();
         
@@ -56,7 +56,7 @@ public class ProxyFactoryTest {
         Integer getNullable();
     }
     
-    public static interface RootConfig extends BaseConfig {
+    public interface RootConfig extends BaseConfig {
         @DefaultValue("default")
         @Override
         String getStr();
@@ -75,7 +75,7 @@ public class ProxyFactoryTest {
         int getRequiredValue();
     }
     
-    public static interface SubConfig {
+    public interface SubConfig {
         @DefaultValue("default")
         String str();
     }
@@ -211,28 +211,36 @@ public class ProxyFactoryTest {
         Assert.assertEquals("default", withArgs.getProperty("a", 2));
     }
     
-    public static interface ConfigWithLongMap {
-        default Map<String, Long> getMap() { return Collections.singletonMap("default", 0L); }
+    public interface ConfigWithMaps {
+        @PropertyName(name="map")
+        default Map<String, Long> getStringToLongMap() { return Collections.singletonMap("default", 0L); }
+
+        @PropertyName(name="map2")
+        default Map<Long, String> getLongToStringMap() { return Collections.singletonMap(0L, "default"); }
     }
     
     @Test
     public void testWithLongMap() {
         SettableConfig config = new DefaultSettableConfig();
-        config.setProperty("map", "1=123,2=456");
-        
+        config.setProperty("map", "a=123,b=456");
+        config.setProperty("map2", "1=a,2=b");
+
         PropertyFactory factory = DefaultPropertyFactory.from(config);
         ConfigProxyFactory proxy = new ConfigProxyFactory(config, config.getDecoder(), factory);
-        ConfigWithLongMap withArgs = proxy.newProxy(ConfigWithLongMap.class);
+        ConfigWithMaps withMaps = proxy.newProxy(ConfigWithMaps.class);
         
-        long sub1 = withArgs.getMap().get("1");
-        long sub2 = withArgs.getMap().get("2");
+        long sub1 = withMaps.getStringToLongMap().get("a");
+        long sub2 = withMaps.getStringToLongMap().get("b");
 
         Assert.assertEquals(123, sub1);
         Assert.assertEquals(456, sub2);
         
-        config.setProperty("map", "1=123,2=789");
-        sub2 = withArgs.getMap().get("2");
+        config.setProperty("map", "a=123,b=789");
+        sub2 = withMaps.getStringToLongMap().get("b");
         Assert.assertEquals(789, sub2);
+
+        Assert.assertEquals("a", withMaps.getLongToStringMap().get(1L));
+        Assert.assertEquals("b", withMaps.getLongToStringMap().get(2L));
     }
     
     @Test
@@ -241,16 +249,16 @@ public class ProxyFactoryTest {
         
         PropertyFactory factory = DefaultPropertyFactory.from(config);
         ConfigProxyFactory proxy = new ConfigProxyFactory(config, config.getDecoder(), factory);
-        ConfigWithLongMap withArgs = proxy.newProxy(ConfigWithLongMap.class);
+        ConfigWithMaps withArgs = proxy.newProxy(ConfigWithMaps.class);
         
-        Assert.assertEquals(Collections.singletonMap("default", 0L), withArgs.getMap());
+        Assert.assertEquals(Collections.singletonMap("default", 0L), withArgs.getStringToLongMap());
         
         config.setProperty("map", "foo=123");
         
-        Assert.assertEquals(Collections.singletonMap("foo", 123L), withArgs.getMap());
+        Assert.assertEquals(Collections.singletonMap("foo", 123L), withArgs.getStringToLongMap());
     }
     
-    public static interface ConfigWithCollections {
+    public interface ConfigWithCollections {
         List<Integer> getList();
         
         Set<Integer> getSet();
@@ -365,18 +373,19 @@ public class ProxyFactoryTest {
     @Test
     public void testCollectionsWithoutValue() {
         SettableConfig config = new DefaultSettableConfig();
-        
+
         PropertyFactory factory = DefaultPropertyFactory.from(config);
         ConfigProxyFactory proxy = new ConfigProxyFactory(config, config.getDecoder(), factory);
         ConfigWithCollections withCollections = proxy.newProxy(ConfigWithCollections.class);
-        
+
+        System.out.println(withCollections.toString());
         Assert.assertTrue(withCollections.getLinkedList().isEmpty());
         Assert.assertTrue(withCollections.getList().isEmpty());
         Assert.assertTrue(withCollections.getSet().isEmpty());
         Assert.assertTrue(withCollections.getSortedSet().isEmpty());
     }
     
-    public static interface ConfigWithCollectionsWithDefaultValueAnnotation {
+    public interface ConfigWithCollectionsWithDefaultValueAnnotation {
         @DefaultValue("")
         LinkedList<Integer> getLinkedList();
     }
@@ -390,7 +399,7 @@ public class ProxyFactoryTest {
         proxy.newProxy(ConfigWithCollectionsWithDefaultValueAnnotation.class);
     }
     
-    public static interface ConfigWithDefaultStringCollections {
+    public interface ConfigWithDefaultStringCollections {
         default List<String> getList() { return Collections.singletonList("default"); }
         
         default Set<String> getSet() { return Collections.singleton("default"); }

--- a/archaius2-guice/src/test/java/com/netflix/archaius/guice/ProxyTest.java
+++ b/archaius2-guice/src/test/java/com/netflix/archaius/guice/ProxyTest.java
@@ -107,9 +107,9 @@ public class ProxyTest {
     
     @Configuration(prefix="prefix-${env}", allowFields=true)
     @ConfigurationSource(value={"moduleTest"}, cascading=MyCascadingStrategy.class)
-    public static interface ModuleTestConfig {
-        public Boolean isLoaded();
-        public String getProp1();
+    public interface ModuleTestConfig {
+        Boolean isLoaded();
+        String getProp1();
     }
     
     @Test

--- a/archaius2-guice/src/test/resources/log4j.properties
+++ b/archaius2-guice/src/test/resources/log4j.properties
@@ -1,0 +1,21 @@
+#
+# Copyright 2019 Netflix, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+log4j.rootLogger=ERROR, console
+
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d %-5p %c{1}:%L %x %m [%t]%n

--- a/archaius2-test/src/main/java/com/netflix/archaius/test/Archaius2TestConfig.java
+++ b/archaius2-test/src/main/java/com/netflix/archaius/test/Archaius2TestConfig.java
@@ -1,5 +1,6 @@
 package com.netflix.archaius.test;
 
+import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Collections;
@@ -202,6 +203,16 @@ public class Archaius2TestConfig implements TestRule, SettableConfig {
 
     @Override
     public <T> T get(Class<T> type, String key, T defaultValue) {
+        return testCompositeConfig.get(type, key, defaultValue);
+    }
+
+    @Override
+    public <T> T get(Type type, String key) {
+        return testCompositeConfig.get(type, key);
+    }
+
+    @Override
+    public <T> T get(Type type, String key, T defaultValue) {
         return testCompositeConfig.get(type, key, defaultValue);
     }
 


### PR DESCRIPTION
- Introduce a new TypeConverter contract through which the decoder may be extended.
- Capture array, enum and typed collection conversions via TypeConverter.Factory implementations
- Support typed collections, such as `Map<String, Long>`, when using ConfigProxyFactory without having to wrap them in a custom type