### PR TITLE
Avoid duplicated runs of release workflow

### DIFF
--- a/.github/workflows/nebula-publish.yml
+++ b/.github/workflows/nebula-publish.yml
@@ -1,9 +1,5 @@
 name: "Publish candidate/release to NetflixOSS and Maven Central"
 on:
-  push:
-    tags:
-      - v*.*.*
-      - v*.*.*-rc.*
   release:
     types:
       - published
@@ -33,7 +29,7 @@ jobs:
           restore-keys: |
             - ${{ runner.os }}-gradlewrapper-
       - name: Publish candidate
-        if: contains(github.ref, '-rc.')
+        if: startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-rc.')
         run: ./gradlew --info --stacktrace -Prelease.useLastTag=true candidate
         env:
           NETFLIX_OSS_SIGNING_KEY: ${{ secrets.ORG_SIGNING_KEY }}
@@ -41,7 +37,7 @@ jobs:
           NETFLIX_OSS_REPO_USERNAME: ${{ secrets.ORG_NETFLIXOSS_USERNAME }}
           NETFLIX_OSS_REPO_PASSWORD: ${{ secrets.ORG_NETFLIXOSS_PASSWORD }}
       - name: Publish release
-        if: (!contains(github.ref, '-rc.'))
+        if: startsWith(github.ref, 'refs/tags/v') && (!contains(github.ref, '-rc.'))
         run: ./gradlew --info -Prelease.useLastTag=true final
         env:
           NETFLIX_OSS_SONATYPE_USERNAME: ${{ secrets.ORG_SONATYPE_USERNAME }}


### PR DESCRIPTION
The publishing workflow was triggered twice on each release, once by the "release" event itself and another by the creation of the tag. This is wasteful of resources and also confusing because one of the runs would always fail (when trying to publish a duplicate artifact to the repositories).