### PR TITLE
Replace JCenter with Maven Central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 }
 
@@ -18,7 +18,7 @@ subprojects {
     sourceCompatibility = JavaVersion.VERSION_1_8
     
     repositories {
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {


### PR DESCRIPTION
This replaces jcenter with maven central to avoid broken builds in the future

