### PR TITLE
Provide a proper error message instead of a ClassCastException

### DIFF
--- a/archaius-core/src/main/java/com/netflix/config/DynamicPropertyUpdater.java
+++ b/archaius-core/src/main/java/com/netflix/config/DynamicPropertyUpdater.java
@@ -127,24 +127,29 @@ public class DynamicPropertyUpdater {
              
                 if (newValue != null) {
                     Object newValueArray;
-                    if (oldValue instanceof CopyOnWriteArrayList && AbstractConfiguration.getDefaultListDelimiter() != '\0'){
-                        newValueArray = 
-                                        new CopyOnWriteArrayList();
-                        
-                      Iterable<String> stringiterator = Splitter.on(AbstractConfiguration.getDefaultListDelimiter()).omitEmptyStrings().trimResults().split((String)newValue);
-                      for(String s :stringiterator){
+                    if (oldValue instanceof CopyOnWriteArrayList && AbstractConfiguration.getDefaultListDelimiter() != '\0') {
+                        newValueArray =
+                                new CopyOnWriteArrayList();
+
+                        if (newValue != null && !(newValue instanceof String))
+                        {
+                            throw new ValidationException("Property " + name + " is expected to be a String, but "
+                                    + newValue.getClass().getName() + " was received");
+                        }
+                        Iterable<String> stringiterator = Splitter.on(AbstractConfiguration.getDefaultListDelimiter()).omitEmptyStrings().trimResults().split((String) newValue);
+                        for (String s : stringiterator) {
                             ((CopyOnWriteArrayList) newValueArray).add(s);
                         }
-                      } else {
-                          newValueArray = newValue;
-                      }
-                  
+                    } else {
+                        newValueArray = newValue;
+                    }
+
                     if (!newValueArray.equals(oldValue)) {
                         logger.debug("updating property key [{}], value [{}]", name, newValue);
     
                         config.setProperty(name, newValue);
                     }
-                   
+
                 } else if (oldValue != null) {
                     logger.debug("nulling out property key [{}]", name);
     

--- a/archaius-core/src/main/java/com/netflix/config/DynamicPropertyUpdater.java
+++ b/archaius-core/src/main/java/com/netflix/config/DynamicPropertyUpdater.java
@@ -128,8 +128,7 @@ public class DynamicPropertyUpdater {
                 if (newValue != null) {
                     Object newValueArray;
                     if (oldValue instanceof CopyOnWriteArrayList && AbstractConfiguration.getDefaultListDelimiter() != '\0') {
-                        newValueArray =
-                                new CopyOnWriteArrayList();
+                        newValueArray = new CopyOnWriteArrayList();
 
                         if (newValue != null && !(newValue instanceof String))
                         {


### PR DESCRIPTION
Otherwise `(String)newValue` fails and there's no way to know which property it was for.

There's currently one failing test, though for me it is failing on a clean branch as well.