### PR TITLE
DynamicMapProperty escaping equal sign

### DIFF
--- a/archaius-core/src/main/java/com/netflix/config/DynamicMapProperty.java
+++ b/archaius-core/src/main/java/com/netflix/config/DynamicMapProperty.java
@@ -80,7 +80,7 @@ public abstract class DynamicMapProperty<TKEY, TVAL> extends DynamicStringListPr
         for (String s : strings) {
             String kv[] = getKeyValue(s);
             if (kv.length == 2) {
-                map.put(getKey(kv[0]), getValue(kv[1]));
+                map.put(getKey(kv[0]), getValue(kv[1].replace("\\=", "=")));
             } else {
                 logger.warn("Ignoring illegal key value pair: " + s);
             }
@@ -89,7 +89,7 @@ public abstract class DynamicMapProperty<TKEY, TVAL> extends DynamicStringListPr
     }
     
     protected String[] getKeyValue(String keyValue) {
-        return keyValue.split("=");    
+        return keyValue.split("(?<!\\\\)=");
     }
     
     protected abstract TKEY getKey(String key);

--- a/archaius-core/src/test/java/com/netflix/config/DynamicMapPropertyTest.java
+++ b/archaius-core/src/test/java/com/netflix/config/DynamicMapPropertyTest.java
@@ -1,8 +1,6 @@
 package com.netflix.config;
 
-import java.util.Arrays;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Assert;
@@ -48,5 +46,14 @@ public class DynamicMapPropertyTest {
         current = dp.getMap();
         
         Assert.assertEquals(Arrays.asList(1,2,3,4,5,6,7,8,9), Lists.newArrayList(current.keySet()));
+    }
+
+    @Test
+    public void testGetKeyValue() {
+
+        DynamicStringMapProperty dp = new DynamicStringMapProperty("testProperty", "");
+        List<String> list = Collections.singletonList("key=a\\=b");
+        Assert.assertEquals("a=b",dp.parseMapFromStringList(list).get("key"));
+
     }
 }


### PR DESCRIPTION
DynamicMapProperty extracts key and value from keyValue string splitted by '='.
If value contains '=' char, keyValue string has more than two '='s, therefore after splitting DynamicMapProperty can't extract key&value, then just ignores it.
so, user can't set values that contains '=' char. and user get no error or warning, Key&values gonna just missing.
 
archaius should provide proper excaping.

I made a change to ```=``` can be escaped by ```\``` (in java ```"\\="```)
