### PR TITLE
Update build status location

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Archaius
 =====
 [![NetflixOSS Lifecycle](https://img.shields.io/osslifecycle/Netflix/archaius.svg)]()
 
-[![Build Status](https://netflixoss.ci.cloudbees.com/buildStatus/icon?job=archaius-master)](https://netflixoss.ci.cloudbees.com/job/archaius-master/)
+[![Build Status](https://travis-ci.com/Netflix/archaius.svg)](https://travis-ci.com/Netflix/archaius)
 
 Features
 -------


### PR DESCRIPTION
This build has been migrated to travis-ci.com as per their [recommendation](https://mailchi.mp/3d439eeb1098/travis-ciorg-is-moving-to-travis-cicom).