### PR TITLE
Add Maps utility for creating appropriately sized maps

### DIFF
--- a/archaius2-core/src/main/java/com/netflix/archaius/config/DefaultCompositeConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/DefaultCompositeConfig.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicReference;
 
+import com.netflix.archaius.util.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,7 +79,7 @@ public class DefaultCompositeConfig extends AbstractDependentConfig implements c
         
         public State(Map<String, Config> children, int size) {
             this.children = children;
-            Map<String, Object> data = new HashMap<>(size);
+            Map<String, Object> data = Maps.newHashMap(size);
             Map<String, Config> instrumentedKeys = new HashMap<>();
             for (Config child : children.values()) {
                 boolean instrumented = child.instrumentationEnabled();
@@ -104,7 +105,7 @@ public class DefaultCompositeConfig extends AbstractDependentConfig implements c
         }
         
         State addConfig(String name, Config config) {
-            LinkedHashMap<String, Config> children = new LinkedHashMap<>(this.children.size() + 1);
+            LinkedHashMap<String, Config> children = Maps.newLinkedHashMap(this.children.size() + 1);
             if (reversed) {
                 children.put(name, config);
                 children.putAll(this.children);
@@ -112,7 +113,9 @@ public class DefaultCompositeConfig extends AbstractDependentConfig implements c
                 children.putAll(this.children);
                 children.put(name, config);
             }
-            return new State(children, cachedState.getData().size() + 16);
+            Iterable<String> keysIterable = config.keys();
+            int size = keysIterable instanceof Collection<?> ? ((Collection<String>) keysIterable).size() : 16;
+            return new State(children, cachedState.getData().size() + size);
         }
         
         State removeConfig(String name) {
@@ -123,7 +126,7 @@ public class DefaultCompositeConfig extends AbstractDependentConfig implements c
             }
             return this;
         }
-        
+
         public State refresh() {
             return new State(children, cachedState.getData().size());
         }

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/DefaultSettableConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/DefaultSettableConfig.java
@@ -17,6 +17,7 @@ package com.netflix.archaius.config;
 
 import com.netflix.archaius.api.Config;
 import com.netflix.archaius.api.config.SettableConfig;
+import com.netflix.archaius.util.Maps;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -39,7 +40,7 @@ public class DefaultSettableConfig extends AbstractConfig implements SettableCon
 
     @Override
     public synchronized <T> void setProperty(String propName, T propValue) {
-        Map<String, Object> copy = new HashMap<>(props.size() + 1);
+        Map<String, Object> copy = Maps.newHashMap(props.size() + 1);
         copy.putAll(props);
         copy.put(propName, propValue);
         props = Collections.unmodifiableMap(copy);
@@ -87,7 +88,7 @@ public class DefaultSettableConfig extends AbstractConfig implements SettableCon
     public void setProperties(Properties src) {
         if (null != src) {
             synchronized (this) {
-                Map<String, Object> copy = new HashMap<>(props.size() + src.size());
+                Map<String, Object> copy = Maps.newHashMap(props.size() + src.size());
                 copy.putAll(props);
                 for (Entry<Object, Object> prop : src.entrySet()) {
                     copy.put(prop.getKey().toString(), prop.getValue());

--- a/archaius2-core/src/main/java/com/netflix/archaius/util/Maps.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/util/Maps.java
@@ -1,0 +1,37 @@
+package com.netflix.archaius.util;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+
+public final class Maps {
+    private Maps() {}
+
+    /**
+     * Calculate initial capacity from expected size and default load factor (0.75).
+     */
+    private static int calculateCapacity(int numMappings) {
+        return (int) Math.ceil(numMappings / 0.75d);
+    }
+
+    /**
+     * Creates a new, empty HashMap suitable for the expected number of mappings.
+     * The returned map is large enough so that the expected number of mappings can be
+     * added without resizing the map.
+     *
+     * This is essentially a backport of HashMap.newHashMap which was added in JDK19.
+     */
+    public static <K, V> HashMap<K, V> newHashMap(int numMappings) {
+        return new HashMap<>(calculateCapacity(numMappings));
+    }
+
+    /**
+     * Creates a new, empty LinkedHashMap suitable for the expected number of mappings.
+     * The returned map is large enough so that the expected number of mappings can be
+     * added without resizing the map.
+     *
+     * This is essentially a backport of LinkedHashMap.newLinkedHashMap which was added in JDK19.
+     */
+    public static <K, V> LinkedHashMap<K, V> newLinkedHashMap(int numMappings) {
+        return new LinkedHashMap<>(calculateCapacity(numMappings));
+    }
+}


### PR DESCRIPTION
In several instances, Maps were being initialized with an initial capacity too small to avoid a resize. Add a Maps utility with static helpers for creating new HashMap and LinkedHashMap instances with an initial capacity sized appropriately for the default load factor; this is similar to helpers that already exist in Guava and JDK19.