### PR TITLE
jackson: Upgrade to a much more current version.

### DIFF
--- a/archaius2-persisted2/build.gradle
+++ b/archaius2-persisted2/build.gradle
@@ -18,8 +18,8 @@ apply plugin: 'java'
 
 dependencies {
     compile  project(':archaius2-core')
-    compile 'com.fasterxml.jackson.core:jackson-core:2.4.3'
-    compile 'com.fasterxml.jackson.core:jackson-databind:2.4.3'
+    compile 'com.fasterxml.jackson.core:jackson-core:2.10.1'
+    compile 'com.fasterxml.jackson.core:jackson-databind:2.10.1'
 
     testCompile project(':archaius2-guice')
 }


### PR DESCRIPTION
Closes #582.

This should be relatively safe given the semantic versioning, and help
help improve security as mentioned in the issue, in addition to probably
providing a lot of bug and other fixes.