### PR TITLE
Revert Jackson dep to 2.4.3

### DIFF
--- a/archaius2-persisted2/build.gradle
+++ b/archaius2-persisted2/build.gradle
@@ -18,8 +18,8 @@ apply plugin: 'java-library'
 
 dependencies {
     api  project(':archaius2-core')
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.14.2'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.2'
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.4.3'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.4.3'
     implementation 'org.apache.commons:commons-lang3:3.3.2'
     implementation 'org.slf4j:slf4j-api:1.7.36'
 


### PR DESCRIPTION
The update to 2.14.2 is causing issues in some downstream dependency resolution. We did two updates, one from 2.4.3 to 2.10.3 and then again to 2.14.2, but since we didn't have a version release in between, I'm reverting to the 2.4.3 for safety.