### PR TITLE
Update PrefixedViewConfig to properly handle trailing dot case

### DIFF
--- a/archaius2-core/src/main/java/com/netflix/archaius/config/PrefixedViewConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/PrefixedViewConfig.java
@@ -47,7 +47,7 @@ public class PrefixedViewConfig extends AbstractConfig {
             data = new LinkedHashMap<String, Object>();
             config.forEachProperty((k, v) -> {
                 if (k.startsWith(prefix)) {
-                    data.put(k.substring(prefix.length()+1), v);
+                    data.put(k.substring(prefix.length()), v);
                 }
             });
         }
@@ -81,10 +81,7 @@ public class PrefixedViewConfig extends AbstractConfig {
     
     public PrefixedViewConfig(final String prefix, final Config config) {
         this.config = config;
-        // TODO: Change this line back to prefix.endsWith(".") ? prefix : prefix + "."
-        //       As is, an input of "foo." would require configs of form "foo..bar" which is odd.
-        //       In case anyone is relying on this behavior, we will fix this separately.
-        this.prefix = prefix;
+        this.prefix = prefix.endsWith(".") ? prefix : prefix + ".";
         this.nonPrefixedLookup = ConfigStrLookup.from(config);
         this.state = new State(config, this.prefix);
         this.config.addListener(new PrefixedViewConfigListener(this));

--- a/archaius2-core/src/test/java/com/netflix/archaius/config/PrefixedViewTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/PrefixedViewTest.java
@@ -62,6 +62,18 @@ public class PrefixedViewTest {
     }
 
     @Test
+    public void trailingDotAllowed() {
+        SettableConfig settable = new DefaultSettableConfig();
+        settable.setProperty("foo.bar", "value");
+
+        Config prefixNoDot = settable.getPrefixedView("foo");
+        Config prefixWithDot = settable.getPrefixedView("foo.");
+
+        Assert.assertEquals(prefixNoDot.getString("bar"), "value");
+        Assert.assertEquals(prefixWithDot.getString("bar"), "value");
+    }
+
+    @Test
     public void unusedPrefixedViewIsGarbageCollected() {
         SettableConfig sourceConfig = new DefaultSettableConfig();
         Config prefix = sourceConfig.getPrefixedView("foo.");


### PR DESCRIPTION
Current behavior for PrefixedViewConfig is that, for a prefix of form "foo." we expect configs of form "foo..bar", which is unusual.

We update PrefixedViewConfig to properly accept prefixes of form "foo." and expect configs of form "foo.bar". 