### PR TITLE
Disallow mutation of internal config state via keys Iterator

### DIFF
--- a/archaius2-core/src/main/java/com/netflix/archaius/config/DefaultCompositeConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/DefaultCompositeConfig.java
@@ -81,8 +81,9 @@ public class DefaultCompositeConfig extends AbstractConfig implements com.netfli
         
         public State(Map<String, Config> children, int size) {
             this.children = children;
-            this.data = new HashMap<>(size);
+            Map<String, Object> data = new HashMap<>(size);
             children.values().forEach(child -> child.forEachProperty(data::putIfAbsent));
+            this.data = Collections.unmodifiableMap(data);
         }
         
         State addConfig(String name, Config config) {
@@ -269,7 +270,7 @@ public class DefaultCompositeConfig extends AbstractConfig implements com.netfli
     public Iterator<String> getKeys() {
         return state.data.keySet().iterator();
     }
-    
+
     @Override
     public synchronized <T> T accept(Visitor<T> visitor) {
         AtomicReference<T> result = new AtomicReference<>(null);
@@ -309,6 +310,6 @@ public class DefaultCompositeConfig extends AbstractConfig implements com.netfli
 
     @Override
     public String toString() {
-        return "[" + state.children.keySet().stream().collect(Collectors.joining(" ")) + "]";
+        return "[" + String.join(" ", state.children.keySet()) + "]";
     }
 }

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/DefaultLayeredConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/DefaultLayeredConfig.java
@@ -212,8 +212,9 @@ public class DefaultLayeredConfig extends AbstractConfig implements LayeredConfi
         ImmutableCompositeState(List<LayerAndConfig> entries) {
             this.children = entries;
             this.children.sort(ByPriorityAndInsertionOrder);
-            this.data = new HashMap<>();
+            Map<String, Object> data = new HashMap<>();
             this.children.forEach(child -> child.config.forEachProperty(data::putIfAbsent));
+            this.data = Collections.unmodifiableMap(data);
         }
         
         public ImmutableCompositeState addChild(LayerAndConfig layerAndConfig) {

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/MapConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/MapConfig.java
@@ -41,7 +41,7 @@ public class MapConfig extends AbstractConfig {
      * }
      */
     public static class Builder {
-        Map<String, String> map = new HashMap<String, String>();
+        Map<String, String> map = new HashMap<>();
         String named;
         
         public <T> Builder put(String key, T value) {
@@ -81,14 +81,13 @@ public class MapConfig extends AbstractConfig {
         return new MapConfig(props);
     }
     
-    private Map<String, String> props = new HashMap<String, String>();
+    private final Map<String, String> props;
     
     public MapConfig(String name, Map<String, String> props) {
         super(name);
-        this.props.putAll(props);
-        this.props = Collections.unmodifiableMap(this.props);
+        this.props = Collections.unmodifiableMap(new HashMap<>(props));
     }
-    
+
     /**
      * Construct a MapConfig as a copy of the provided Map
      * @param name
@@ -96,8 +95,7 @@ public class MapConfig extends AbstractConfig {
      */
     public MapConfig(Map<String, String> props) {
         super(generateUniqueName("immutable-"));
-        this.props.putAll(props);
-        this.props = Collections.unmodifiableMap(this.props);
+        this.props = Collections.unmodifiableMap(new HashMap<>(props));
     }
 
     /**
@@ -107,10 +105,11 @@ public class MapConfig extends AbstractConfig {
      */
     public MapConfig(Properties props) {
         super(generateUniqueName("immutable-"));
+        Map<String, String> properties = new HashMap<>();
         for (Entry<Object, Object> entry : props.entrySet()) {
-            this.props.put(entry.getKey().toString(), entry.getValue().toString());
+            properties.put(entry.getKey().toString(), entry.getValue().toString());
         }
-        this.props = Collections.unmodifiableMap(this.props);
+        this.props = Collections.unmodifiableMap(properties);
     }
     
     @Override

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/PollingDynamicConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/PollingDynamicConfig.java
@@ -15,7 +15,7 @@
  */
 package com.netflix.archaius.config;
 
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -37,7 +37,7 @@ import com.netflix.archaius.config.polling.PollingResponse;
 public class PollingDynamicConfig extends AbstractConfig {
     private static final Logger LOG = LoggerFactory.getLogger(PollingDynamicConfig.class);
     
-    private volatile Map<String, String> current = new HashMap<String, String>();
+    private volatile Map<String, String> current = Collections.emptyMap();
     private final AtomicBoolean busy = new AtomicBoolean();
     private final Callable<PollingResponse> reader;
     private final AtomicLong updateCounter = new AtomicLong();
@@ -81,7 +81,7 @@ public class PollingDynamicConfig extends AbstractConfig {
             try {
                 PollingResponse response = reader.call();
                 if (response.hasData()) {
-                    current = response.getToAdd();
+                    current = Collections.unmodifiableMap(response.getToAdd());
                     notifyConfigUpdated(this);
                 }
             }

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/PrefixedViewConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/PrefixedViewConfig.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.archaius.config;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -44,12 +45,13 @@ public class PrefixedViewConfig extends AbstractConfig {
         final Map<String, Object> data;
         
         public State(Config config, String prefix) {
-            data = new LinkedHashMap<String, Object>();
+            Map<String, Object> data = new LinkedHashMap<>();
             config.forEachProperty((k, v) -> {
                 if (k.startsWith(prefix)) {
                     data.put(k.substring(prefix.length()), v);
                 }
             });
+            this.data = Collections.unmodifiableMap(data);
         }
     }
 

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/PrivateViewConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/PrivateViewConfig.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.archaius.config;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -37,8 +38,9 @@ public class PrivateViewConfig extends AbstractConfig {
         final Map<String, Object> data;
 
         public State(Config config) {
-            data = new LinkedHashMap<>();
+            Map<String, Object> data = new LinkedHashMap<>();
             config.forEachProperty(data::put);
+            this.data = Collections.unmodifiableMap(data);
         }
     }
 

--- a/archaius2-core/src/test/java/com/netflix/archaius/DefaultConfigLoaderTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/DefaultConfigLoaderTest.java
@@ -13,6 +13,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Properties;
 import java.util.Set;
 
@@ -39,7 +40,7 @@ public class DefaultConfigLoaderTest {
         when(mockContext.resolve(anyString())).thenReturn("resolved");
         StrInterpolator mockStrInterpolator = mock(StrInterpolator.class);
         when(mockStrInterpolator.create(any(StrInterpolator.Lookup.class))).thenReturn(mockContext);
-        Set<ConfigReader> readers = new HashSet();
+        Set<ConfigReader> readers = new HashSet<>();
         ConfigReader reader1 = new PropertiesConfigReader();
         ConfigReader reader2 = new PropertiesConfigReader();
         readers.add(reader1);
@@ -58,9 +59,9 @@ public class DefaultConfigLoaderTest {
 
     @Test
     public void testDefaultLoaderBehavior() throws ConfigException {
-        Config applicationConfig = DefaultConfigLoader.builder().build().newLoader().load("application");
+        CompositeConfig applicationConfig = DefaultConfigLoader.builder().build().newLoader().load("application");
         Config applicationProdConfig = DefaultConfigLoader.builder().build().newLoader().load("application-prod");
-        ((CompositeConfig) applicationConfig).addConfig("prod", applicationProdConfig);
+        applicationConfig.addConfig("prod", applicationProdConfig);
         Assert.assertEquals(applicationConfig.getString("application.list2"), "a,b");
         Assert.assertEquals(applicationConfig.getBoolean("application-prod.loaded"), true);
     }

--- a/archaius2-core/src/test/java/com/netflix/archaius/config/CompositeConfigTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/CompositeConfigTest.java
@@ -151,6 +151,20 @@ public class CompositeConfigTest {
     }
 
     @Test
+    public void testGetKeysIteratorRemoveThrows() throws ConfigException {
+        com.netflix.archaius.api.config.CompositeConfig composite = new DefaultCompositeConfig();
+
+
+        composite.addConfig("d", MapConfig.builder().put("d1", "A").put("d2",  "B").build());
+        composite.addConfig("e", MapConfig.builder().put("e1", "A").put("e2",  "B").build());
+
+        Iterator<String> keys = composite.getKeys();
+        Assert.assertTrue(keys.hasNext());
+        keys.next();
+        Assert.assertThrows(UnsupportedOperationException.class, keys::remove);
+    }
+
+    @Test
     public void unusedCompositeConfigIsGarbageCollected() throws ConfigException {
         SettableConfig sourceConfig = new DefaultSettableConfig();
         com.netflix.archaius.api.config.CompositeConfig config = DefaultCompositeConfig.builder()
@@ -170,7 +184,7 @@ public class CompositeConfigTest {
 
     private static Set<String> set(Iterator<String> values) {
         Set<String> vals = new LinkedHashSet<>();
-        values.forEachRemaining(e -> vals.add(e));
+        values.forEachRemaining(vals::add);
         return Collections.unmodifiableSet(vals);
     }
 }

--- a/archaius2-core/src/test/java/com/netflix/archaius/config/DefaultLayeredConfigTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/DefaultLayeredConfigTest.java
@@ -12,6 +12,7 @@ import org.mockito.Mockito;
 
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
+import java.util.Iterator;
 
 public class DefaultLayeredConfigTest {
     @Test
@@ -144,5 +145,47 @@ public class DefaultLayeredConfigTest {
         config = null;
         System.gc();
         Assert.assertNull(weakReference.get());
+    }
+
+    @Test
+    public void testGetKeys() {
+        LayeredConfig config = new DefaultLayeredConfig();
+        MapConfig appConfig = MapConfig.builder()
+                .put("propname", Layers.APPLICATION.getName())
+                .name(Layers.APPLICATION.getName())
+                .build();
+
+        MapConfig libConfig = MapConfig.builder()
+                .put("propname", Layers.LIBRARY.getName() + "1")
+                .name(Layers.LIBRARY.getName() + "1")
+                .build();
+        config.addConfig(Layers.APPLICATION, appConfig);
+        config.addConfig(Layers.LIBRARY, libConfig);
+
+        Iterator<String> keys = config.getKeys();
+        Assert.assertTrue(keys.hasNext());
+        Assert.assertEquals("propname", keys.next());
+        Assert.assertFalse(keys.hasNext());
+    }
+
+    @Test
+    public void testGetKeysIteratorRemoveThrows() {
+        LayeredConfig config = new DefaultLayeredConfig();
+        MapConfig appConfig = MapConfig.builder()
+                .put("propname", Layers.APPLICATION.getName())
+                .name(Layers.APPLICATION.getName())
+                .build();
+
+        MapConfig libConfig = MapConfig.builder()
+                .put("propname", Layers.LIBRARY.getName() + "1")
+                .name(Layers.LIBRARY.getName() + "1")
+                .build();
+        config.addConfig(Layers.APPLICATION, appConfig);
+        config.addConfig(Layers.LIBRARY, libConfig);
+
+        Iterator<String> keys = config.getKeys();
+        Assert.assertTrue(keys.hasNext());
+        keys.next();
+        Assert.assertThrows(UnsupportedOperationException.class, keys::remove);
     }
 }

--- a/archaius2-core/src/test/java/com/netflix/archaius/config/MapConfigTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/MapConfigTest.java
@@ -15,7 +15,12 @@
  */
 package com.netflix.archaius.config;
 
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.Ignore;
@@ -26,7 +31,7 @@ import com.netflix.archaius.api.exceptions.ConfigException;
 import com.netflix.archaius.exceptions.ParseException;
 
 public class MapConfigTest {
-    private MapConfig config = MapConfig.builder()
+    private final MapConfig config = MapConfig.builder()
             .put("str", "value")
             .put("badnumber", "badnumber")
             .build();
@@ -177,6 +182,37 @@ public class MapConfigTest {
         
         Assert.assertEquals((long)123L, (long)config.getLong("value"));
     }
-    
 
+    @Test
+    public void getKeys() {
+        Map<String, String> props = new HashMap<>();
+        props.put("key1", "value1");
+        props.put("key2", "value2");
+
+        Config config = MapConfig.from(props);
+
+        Iterator<String> keys = config.getKeys();
+        Assert.assertTrue(keys.hasNext());
+
+        Set<String> keySet = new HashSet<>();
+        while (keys.hasNext()) {
+            keySet.add(keys.next());
+        }
+
+        Assert.assertEquals(2, keySet.size());
+        Assert.assertEquals(props.keySet(), keySet);
+    }
+
+    @Test
+    public void getKeysIteratorRemoveThrows() {
+        Config config = MapConfig.builder()
+                .put("key1", "value1")
+                .put("key2", "value2")
+                .build();
+        Iterator<String> keys = config.getKeys();
+
+        Assert.assertTrue(keys.hasNext());
+        keys.next();
+        Assert.assertThrows(UnsupportedOperationException.class, keys::remove);
+    }
 }

--- a/archaius2-core/src/test/java/com/netflix/archaius/config/PrefixedViewTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/PrefixedViewTest.java
@@ -7,6 +7,9 @@ import com.netflix.archaius.api.exceptions.ConfigException;
 
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -83,5 +86,36 @@ public class PrefixedViewTest {
         prefix = null;
         System.gc();
         Assert.assertNull(weakReference.get());
+    }
+
+    @Test
+    public void testGetKeys() {
+        Config config = MapConfig.builder()
+                .put("foo.prop1", "value1")
+                .put("foo.prop2", "value2")
+                .build()
+                .getPrefixedView("foo");
+
+        Iterator<String> keys = config.getKeys();
+        Set<String> keySet = new HashSet<>();
+        while (keys.hasNext()) {
+            keySet.add(keys.next());
+        }
+        Assert.assertEquals(2, keySet.size());
+        Assert.assertTrue(keySet.contains("prop1"));
+        Assert.assertTrue(keySet.contains("prop2"));
+    }
+
+    @Test
+    public void testGetKeysIteratorRemoveThrows() {
+        Config config = MapConfig.builder()
+                .put("foo.prop1", "value1")
+                .put("foo.prop2", "value2")
+                .build()
+                .getPrefixedView("foo");
+
+        Iterator<String> keys = config.getKeys();
+        keys.next();
+        Assert.assertThrows(UnsupportedOperationException.class, keys::remove);
     }
 }

--- a/archaius2-core/src/test/java/com/netflix/archaius/config/PrivateViewTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/PrivateViewTest.java
@@ -11,6 +11,9 @@ import org.mockito.Mockito;
 
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
 
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
@@ -95,5 +98,36 @@ public class PrivateViewTest {
         privateView = null;
         System.gc();
         Assert.assertNull(weakReference.get());
+    }
+
+    @Test
+    public void testGetKeys() {
+        Config config = MapConfig.builder()
+                .put("foo", "foo-value")
+                .put("bar", "bar-value")
+                .build()
+                .getPrivateView();
+
+        Iterator<String> keys = config.getKeys();
+        Set<String> keySet = new HashSet<>();
+        while (keys.hasNext()) {
+            keySet.add(keys.next());
+        }
+        Assert.assertEquals(2, keySet.size());
+        Assert.assertTrue(keySet.contains("foo"));
+        Assert.assertTrue(keySet.contains("bar"));
+    }
+
+    @Test
+    public void testGetKeysIteratorRemoveThrows() {
+        Config config = MapConfig.builder()
+                .put("foo", "foo-value")
+                .put("bar", "bar-value")
+                .build()
+                .getPrivateView();
+
+        Iterator<String> keys = config.getKeys();
+        keys.next();
+        Assert.assertThrows(UnsupportedOperationException.class, keys::remove);
     }
 }


### PR DESCRIPTION
Config implementations exposed internal mutable state by returning keySet iterators for their underlying Maps because the default Iterator for HashMap / LinkedHashMap implements remove. Wrap all of the maps with Collections.unmodifiableMap to avoid the issue.