### PR TITLE
Rgallardo/add view config

### DIFF
--- a/archaius2-api/src/main/java/com/netflix/archaius/api/Config.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/api/Config.java
@@ -145,13 +145,25 @@ public interface Config extends PropertySource {
     
     /**
      * @param prefix
-     * @return Return a subset of the configuration prefixed by a key.
+     * @return Return a subset of the configuration prefixed by a key. A prefixed view is NOT independent of its parent
+     * config. In particular, setting the decoder or the string interpolator is not supported and causes unspecified
+     * behavior.
+     * @see #getPrivateView()
      */
     Config getPrefixedView(String prefix);
-    
+
+    /**
+     * @return A "private view" of this config. The returned object can have its own {@link Decoder},
+     * {@link StrInterpolator}, and {@link ConfigListener}s that will NOT be shared with the original config. Updates to
+     * the underlying config's entries WILL be visible and will generate events on any registered listener.
+     */
+    Config getPrivateView();
+
     /**
      * Set the interpolator to be used.  The interpolator is normally created from the top level
-     * configuration object and is passed down to any children as they are added.
+     * configuration object and is passed down to any children as they are added. Setting the interpolator on a child
+     * config is not supported and causes unspecified behavior.
+     * @see #getPrivateView()
      * @param interpolator
      */
     void setStrInterpolator(StrInterpolator interpolator);
@@ -159,7 +171,10 @@ public interface Config extends PropertySource {
     StrInterpolator getStrInterpolator();
     
     /**
-     * Set the Decoder used by get() to parse any type
+     * Set the Decoder used by get() to parse any type. The decoder is normally created from the top level
+     * configuration object and is passed down to children as they are added. Setting the decoder on a child
+     * config is not supported and causes unspecified behavior.
+     * @see #getPrivateView()
      * @param decoder
      */
     void setDecoder(Decoder decoder);

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/AbstractConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/AbstractConfig.java
@@ -233,6 +233,11 @@ public abstract class AbstractConfig implements Config {
     }
 
     @Override
+    public Config getPrivateView() {
+        return new PrivateViewConfig(this);
+    }
+
+    @Override
     public <T> T accept(Visitor<T> visitor) {
         T result = null;
         forEachProperty((k, v) -> visitor.visitKey(k, v));

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/PrivateViewConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/PrivateViewConfig.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.archaius.config;
+
+import java.lang.ref.Reference;
+import java.lang.ref.WeakReference;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+
+import com.netflix.archaius.api.Config;
+import com.netflix.archaius.api.ConfigListener;
+import com.netflix.archaius.api.Decoder;
+import com.netflix.archaius.api.StrInterpolator;
+
+/**
+ * View into another Config that allows usage of a private {@link Decoder}, {@link StrInterpolator}, and
+ * {@link ConfigListener}s that will NOT be shared with the original config.
+ * <p>
+ * This class is meant to work with dynamic Config object that may have properties added and removed.
+ */
+public class PrivateViewConfig extends AbstractConfig {
+
+    private static class State {
+        final Map<String, Object> data;
+
+        public State(Config config) {
+            data = new LinkedHashMap<>();
+            config.forEachProperty(data::put);
+        }
+    }
+
+    /** Listener to update our own state on upstream changes and then propagate the even to our own listeners. */
+    private static class ViewConfigListener implements ConfigListener {
+        private final Reference<PrivateViewConfig> vcRef;
+
+        private ViewConfigListener(PrivateViewConfig pvc) {
+            this.vcRef = new WeakReference<>(pvc);
+        }
+
+        @Override
+        public void onConfigAdded(Config config) {
+            updateState(config).ifPresent(vc -> vc.notifyConfigAdded(vc));
+        }
+
+        @Override
+        public void onConfigRemoved(Config config) {
+            updateState(config).ifPresent(vc -> vc.notifyConfigRemoved(vc));
+        }
+
+        @Override
+        public void onConfigUpdated(Config config) {
+            updateState(config).ifPresent(vc -> vc.notifyConfigUpdated(vc));
+        }
+
+        @Override
+        public void onError(Throwable error, Config config) {
+        }
+
+        /**
+         * Checks that the PrivateViewConfig object is still alive, and if so it updates its local state from the wrapped
+         * source.
+         *
+         * @return An Optional with the PrivateViewConfig object IFF the weak reference to it is still alive, empty otherwise.
+         */
+        private Optional<PrivateViewConfig> updateState(Config updatedWrappedConfig) {
+            PrivateViewConfig pvc = vcRef.get();
+            if (pvc != null) {
+                pvc.state = new State(updatedWrappedConfig);
+                return Optional.of(pvc);
+            } else {
+                // The view is gone, cleanup time!
+                updatedWrappedConfig.removeListener(this);
+                return Optional.empty();
+            }
+        }
+    }
+
+    private volatile State state;
+
+    public PrivateViewConfig(final Config wrappedConfig) {
+        this.state = new State(wrappedConfig);
+        wrappedConfig.addListener(new ViewConfigListener(this));
+    }
+
+    @Override
+    public Iterator<String> getKeys() {
+        return state.data.keySet().iterator();
+    }
+
+    @Override
+    public boolean containsKey(String key) {
+        return state.data.containsKey(key);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return state.data.isEmpty();
+    }
+
+    @Override
+    public <T> T accept(Visitor<T> visitor) {
+        T t = null;
+        for (Entry<String, Object> entry : state.data.entrySet()) {
+            t = visitor.visitKey(entry.getKey(), entry.getValue());
+        }
+        return t;
+    }
+
+    @Override
+    public Object getRawProperty(String key) {
+        return state.data.get(key);
+    }
+}

--- a/archaius2-core/src/test/java/com/netflix/archaius/config/PrivateViewTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/PrivateViewTest.java
@@ -1,0 +1,85 @@
+package com.netflix.archaius.config;
+
+import com.netflix.archaius.api.Config;
+import com.netflix.archaius.api.ConfigListener;
+import com.netflix.archaius.api.Decoder;
+import com.netflix.archaius.api.config.SettableConfig;
+import com.netflix.archaius.api.exceptions.ConfigException;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+public class PrivateViewTest {
+
+    @Test
+    public void decoderSettingDoesNotPropagate() throws ConfigException {
+        com.netflix.archaius.api.config.CompositeConfig config = DefaultCompositeConfig.builder()
+                .withConfig("foo", MapConfig.builder().put("foo.bar", "value").build())
+                .build();
+
+        Config privateView = config.getPrivateView();
+
+        Decoder privateDecoder = Mockito.mock(Decoder.class);
+        privateView.setDecoder(privateDecoder);
+
+        assertNotSame(config.getDecoder(), privateView.getDecoder());
+
+        Decoder newUpstreamDecoder = Mockito.mock(Decoder.class);
+        config.setDecoder(newUpstreamDecoder);
+
+        assertNotSame(config.getDecoder(), privateView.getDecoder());
+
+        assertSame(privateDecoder, privateView.getDecoder());
+    }
+
+    @Test
+    public void confirmNotificationOnAnyChange() throws ConfigException {
+        com.netflix.archaius.api.config.CompositeConfig config = DefaultCompositeConfig.builder()
+                .withConfig("foo", MapConfig.builder().put("foo.bar", "value").build())
+                .build();
+        
+        Config privateView = config.getPrivateView();
+        ConfigListener listener = Mockito.mock(ConfigListener.class);
+        
+        privateView.addListener(listener);
+        
+        Mockito.verify(listener, Mockito.times(0)).onConfigAdded(Mockito.any());
+        
+        config.addConfig("bar", DefaultCompositeConfig.builder()
+                .withConfig("foo", MapConfig.builder().put("foo.bar", "value").build())
+                .build());
+        
+        Mockito.verify(listener, Mockito.times(1)).onConfigAdded(Mockito.any());
+    }
+    
+    @Test
+    public void confirmNotificationOnSettableConfigChange() throws ConfigException {
+        SettableConfig settable = new DefaultSettableConfig();
+        settable.setProperty("foo.bar", "original");
+        
+        com.netflix.archaius.api.config.CompositeConfig config = DefaultCompositeConfig.builder()
+                .withConfig("settable", settable)
+                .build();
+        
+        Config privateView = config.getPrivateView();
+        ConfigListener listener = Mockito.mock(ConfigListener.class);
+        privateView.addListener(listener);
+        
+        // Confirm original state
+        Assert.assertEquals("original", privateView.getString("foo.bar"));
+        Mockito.verify(listener, Mockito.times(0)).onConfigAdded(Mockito.any());
+
+        // Update the property and confirm onConfigUpdated notification
+        settable.setProperty("foo.bar", "new");
+        Mockito.verify(listener, Mockito.times(1)).onConfigUpdated(Mockito.any());
+        Assert.assertEquals("new", privateView.getString("foo.bar"));
+        
+        // Add a new config and confirm onConfigAdded notification
+        config.addConfig("new", MapConfig.builder().put("foo.bar", "new2").build());
+        Mockito.verify(listener, Mockito.times(1)).onConfigAdded(Mockito.any());
+        Mockito.verify(listener, Mockito.times(1)).onConfigUpdated(Mockito.any());
+    }
+}

--- a/archaius2-test/src/main/java/com/netflix/archaius/test/Archaius2TestConfig.java
+++ b/archaius2-test/src/main/java/com/netflix/archaius/test/Archaius2TestConfig.java
@@ -242,6 +242,11 @@ public class Archaius2TestConfig implements TestRule, SettableConfig {
     }
 
     @Override
+    public Config getPrivateView() {
+        return testCompositeConfig.getPrivateView();
+    }
+
+    @Override
     public void setStrInterpolator(StrInterpolator interpolator) {
         testCompositeConfig.setStrInterpolator(interpolator);
     }


### PR DESCRIPTION
Add a PrivateViewConfig class that allows usage of a "private" decoder or string interpolator.

The current implementation tries very hard to keep a single decoder and string interpolator in use throughout the entire configuration tree.

Because this existing behavior is probably depended on by someone, we introduce a new Config#getPrivateView method that returns an object that does NOT propagate changes to decoder and interpolator. This view is meant to be used locally by users that want a custom decoder for a specific use case.