### PR TITLE
Add ability to get an Iterable of keys from a Config

### DIFF
--- a/archaius2-api/src/main/java/com/netflix/archaius/api/Config.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/api/Config.java
@@ -135,9 +135,16 @@ public interface Config extends PropertySource {
     boolean containsKey(String key);
     
     /**
-     * @return Return an iterator to all property names owned by this config
+     * @return Return an unmodifiable Iterator to all property names owned by this config
      */
     Iterator<String> getKeys();
+
+    /**
+     * @return Return an unmodifiable Iterable of all property names owned by this config.
+     */
+    default Iterable<String> keys() {
+        return this::getKeys;
+    }
     
     /**
      * @return Return an interator to all prefixed property names owned by this config

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/AbstractConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/AbstractConfig.java
@@ -436,9 +436,7 @@ public abstract class AbstractConfig implements Config {
     
     @Override
     public void forEachProperty(BiConsumer<String, Object> consumer) {
-        Iterator<String> keys = getKeys();
-        while (keys.hasNext()) {
-            String key = keys.next();
+        for (String key : keys()) {
             Object value = this.getRawProperty(key);
             if (value != null) {
                 consumer.accept(key, value);

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/DefaultCompositeConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/DefaultCompositeConfig.java
@@ -272,6 +272,11 @@ public class DefaultCompositeConfig extends AbstractConfig implements com.netfli
     }
 
     @Override
+    public Iterable<String> keys() {
+        return state.data.keySet();
+    }
+
+    @Override
     public synchronized <T> T accept(Visitor<T> visitor) {
         AtomicReference<T> result = new AtomicReference<>(null);
         if (visitor instanceof CompositeVisitor) {

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/DefaultLayeredConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/DefaultLayeredConfig.java
@@ -263,4 +263,9 @@ public class DefaultLayeredConfig extends AbstractConfig implements LayeredConfi
     public Iterator<String> getKeys() {
         return state.data.keySet().iterator();
     }
+
+    @Override
+    public Iterable<String> keys() {
+        return state.data.keySet();
+    }
 }

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/DefaultSettableConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/DefaultSettableConfig.java
@@ -36,23 +36,23 @@ public class DefaultSettableConfig extends AbstractConfig implements SettableCon
     public DefaultSettableConfig() {
         super(generateUniqueName("settable-"));
     }
-    
+
     @Override
     public synchronized <T> void setProperty(String propName, T propValue) {
         Map<String, Object> copy = new HashMap<>(props.size() + 1);
         copy.putAll(props);
         copy.put(propName, propValue);
-        props = copy;
+        props = Collections.unmodifiableMap(copy);
         notifyConfigUpdated(this);
     }
-    
+
     @Override
     public void clearProperty(String propName) {
         if (props.containsKey(propName)) {
             synchronized (this) {
                 Map<String, Object> copy = new HashMap<>(props);
                 copy.remove(propName);
-                props = copy;
+                props = Collections.unmodifiableMap(copy);
                 notifyConfigUpdated(this);
             }
         }
@@ -79,6 +79,11 @@ public class DefaultSettableConfig extends AbstractConfig implements SettableCon
     }
 
     @Override
+    public Iterable<String> keys() {
+        return props.keySet();
+    }
+
+    @Override
     public void setProperties(Properties src) {
         if (null != src) {
             synchronized (this) {
@@ -87,7 +92,7 @@ public class DefaultSettableConfig extends AbstractConfig implements SettableCon
                 for (Entry<Object, Object> prop : src.entrySet()) {
                     copy.put(prop.getKey().toString(), prop.getValue());
                 }
-                props = copy;
+                props = Collections.unmodifiableMap(copy);
                 notifyConfigUpdated(this);
             }
         }
@@ -99,7 +104,7 @@ public class DefaultSettableConfig extends AbstractConfig implements SettableCon
             synchronized (this) {
                 Map<String, Object> copy = new HashMap<>(props);
                 src.forEachProperty(copy::put);
-                props = copy;
+                props = Collections.unmodifiableMap(copy);
                 notifyConfigUpdated(this);
             }
         }

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/EmptyConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/EmptyConfig.java
@@ -17,6 +17,7 @@ package com.netflix.archaius.config;
 
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.Optional;
 import java.util.function.BiConsumer;
 
 public final class EmptyConfig extends AbstractConfig {
@@ -39,6 +40,16 @@ public final class EmptyConfig extends AbstractConfig {
     @Override
     public Iterator<String> getKeys() {
         return Collections.emptyIterator();
+    }
+
+    @Override
+    public Iterable<String> keys() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Optional<Object> getProperty(String key) {
+        return Optional.empty();
     }
 
     @Override

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/EnvironmentConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/EnvironmentConfig.java
@@ -50,6 +50,11 @@ public class EnvironmentConfig extends AbstractConfig {
     }
 
     @Override
+    public Iterable<String> keys() {
+        return properties.keySet();
+    }
+
+    @Override
     public void forEachProperty(BiConsumer<String, Object> consumer) {
         properties.forEach(consumer);
     }

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/MapConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/MapConfig.java
@@ -132,6 +132,11 @@ public class MapConfig extends AbstractConfig {
     }
 
     @Override
+    public Iterable<String> keys() {
+        return props.keySet();
+    }
+
+    @Override
     public void forEachProperty(BiConsumer<String, Object> consumer) {
         props.forEach(consumer);
     }

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/PollingDynamicConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/PollingDynamicConfig.java
@@ -121,6 +121,11 @@ public class PollingDynamicConfig extends AbstractConfig {
     }
 
     @Override
+    public Iterable<String> keys() {
+        return current.keySet();
+    }
+
+    @Override
     public void forEachProperty(BiConsumer<String, Object> consumer) {
         current.forEach(consumer);
     }

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/PrefixedViewConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/PrefixedViewConfig.java
@@ -99,6 +99,11 @@ public class PrefixedViewConfig extends AbstractConfig {
     }
 
     @Override
+    public Iterable<String> keys() {
+        return state.data.keySet();
+    }
+
+    @Override
     public boolean containsKey(String key) {
         return state.data.containsKey(key);
     }

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/PrivateViewConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/PrivateViewConfig.java
@@ -90,6 +90,11 @@ public class PrivateViewConfig extends AbstractConfig {
     }
 
     @Override
+    public Iterable<String> keys() {
+        return state.data.keySet();
+    }
+
+    @Override
     public boolean containsKey(String key) {
         return state.data.containsKey(key);
     }

--- a/archaius2-core/src/test/java/com/netflix/archaius/TestUtils.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/TestUtils.java
@@ -1,0 +1,37 @@
+package com.netflix.archaius;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+public class TestUtils {
+    @SafeVarargs
+    public static <T> Set<T> set(T ... values) {
+        return Collections.unmodifiableSet(new LinkedHashSet<>(Arrays.asList(values)));
+    }
+
+    public static <T> Set<T> set(Iterator<T> values) {
+        Set<T> vals = new LinkedHashSet<>();
+        values.forEachRemaining(vals::add);
+        return Collections.unmodifiableSet(vals);
+    }
+
+    public static <T> Set<T> set(Iterable<T> values) {
+        return values instanceof Collection<?> ? new HashSet<>((Collection<T>) values) : set(values.iterator());
+    }
+
+    public static <T> int size(Iterable<T> values) {
+        if (values instanceof Collection<?>) {
+            return ((Collection<?>) values).size();
+        }
+        int count = 0;
+        for (T el : values) {
+            count++;
+        }
+        return count;
+    }
+}

--- a/archaius2-core/src/test/java/com/netflix/archaius/config/DefaultLayeredConfigTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/DefaultLayeredConfigTest.java
@@ -12,7 +12,11 @@ import org.mockito.Mockito;
 
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
+import java.util.Collection;
 import java.util.Iterator;
+
+import static com.netflix.archaius.TestUtils.set;
+import static com.netflix.archaius.TestUtils.size;
 
 public class DefaultLayeredConfigTest {
     @Test
@@ -187,5 +191,44 @@ public class DefaultLayeredConfigTest {
         Assert.assertTrue(keys.hasNext());
         keys.next();
         Assert.assertThrows(UnsupportedOperationException.class, keys::remove);
+    }
+
+    @Test
+    public void testKeysIterable() {
+        LayeredConfig config = new DefaultLayeredConfig();
+        MapConfig appConfig = MapConfig.builder()
+                .put("propname", Layers.APPLICATION.getName())
+                .name(Layers.APPLICATION.getName())
+                .build();
+
+        MapConfig libConfig = MapConfig.builder()
+                .put("propname", Layers.LIBRARY.getName() + "1")
+                .name(Layers.LIBRARY.getName() + "1")
+                .build();
+        config.addConfig(Layers.APPLICATION, appConfig);
+        config.addConfig(Layers.LIBRARY, libConfig);
+
+        Iterable<String> keys = config.keys();
+        Assert.assertEquals(1, size(keys));
+        Assert.assertEquals(set("propname"), set(keys));
+    }
+
+    @Test
+    public void testKeysIterableModificationThrows() {
+        LayeredConfig config = new DefaultLayeredConfig();
+        MapConfig appConfig = MapConfig.builder()
+                .put("propname", Layers.APPLICATION.getName())
+                .name(Layers.APPLICATION.getName())
+                .build();
+
+        MapConfig libConfig = MapConfig.builder()
+                .put("propname", Layers.LIBRARY.getName() + "1")
+                .name(Layers.LIBRARY.getName() + "1")
+                .build();
+        config.addConfig(Layers.APPLICATION, appConfig);
+        config.addConfig(Layers.LIBRARY, libConfig);
+
+        Assert.assertThrows(UnsupportedOperationException.class, config.keys().iterator()::remove);
+        Assert.assertThrows(UnsupportedOperationException.class, ((Collection<String>) config.keys())::clear);
     }
 }

--- a/archaius2-core/src/test/java/com/netflix/archaius/config/DefaultSettableConfigTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/DefaultSettableConfigTest.java
@@ -1,0 +1,111 @@
+package com.netflix.archaius.config;
+
+import com.netflix.archaius.api.config.SettableConfig;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Properties;
+
+import static com.netflix.archaius.TestUtils.set;
+import static com.netflix.archaius.TestUtils.size;
+
+public class DefaultSettableConfigTest {
+
+    @Test
+    public void testGetKeys() {
+        SettableConfig config = new DefaultSettableConfig();
+
+        Assert.assertFalse(config.getKeys().hasNext());
+
+        config.setProperty("prop1", "value1");
+        config.setProperty("prop2", "value2");
+        config.setProperty("prop3", "value3");
+
+        Assert.assertEquals(set("prop1", "prop2", "prop3"), set(config.getKeys()));
+
+        config.clearProperty("prop3");
+        Assert.assertEquals(set("prop1", "prop2"), set(config.getKeys()));
+
+        config.setProperties(MapConfig.builder().put("prop4", "value4").build());
+        Assert.assertEquals(set("prop1", "prop2", "prop4"), set(config.getKeys()));
+
+        Properties props = new Properties();
+        props.put("prop5", "value5");
+        config.setProperties(props);
+        Assert.assertEquals(set("prop1", "prop2", "prop4", "prop5"), set(config.getKeys()));
+    }
+
+    @Test
+    public void testGetKeysIteratorRemoveThrows() {
+        SettableConfig config = new DefaultSettableConfig();
+
+        config.setProperty("prop1", "value1");
+        config.setProperty("prop2", "value2");
+
+        Assert.assertThrows(UnsupportedOperationException.class, config.getKeys()::remove);
+
+        config.clearProperty("prop2");
+
+        Assert.assertThrows(UnsupportedOperationException.class, config.getKeys()::remove);
+
+        config.setProperties(MapConfig.builder().put("prop3", "value3").build());
+
+        Assert.assertThrows(UnsupportedOperationException.class, config.getKeys()::remove);
+
+        Properties properties = new Properties();
+        properties.put("prop5", "value5");
+        config.setProperties(properties);
+
+        Assert.assertThrows(UnsupportedOperationException.class, config.getKeys()::remove);
+    }
+
+    @Test
+    public void testKeysIterable() {
+        SettableConfig config = new DefaultSettableConfig();
+
+        Assert.assertEquals(0, size(config.keys()));
+
+        config.setProperty("prop1", "value1");
+        config.setProperty("prop2", "value2");
+        config.setProperty("prop3", "value3");
+
+        Assert.assertEquals(set("prop1", "prop2", "prop3"), set(config.keys()));
+
+        config.clearProperty("prop3");
+        Assert.assertEquals(set("prop1", "prop2"), set(config.keys()));
+
+        config.setProperties(MapConfig.builder().put("prop4", "value4").build());
+        Assert.assertEquals(set("prop1", "prop2", "prop4"), set(config.keys()));
+
+        Properties props = new Properties();
+        props.put("prop5", "value5");
+        config.setProperties(props);
+        Assert.assertEquals(set("prop1", "prop2", "prop4", "prop5"), set(config.keys()));
+    }
+
+    @Test
+    public void testKeysIterableModificationThrows() {
+        SettableConfig config = new DefaultSettableConfig();
+
+        config.setProperty("prop1", "value1");
+        config.setProperty("prop2", "value2");
+
+        Assert.assertThrows(UnsupportedOperationException.class, config.keys().iterator()::remove);
+
+        config.clearProperty("prop2");
+
+        Assert.assertThrows(UnsupportedOperationException.class, config.keys().iterator()::remove);
+
+        config.setProperties(MapConfig.builder().put("prop3", "value3").build());
+
+        Assert.assertThrows(UnsupportedOperationException.class, config.keys().iterator()::remove);
+
+        Properties properties = new Properties();
+        properties.put("prop4", "value4");
+        config.setProperties(properties);
+
+        Assert.assertThrows(UnsupportedOperationException.class, config.keys().iterator()::remove);
+        Assert.assertThrows(UnsupportedOperationException.class, ((Collection<String>) config.keys())::clear);
+    }
+}

--- a/archaius2-core/src/test/java/com/netflix/archaius/config/MapConfigTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/MapConfigTest.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.archaius.config;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -29,6 +30,9 @@ import org.junit.Test;
 import com.netflix.archaius.api.Config;
 import com.netflix.archaius.api.exceptions.ConfigException;
 import com.netflix.archaius.exceptions.ParseException;
+
+import static com.netflix.archaius.TestUtils.set;
+import static com.netflix.archaius.TestUtils.size;
 
 public class MapConfigTest {
     private final MapConfig config = MapConfig.builder()
@@ -214,5 +218,28 @@ public class MapConfigTest {
         Assert.assertTrue(keys.hasNext());
         keys.next();
         Assert.assertThrows(UnsupportedOperationException.class, keys::remove);
+    }
+
+    @Test
+    public void testKeysIterable() {
+        Config config = MapConfig.builder()
+                .put("key1", "value1")
+                .put("key2", "value2")
+                .build();
+        Iterable<String> keys = config.keys();
+
+        Assert.assertEquals(2, size(keys));
+        Assert.assertEquals(set("key1", "key2"), set(keys));
+    }
+
+    @Test
+    public void testKeysIterableModificationThrows() {
+        Config config = MapConfig.builder()
+                .put("key1", "value1")
+                .put("key2", "value2")
+                .build();
+
+        Assert.assertThrows(UnsupportedOperationException.class, config.keys().iterator()::remove);
+        Assert.assertThrows(UnsupportedOperationException.class, ((Collection<String>) config.keys())::clear);
     }
 }

--- a/archaius2-core/src/test/java/com/netflix/archaius/config/PrefixedViewTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/PrefixedViewTest.java
@@ -7,6 +7,7 @@ import com.netflix.archaius.api.exceptions.ConfigException;
 
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
@@ -14,6 +15,9 @@ import java.util.Set;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
+
+import static com.netflix.archaius.TestUtils.set;
+import static com.netflix.archaius.TestUtils.size;
 
 public class PrefixedViewTest {
     @Test
@@ -117,5 +121,30 @@ public class PrefixedViewTest {
         Iterator<String> keys = config.getKeys();
         keys.next();
         Assert.assertThrows(UnsupportedOperationException.class, keys::remove);
+    }
+
+    @Test
+    public void testKeysIterable() {
+        Config config = MapConfig.builder()
+                .put("foo.prop1", "value1")
+                .put("foo.prop2", "value2")
+                .build()
+                .getPrefixedView("foo");
+
+        Iterable<String> keys = config.keys();
+        Assert.assertEquals(2, size(keys));
+        Assert.assertEquals(set("prop1", "prop2"), set(keys));
+    }
+
+    @Test
+    public void testKeysIterableModificationThrows() {
+        Config config = MapConfig.builder()
+                .put("foo.prop1", "value1")
+                .put("foo.prop2", "value2")
+                .build()
+                .getPrefixedView("foo");
+
+        Assert.assertThrows(UnsupportedOperationException.class, config.keys().iterator()::remove);
+        Assert.assertThrows(UnsupportedOperationException.class, ((Collection<String>) config.keys())::clear);
     }
 }

--- a/archaius2-core/src/test/java/com/netflix/archaius/config/PrivateViewTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/PrivateViewTest.java
@@ -11,12 +11,16 @@ import org.mockito.Mockito;
 
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
+
+import static com.netflix.archaius.TestUtils.set;
+import static com.netflix.archaius.TestUtils.size;
 
 public class PrivateViewTest {
 
@@ -129,5 +133,30 @@ public class PrivateViewTest {
         Iterator<String> keys = config.getKeys();
         keys.next();
         Assert.assertThrows(UnsupportedOperationException.class, keys::remove);
+    }
+
+    @Test
+    public void testKeysIterable() {
+        Config config = MapConfig.builder()
+                .put("foo", "foo-value")
+                .put("bar", "bar-value")
+                .build()
+                .getPrivateView();
+
+        Iterable<String> keys = config.keys();
+        Assert.assertEquals(2, size(keys));
+        Assert.assertEquals(set("foo", "bar"), set(keys));
+    }
+
+    @Test
+    public void testKeysIterableModificationThrows() {
+        Config config = MapConfig.builder()
+                .put("foo", "foo-value")
+                .put("bar", "bar-value")
+                .build()
+                .getPrivateView();
+
+        Assert.assertThrows(UnsupportedOperationException.class, config.keys().iterator()::remove);
+        Assert.assertThrows(UnsupportedOperationException.class, ((Collection<String>) config.keys())::clear);
     }
 }


### PR DESCRIPTION
The existing `getKeys()` method of Config is problematic in practice in common usage, since it returns an `Iterator` instead of `Iterable`, which means callers have no ability to determine the size of the returned set of keys without fully iterating over it.