### PR TITLE
Fix memory leak caused by anonymous listeners in abandoned views

### DIFF
--- a/archaius2-core/src/main/java/com/netflix/archaius/config/DependentConfigListener.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/DependentConfigListener.java
@@ -14,7 +14,7 @@ import java.util.Optional;
  *
  * @param <T> The type of the dependent config
  */
-public abstract class DependentConfigListener<T extends AbstractConfig> implements ConfigListener {
+abstract class DependentConfigListener<T extends AbstractConfig> implements ConfigListener {
     private final Reference<T> dependentConfigRef;
 
     DependentConfigListener(T dependentConfig) {
@@ -23,22 +23,22 @@ public abstract class DependentConfigListener<T extends AbstractConfig> implemen
 
     @Override
     public void onConfigAdded(Config config) {
-        updateState(config).ifPresent(vc -> onSourceConfigAdded(vc, config));
+        updateState(config).ifPresent(depConfig -> onSourceConfigAdded(depConfig, config));
     }
 
     @Override
     public void onConfigRemoved(Config config) {
-        updateState(config).ifPresent(vc -> onSourceConfigRemoved(vc, config));
+        updateState(config).ifPresent(depConfig -> onSourceConfigRemoved(depConfig, config));
     }
 
     @Override
     public void onConfigUpdated(Config config) {
-        updateState(config).ifPresent(vc -> onSourceConfigUpdated(vc, config));
+        updateState(config).ifPresent(depConfig -> onSourceConfigUpdated(depConfig, config));
     }
 
     @Override
     public void onError(Throwable error, Config config) {
-        updateState(config).ifPresent(vc -> onSourceError(error, vc, config));
+        updateState(config).ifPresent(depConfig -> onSourceError(error, depConfig, config));
     }
 
     public abstract void onSourceConfigAdded(T dependentConfig, Config sourceConfig);

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/DependentConfigListener.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/DependentConfigListener.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 /**
  * ConfigListener for the dependent/wrapper config paradigm. Most notably makes the reference to the dependent config
  * a weak reference and removes this listener from the source config so that any abandoned dependent configs can be
- * properly garbage collected
+ * properly garbage collected.
  *
  * @param <T> The type of the dependent config
  */

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/DependentConfigListener.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/DependentConfigListener.java
@@ -1,0 +1,65 @@
+package com.netflix.archaius.config;
+
+import com.netflix.archaius.api.Config;
+import com.netflix.archaius.api.ConfigListener;
+
+import java.lang.ref.Reference;
+import java.lang.ref.WeakReference;
+import java.util.Optional;
+
+/**
+ * ConfigListener for the dependent/wrapper config paradigm. Most notably makes the reference to the dependent config
+ * a weak reference and removes this listener from the source config so that any abandoned dependent configs can be
+ * properly garbage collected
+ *
+ * @param <T> The type of the dependent config
+ */
+public abstract class DependentConfigListener<T extends AbstractConfig> implements ConfigListener {
+    private final Reference<T> dependentConfigRef;
+
+    DependentConfigListener(T dependentConfig) {
+        dependentConfigRef = new WeakReference<>(dependentConfig);
+    }
+
+    @Override
+    public void onConfigAdded(Config config) {
+        updateState(config).ifPresent(vc -> onSourceConfigAdded(vc, config));
+    }
+
+    @Override
+    public void onConfigRemoved(Config config) {
+        updateState(config).ifPresent(vc -> onSourceConfigRemoved(vc, config));
+    }
+
+    @Override
+    public void onConfigUpdated(Config config) {
+        updateState(config).ifPresent(vc -> onSourceConfigUpdated(vc, config));
+    }
+
+    @Override
+    public void onError(Throwable error, Config config) {
+        updateState(config).ifPresent(vc -> onSourceError(error, vc, config));
+    }
+
+    public abstract void onSourceConfigAdded(T dependentConfig, Config sourceConfig);
+    public abstract void onSourceConfigRemoved(T dependentConfig, Config sourceConfig);
+    public abstract void onSourceConfigUpdated(T dependentConfig, Config sourceConfig);
+    public abstract void onSourceError(Throwable error, T dependentConfig, Config sourceConfig);
+
+    /**
+     * Checks that the dependent Config object is still alive, and if so it updates its local state from the wrapped
+     * source.
+     *
+     * @return An Optional with the dependent Config object IFF the weak reference to it is still alive, empty otherwise.
+     */
+    private Optional<T> updateState(Config updatedSourceConfig) {
+        T dependentConfig = dependentConfigRef.get();
+        if (dependentConfig != null) {
+            return Optional.of(dependentConfig);
+        } else {
+            // The view is gone, cleanup time!
+            updatedSourceConfig.removeListener(this);
+            return Optional.empty();
+        }
+    }
+}

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/PrefixedViewConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/PrefixedViewConfig.java
@@ -46,8 +46,8 @@ public class PrefixedViewConfig extends AbstractConfig {
         public State(Config config, String prefix) {
             data = new LinkedHashMap<String, Object>();
             config.forEachProperty((k, v) -> {
-                    if (k.startsWith(prefix)) {
-                        data.put(k.substring(prefix.length() + 1), v);
+                if (k.startsWith(prefix)) {
+                    data.put(k.substring(prefix.length()+1), v);
                 }
             });
         }

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/PrefixedViewConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/PrefixedViewConfig.java
@@ -46,8 +46,8 @@ public class PrefixedViewConfig extends AbstractConfig {
         public State(Config config, String prefix) {
             data = new LinkedHashMap<String, Object>();
             config.forEachProperty((k, v) -> {
-                if (k.startsWith(prefix)) {
-                    data.put(k.substring(prefix.length()), v);
+                    if (k.startsWith(prefix)) {
+                        data.put(k.substring(prefix.length()), v);
                 }
             });
         }
@@ -58,6 +58,7 @@ public class PrefixedViewConfig extends AbstractConfig {
         private PrefixedViewConfigListener(PrefixedViewConfig pvc) {
             super(pvc);
         }
+
         @Override
         public void onSourceConfigAdded(PrefixedViewConfig pvc, Config config) {
             pvc.updateState(config);

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/PrefixedViewConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/PrefixedViewConfig.java
@@ -47,7 +47,7 @@ public class PrefixedViewConfig extends AbstractConfig {
             data = new LinkedHashMap<String, Object>();
             config.forEachProperty((k, v) -> {
                     if (k.startsWith(prefix)) {
-                        data.put(k.substring(prefix.length()), v);
+                        data.put(k.substring(prefix.length() + 1), v);
                 }
             });
         }
@@ -81,7 +81,10 @@ public class PrefixedViewConfig extends AbstractConfig {
     
     public PrefixedViewConfig(final String prefix, final Config config) {
         this.config = config;
-        this.prefix = prefix.endsWith(".") ? prefix : prefix + ".";
+        // TODO: Change this line back to prefix.endsWith(".") ? prefix : prefix + "."
+        //       As is, an input of "foo." would require configs of form "foo..bar" which is odd.
+        //       In case anyone is relying on this behavior, we will fix this separately.
+        this.prefix = prefix;
         this.nonPrefixedLookup = ConfigStrLookup.from(config);
         this.state = new State(config, this.prefix);
         this.config.addListener(new PrefixedViewConfigListener(this));

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/PrivateViewConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/PrivateViewConfig.java
@@ -50,19 +50,19 @@ public class PrivateViewConfig extends AbstractConfig {
 
         @Override
         public void onSourceConfigAdded(PrivateViewConfig pvc, Config config) {
-            pvc.state = new State(config);
+            pvc.updateState(config);
             pvc.notifyConfigAdded(pvc);
         }
 
         @Override
         public void onSourceConfigRemoved(PrivateViewConfig pvc, Config config) {
-            pvc.state = new State(config);
+            pvc.updateState(config);
             pvc.notifyConfigRemoved(pvc);
         }
 
         @Override
         public void onSourceConfigUpdated(PrivateViewConfig pvc, Config config) {
-            pvc.state = new State(config);
+            pvc.updateState(config);
             pvc.notifyConfigUpdated(pvc);
         }
 
@@ -72,6 +72,10 @@ public class PrivateViewConfig extends AbstractConfig {
     }
 
     private volatile State state;
+
+    private void updateState(Config config) {
+        this.state = new State(config);
+    }
 
     public PrivateViewConfig(final Config wrappedConfig) {
         this.state = new State(wrappedConfig);

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/PrivateViewConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/PrivateViewConfig.java
@@ -15,13 +15,10 @@
  */
 package com.netflix.archaius.config;
 
-import java.lang.ref.Reference;
-import java.lang.ref.WeakReference;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Optional;
 
 import com.netflix.archaius.api.Config;
 import com.netflix.archaius.api.ConfigListener;
@@ -46,48 +43,31 @@ public class PrivateViewConfig extends AbstractConfig {
     }
 
     /** Listener to update our own state on upstream changes and then propagate the even to our own listeners. */
-    private static class ViewConfigListener implements ConfigListener {
-        private final Reference<PrivateViewConfig> vcRef;
-
-        private ViewConfigListener(PrivateViewConfig pvc) {
-            this.vcRef = new WeakReference<>(pvc);
+    private static class ViewConfigListener extends DependentConfigListener<PrivateViewConfig> {
+        private ViewConfigListener(PrivateViewConfig dependentConfig) {
+            super(dependentConfig);
         }
 
         @Override
-        public void onConfigAdded(Config config) {
-            updateState(config).ifPresent(vc -> vc.notifyConfigAdded(vc));
+        public void onSourceConfigAdded(PrivateViewConfig pvc, Config config) {
+            pvc.state = new State(config);
+            pvc.notifyConfigAdded(pvc);
         }
 
         @Override
-        public void onConfigRemoved(Config config) {
-            updateState(config).ifPresent(vc -> vc.notifyConfigRemoved(vc));
+        public void onSourceConfigRemoved(PrivateViewConfig pvc, Config config) {
+            pvc.state = new State(config);
+            pvc.notifyConfigRemoved(pvc);
         }
 
         @Override
-        public void onConfigUpdated(Config config) {
-            updateState(config).ifPresent(vc -> vc.notifyConfigUpdated(vc));
+        public void onSourceConfigUpdated(PrivateViewConfig pvc, Config config) {
+            pvc.state = new State(config);
+            pvc.notifyConfigUpdated(pvc);
         }
 
         @Override
-        public void onError(Throwable error, Config config) {
-        }
-
-        /**
-         * Checks that the PrivateViewConfig object is still alive, and if so it updates its local state from the wrapped
-         * source.
-         *
-         * @return An Optional with the PrivateViewConfig object IFF the weak reference to it is still alive, empty otherwise.
-         */
-        private Optional<PrivateViewConfig> updateState(Config updatedWrappedConfig) {
-            PrivateViewConfig pvc = vcRef.get();
-            if (pvc != null) {
-                pvc.state = new State(updatedWrappedConfig);
-                return Optional.of(pvc);
-            } else {
-                // The view is gone, cleanup time!
-                updatedWrappedConfig.removeListener(this);
-                return Optional.empty();
-            }
+        public void onSourceError(Throwable error, PrivateViewConfig pvc, Config config) {
         }
     }
 

--- a/archaius2-core/src/test/java/com/netflix/archaius/config/CompositeConfigTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/CompositeConfigTest.java
@@ -22,7 +22,6 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Properties;
-
 import java.util.Set;
 
 import com.netflix.archaius.api.Config;
@@ -33,7 +32,6 @@ import com.netflix.archaius.DefaultConfigLoader;
 import com.netflix.archaius.cascade.ConcatCascadeStrategy;
 import com.netflix.archaius.api.exceptions.ConfigException;
 import com.netflix.archaius.visitor.PrintStreamVisitor;
-import org.mockito.Mockito;
 
 public class CompositeConfigTest {
     @Test

--- a/archaius2-core/src/test/java/com/netflix/archaius/config/CompositeConfigTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/CompositeConfigTest.java
@@ -25,6 +25,7 @@ import java.util.Properties;
 import java.util.Set;
 
 import com.netflix.archaius.api.Config;
+import com.netflix.archaius.api.config.SettableConfig;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -151,8 +152,9 @@ public class CompositeConfigTest {
 
     @Test
     public void unusedCompositeConfigIsGarbageCollected() throws ConfigException {
+        SettableConfig sourceConfig = new DefaultSettableConfig();
         com.netflix.archaius.api.config.CompositeConfig config = DefaultCompositeConfig.builder()
-                .withConfig("settable", new DefaultSettableConfig())
+                .withConfig("settable", sourceConfig)
                 .build();
         Reference<Config> weakReference = new WeakReference<>(config);
 

--- a/archaius2-core/src/test/java/com/netflix/archaius/config/DefaultLayeredConfigTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/DefaultLayeredConfigTest.java
@@ -6,7 +6,6 @@ import com.netflix.archaius.api.ConfigListener;
 import com.netflix.archaius.api.config.LayeredConfig;
 import com.netflix.archaius.api.config.SettableConfig;
 
-import com.netflix.archaius.api.exceptions.ConfigException;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;

--- a/archaius2-core/src/test/java/com/netflix/archaius/config/DefaultLayeredConfigTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/DefaultLayeredConfigTest.java
@@ -135,8 +135,9 @@ public class DefaultLayeredConfigTest {
 
     @Test
     public void unusedLayeredConfigIsGarbageCollected() {
+        SettableConfig sourceConfig = new DefaultSettableConfig();
         LayeredConfig config = new DefaultLayeredConfig();
-        config.addConfig(Layers.LIBRARY, new DefaultSettableConfig());
+        config.addConfig(Layers.LIBRARY, sourceConfig);
         Reference<Config> weakReference = new WeakReference<>(config);
 
         // No more pointers to prefix means this should be garbage collected and any additional listeners on it

--- a/archaius2-core/src/test/java/com/netflix/archaius/config/DefaultLayeredConfigTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/DefaultLayeredConfigTest.java
@@ -1,13 +1,18 @@
 package com.netflix.archaius.config;
 
 import com.netflix.archaius.Layers;
+import com.netflix.archaius.api.Config;
 import com.netflix.archaius.api.ConfigListener;
 import com.netflix.archaius.api.config.LayeredConfig;
 import com.netflix.archaius.api.config.SettableConfig;
 
+import com.netflix.archaius.api.exceptions.ConfigException;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
+
+import java.lang.ref.Reference;
+import java.lang.ref.WeakReference;
 
 public class DefaultLayeredConfigTest {
     @Test
@@ -127,5 +132,17 @@ public class DefaultLayeredConfigTest {
         
         config.removeConfig(Layers.RUNTIME, runtimeConfig.getName());
         Assert.assertEquals(appConfig.getName(), config.getRawProperty("propname"));
+    }
+
+    @Test
+    public void unusedLayeredConfigIsGarbageCollected() {
+        LayeredConfig config = new DefaultLayeredConfig();
+        config.addConfig(Layers.LIBRARY, new DefaultSettableConfig());
+        Reference<Config> weakReference = new WeakReference<>(config);
+
+        // No more pointers to prefix means this should be garbage collected and any additional listeners on it
+        config = null;
+        System.gc();
+        Assert.assertNull(weakReference.get());
     }
 }

--- a/archaius2-core/src/test/java/com/netflix/archaius/config/PrefixedViewTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/PrefixedViewTest.java
@@ -63,7 +63,8 @@ public class PrefixedViewTest {
 
     @Test
     public void unusedPrefixedViewIsGarbageCollected() {
-        Config prefix = new DefaultSettableConfig().getPrefixedView("foo.");
+        SettableConfig sourceConfig = new DefaultSettableConfig();
+        Config prefix = sourceConfig.getPrefixedView("foo.");
         Reference<Config> weakReference = new WeakReference<>(prefix);
 
         // No more pointers to prefix means this should be garbage collected and any additional listeners on it

--- a/archaius2-core/src/test/java/com/netflix/archaius/config/PrivateViewTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/PrivateViewTest.java
@@ -87,7 +87,8 @@ public class PrivateViewTest {
     }
     @Test
     public void unusedPrivateViewIsGarbageCollected() {
-        Config privateView = new DefaultSettableConfig().getPrivateView();
+        SettableConfig sourceConfig = new DefaultSettableConfig();
+        Config privateView = sourceConfig.getPrivateView();
         Reference<Config> weakReference = new WeakReference<>(privateView);
 
         // No more pointers to prefix means this should be garbage collected and any additional listeners on it

--- a/archaius2-core/src/test/java/com/netflix/archaius/config/PrivateViewTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/PrivateViewTest.java
@@ -9,6 +9,9 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import java.lang.ref.Reference;
+import java.lang.ref.WeakReference;
+
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 
@@ -81,5 +84,15 @@ public class PrivateViewTest {
         config.addConfig("new", MapConfig.builder().put("foo.bar", "new2").build());
         Mockito.verify(listener, Mockito.times(1)).onConfigAdded(Mockito.any());
         Mockito.verify(listener, Mockito.times(1)).onConfigUpdated(Mockito.any());
+    }
+    @Test
+    public void unusedPrivateViewIsGarbageCollected() {
+        Config privateView = new DefaultSettableConfig().getPrivateView();
+        Reference<Config> weakReference = new WeakReference<>(privateView);
+
+        // No more pointers to prefix means this should be garbage collected and any additional listeners on it
+        privateView = null;
+        System.gc();
+        Assert.assertNull(weakReference.get());
     }
 }


### PR DESCRIPTION
Views created that depend on other views (Composite, Layered, and Prefixed) create listeners on the source view that update themselves. This reference to themselves prevents GC until the source view is abandoned, meaning creating unused dependent views is a memory and performance leak. This applies the WeakReference logic from the PrivateView to the other dependent view types in order to fix this leak.

There is a small bug in PrefixedViewConfig where we supposedly allow prefixes of form "foo" or "foo.", but any prefix of form "foo." will actually still assume form "foo", meaning that configs such as "foo.bar" would, in the prefixed view, be taken as configs of type "ar" instead of the expected "bar".  I'll address this in a followup change in case there is anyone relying on this behavior.