### PR TITLE
Tests now pass on JDK 17!

### DIFF
--- a/archaius2-core/src/test/java/com/netflix/archaius/config/CompositeConfigTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/CompositeConfigTest.java
@@ -40,8 +40,8 @@ import com.netflix.archaius.visitor.PrintStreamVisitor;
 
 import static com.netflix.archaius.TestUtils.set;
 import static com.netflix.archaius.TestUtils.size;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/archaius2-core/src/test/java/com/netflix/archaius/config/DefaultLayeredConfigTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/DefaultLayeredConfigTest.java
@@ -24,8 +24,8 @@ import java.util.concurrent.Callable;
 
 import static com.netflix.archaius.TestUtils.set;
 import static com.netflix.archaius.TestUtils.size;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -40,8 +40,8 @@ public class DefaultLayeredConfigTest {
         
         LayeredConfig.LayeredVisitor<String> visitor = Mockito.mock(LayeredConfig.LayeredVisitor.class);
         config.accept(visitor);
-        Mockito.verify(visitor, Mockito.never()).visitConfig(Mockito.any(), Mockito.any());
-        Mockito.verify(visitor, Mockito.never()).visitKey(Mockito.any(), Mockito.any());
+        Mockito.verify(visitor, Mockito.never()).visitConfig(any(), any());
+        Mockito.verify(visitor, Mockito.never()).visitKey(any(), any());
     }
     
     @Test
@@ -54,7 +54,7 @@ public class DefaultLayeredConfigTest {
         // Add a child
         config.addConfig(Layers.APPLICATION, new DefaultSettableConfig());
         
-        Mockito.verify(listener, Mockito.times(1)).onConfigUpdated(Mockito.any());
+        Mockito.verify(listener, Mockito.times(1)).onConfigUpdated(any());
     }
     
     @Test
@@ -80,7 +80,7 @@ public class DefaultLayeredConfigTest {
         Assert.assertEquals("propvalue2", config.getProperty("propname").get());
         Assert.assertEquals("propvalue2", config.getRawProperty("propname"));
         
-        Mockito.verify(listener, Mockito.times(2)).onConfigUpdated(Mockito.any());
+        Mockito.verify(listener, Mockito.times(2)).onConfigUpdated(any());
     }
     
     @Test
@@ -94,7 +94,7 @@ public class DefaultLayeredConfigTest {
         SettableConfig child = new DefaultSettableConfig();
         child.setProperty("propname", "propvalue");
         config.addConfig(Layers.APPLICATION, child);
-        Mockito.verify(listener, Mockito.times(1)).onConfigUpdated(Mockito.any());        
+        Mockito.verify(listener, Mockito.times(1)).onConfigUpdated(any());
         
         // Validate initial state
         Assert.assertEquals("propvalue", config.getProperty("propname").get());
@@ -107,7 +107,7 @@ public class DefaultLayeredConfigTest {
         Assert.assertFalse(config.getProperty("propname").isPresent());
         Assert.assertNull(config.getRawProperty("propname"));
         
-        Mockito.verify(listener, Mockito.times(2)).onConfigUpdated(Mockito.any());        
+        Mockito.verify(listener, Mockito.times(2)).onConfigUpdated(any());
     }
     
     @Test

--- a/archaius2-core/src/test/java/com/netflix/archaius/config/PollingDynamicConfigTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/PollingDynamicConfigTest.java
@@ -43,8 +43,8 @@ import static org.junit.Assert.assertTrue;
 
 import static com.netflix.archaius.TestUtils.set;
 import static com.netflix.archaius.TestUtils.size;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -197,7 +197,7 @@ public class PollingDynamicConfigTest {
             strategy.fire();
             Assert.fail("Should have thrown an exception");
         }
-        catch (Exception e) {
+        catch (Exception expected) {
             
         }
         

--- a/archaius2-core/src/test/java/com/netflix/archaius/config/PrefixedViewTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/PrefixedViewTest.java
@@ -1,10 +1,8 @@
 package com.netflix.archaius.config;
 
-import com.netflix.archaius.Layers;
 import com.netflix.archaius.api.Config;
 import com.netflix.archaius.api.ConfigListener;
 import com.netflix.archaius.api.PropertyDetails;
-import com.netflix.archaius.api.config.LayeredConfig;
 import com.netflix.archaius.api.config.SettableConfig;
 import com.netflix.archaius.api.exceptions.ConfigException;
 
@@ -27,8 +25,8 @@ import org.mockito.Mockito;
 
 import static com.netflix.archaius.TestUtils.set;
 import static com.netflix.archaius.TestUtils.size;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -45,13 +43,13 @@ public class PrefixedViewTest {
         
         prefix.addListener(listener);
         
-        Mockito.verify(listener, Mockito.times(0)).onConfigAdded(Mockito.any());
+        Mockito.verify(listener, Mockito.times(0)).onConfigAdded(any());
         
         config.addConfig("bar", DefaultCompositeConfig.builder()
                 .withConfig("foo", MapConfig.builder().put("foo.bar", "value").build())
                 .build());
         
-        Mockito.verify(listener, Mockito.times(1)).onConfigAdded(Mockito.any());
+        Mockito.verify(listener, Mockito.times(1)).onConfigAdded(any());
     }
     
     @Test
@@ -69,17 +67,17 @@ public class PrefixedViewTest {
         
         // Confirm original state
         Assert.assertEquals("original", prefix.getString("bar"));
-        Mockito.verify(listener, Mockito.times(0)).onConfigAdded(Mockito.any());
+        Mockito.verify(listener, Mockito.times(0)).onConfigAdded(any());
 
         // Update the property and confirm onConfigUpdated notification
         settable.setProperty("foo.bar", "new");
-        Mockito.verify(listener, Mockito.times(1)).onConfigUpdated(Mockito.any());
+        Mockito.verify(listener, Mockito.times(1)).onConfigUpdated(any());
         Assert.assertEquals("new", prefix.getString("bar"));
         
         // Add a new config and confirm onConfigAdded notification
         config.addConfig("new", MapConfig.builder().put("foo.bar", "new2").build());
-        Mockito.verify(listener, Mockito.times(1)).onConfigAdded(Mockito.any());
-        Mockito.verify(listener, Mockito.times(1)).onConfigUpdated(Mockito.any());
+        Mockito.verify(listener, Mockito.times(1)).onConfigAdded(any());
+        Mockito.verify(listener, Mockito.times(1)).onConfigUpdated(any());
     }
 
     @Test

--- a/archaius2-core/src/test/java/com/netflix/archaius/config/PrivateViewTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/PrivateViewTest.java
@@ -28,8 +28,8 @@ import static org.junit.Assert.assertSame;
 
 import static com.netflix.archaius.TestUtils.set;
 import static com.netflix.archaius.TestUtils.size;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -68,13 +68,13 @@ public class PrivateViewTest {
         
         privateView.addListener(listener);
         
-        Mockito.verify(listener, Mockito.times(0)).onConfigAdded(Mockito.any());
+        Mockito.verify(listener, Mockito.times(0)).onConfigAdded(any());
         
         config.addConfig("bar", DefaultCompositeConfig.builder()
                 .withConfig("foo", MapConfig.builder().put("foo.bar", "value").build())
                 .build());
         
-        Mockito.verify(listener, Mockito.times(1)).onConfigAdded(Mockito.any());
+        Mockito.verify(listener, Mockito.times(1)).onConfigAdded(any());
     }
     
     @Test
@@ -92,17 +92,17 @@ public class PrivateViewTest {
         
         // Confirm original state
         Assert.assertEquals("original", privateView.getString("foo.bar"));
-        Mockito.verify(listener, Mockito.times(0)).onConfigAdded(Mockito.any());
+        Mockito.verify(listener, Mockito.times(0)).onConfigAdded(any());
 
         // Update the property and confirm onConfigUpdated notification
         settable.setProperty("foo.bar", "new");
-        Mockito.verify(listener, Mockito.times(1)).onConfigUpdated(Mockito.any());
+        Mockito.verify(listener, Mockito.times(1)).onConfigUpdated(any());
         Assert.assertEquals("new", privateView.getString("foo.bar"));
         
         // Add a new config and confirm onConfigAdded notification
         config.addConfig("new", MapConfig.builder().put("foo.bar", "new2").build());
-        Mockito.verify(listener, Mockito.times(1)).onConfigAdded(Mockito.any());
-        Mockito.verify(listener, Mockito.times(1)).onConfigUpdated(Mockito.any());
+        Mockito.verify(listener, Mockito.times(1)).onConfigAdded(any());
+        Mockito.verify(listener, Mockito.times(1)).onConfigUpdated(any());
     }
     @Test
     public void unusedPrivateViewIsGarbageCollected() {

--- a/archaius2-core/src/test/java/com/netflix/archaius/property/PropertyTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/property/PropertyTest.java
@@ -37,6 +37,7 @@ import com.netflix.archaius.api.exceptions.ConfigException;
 import com.netflix.archaius.config.DefaultSettableConfig;
 import com.netflix.archaius.config.MapConfig;
 
+@SuppressWarnings("deprecation")
 public class PropertyTest {
     static class MyService {
         private Property<Integer> value;

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ subprojects {
         testImplementation 'org.slf4j:slf4j-reload4j:1.7.36'
         testImplementation 'junit:junit:4.13.2'
         testImplementation 'org.hamcrest:hamcrest-all:1.3'
-        testImplementation 'org.mockito:mockito-core:1.+'
+        testImplementation 'org.mockito:mockito-core:4.+'
     }
 
     group = "com.netflix.${githubProjectName}"
@@ -43,6 +43,10 @@ subprojects {
         System.console().printf("Launching tests using JDK %s%n", testJdk)
         javaLauncher = javaToolchains.launcherFor {
             languageVersion = JavaLanguageVersion.of(testJdk)
+        }
+        if (javaLauncher.get().metadata.languageVersion.asInt() >= 11) {
+            // Mockito 4 will not work on JDK >=11 without this. Mockito 5 does not work on JDK8 at all :-/
+            jvmArgs '--add-opens', 'java.base/java.lang=ALL-UNNAMED'
         }
     }
 }


### PR DESCRIPTION
* Updated mockito to 4.x
* Open the java.lang module to introspection. Mockito 5 removes the need for this, but it does not work AT ALL on JDK 8, so we can't migrate to it yet.