### PR TITLE
Fix lambda generation for JDK17

### DIFF
--- a/archaius2-core/src/main/java/com/netflix/archaius/ConfigProxyFactory.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/ConfigProxyFactory.java
@@ -326,11 +326,11 @@ public class ConfigProxyFactory {
             else {
                 // Java 9 onwards
                 lookup = MethodHandles.lookup();
-                methodHandle = lookup
-                        .findSpecial(type,
-                                method.getName(),
-                                MethodType.methodType(method.getReturnType(), method.getParameterTypes()),
-                                type);
+                methodHandle = lookup.findSpecial(
+                        method.getDeclaringClass(),
+                        method.getName(),
+                        MethodType.methodType(method.getReturnType(), method.getParameterTypes()),
+                        method.getDeclaringClass());
             }
         } catch (ReflectiveOperationException e) {
             throw new RuntimeException("Failed to create temporary object for " + type.getName(), e);


### PR DESCRIPTION
The call to lookup.findSpecial would result in a method handle with the wrong receiver type on JDK9+; the existing tests failed on JDK17 but pass with this change.