### PR TITLE
Improve Gradle build performance

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,3 @@
 version=2.0.0-SNAPSHOT
+org.gradle.caching = true
+org.gradle.parallel = true


### PR DESCRIPTION
Parallel builds. This project contains multiple modules. Parallel builds can improve the build speed by executing tasks in parallel. We can enable this feature by setting org.gradle.parallel=true.

Gradle caching. Shared caches can reduce the number of tasks you need to execute by reusing outputs already generated elsewhere. This can significantly decrease build times. We can enable this feature by setting org.gradle.caching=true.

Copy of https://github.com/Netflix/archaius/pull/626 rebased against 2.x
Credit to @shisheng-1