### PR TITLE
travis: Remove deprecated sudo setting.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
 jdk:
 - openjdk8
-sudo: false
 install: ./installViaTravis.sh
 script: ./buildViaTravis.sh
 env:


### PR DESCRIPTION
Closes #572.

As mentioned in the issue, this setting was depracted over a year ago
and should be removed.