### PR TITLE
Add utility methods to simplify usage of collection-valued properties.

### DIFF
--- a/archaius2-api/src/main/java/com/netflix/archaius/api/ArchaiusType.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/api/ArchaiusType.java
@@ -1,0 +1,95 @@
+package com.netflix.archaius.api;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * An implementation of {@link ParameterizedType} that can represent the collection types that Archaius can
+ * handle with the default property value decoders, plus static utility methods for list, set and map types.
+ *
+ * @see PropertyRepository#getList(String, Class)
+ * @see PropertyRepository#getSet(String, Class)
+ * @see PropertyRepository#getMap(String, Class, Class)
+ * @see Config#get(Type, String)
+ * @see Config#get(Type, String, Object)
+ */
+public class ArchaiusType implements ParameterizedType {
+
+    /** Return a ParametrizedType to represent a {@code List<listValuesType>} */
+    public static ParameterizedType forListOf(Class<?> listValuesType) {
+        Class<?> maybeWrappedType = PRIMITIVE_WRAPPERS.getOrDefault(listValuesType, listValuesType);
+        return new ArchaiusType(List.class, new Class<?>[] { maybeWrappedType });
+    }
+
+    /** Return a ParametrizedType to represent a {@code Set<setValuesType>} */
+    public static ParameterizedType forSetOf(Class<?> setValuesType) {
+        Class<?> maybeWrappedType = PRIMITIVE_WRAPPERS.getOrDefault(setValuesType, setValuesType);
+        return new ArchaiusType(Set.class, new Class<?>[] { maybeWrappedType });
+    }
+
+    /** Return a ParametrizedType to represent a {@code Map<mapKeysType, mapValuesType>} */
+    public static ParameterizedType forMapOf(Class<?> mapKeysTpe, Class<?> mapValuesType) {
+        Class<?> maybeWrappedKeyType = PRIMITIVE_WRAPPERS.getOrDefault(mapKeysTpe, mapKeysTpe);
+        Class<?> maybeWrappedValuesType = PRIMITIVE_WRAPPERS.getOrDefault(mapValuesType, mapValuesType);
+
+        return new ArchaiusType(Map.class, new Class<?>[] {maybeWrappedKeyType, maybeWrappedValuesType});
+    }
+
+    private final static Map<Class<?> /*primitive*/, Class<?> /*wrapper*/> PRIMITIVE_WRAPPERS;
+    static {
+        Map<Class<?>, Class<?>> wrappers = new HashMap<>();
+        wrappers.put(Integer.TYPE, Integer.class);
+        wrappers.put(Long.TYPE, Long.class);
+        wrappers.put(Double.TYPE, Double.class);
+        wrappers.put(Float.TYPE, Float.class);
+        wrappers.put(Boolean.TYPE, Boolean.class);
+        wrappers.put(Character.TYPE, Character.class);
+        wrappers.put(Byte.TYPE, Byte.class);
+        wrappers.put(Short.TYPE, Short.class);
+        wrappers.put(Void.TYPE, Void.class);
+
+        PRIMITIVE_WRAPPERS = Collections.unmodifiableMap(wrappers);
+    }
+
+    private final Class<?> rawType;
+    private final Class<?>[] typeArguments;
+
+    private ArchaiusType(Class<?> rawType, Class<?>[] typeArguments) {
+        this.rawType = Objects.requireNonNull(rawType);
+        this.typeArguments = Objects.requireNonNull(typeArguments);
+        if (rawType.isArray()
+            || rawType.isPrimitive()
+            || rawType.getTypeParameters().length != typeArguments.length) {
+            throw new IllegalArgumentException("The provided rawType and arguments don't look like a supported parametrized type");
+        }
+    }
+
+    @Override
+    public Type[] getActualTypeArguments() {
+        return typeArguments;
+    }
+
+    @Override
+    public Type getRawType() {
+        return rawType;
+    }
+
+    @Override
+    public Type getOwnerType() {
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        String typeArgumentNames = Arrays.stream(typeArguments).map(Class::getSimpleName).collect(Collectors.joining(","));
+        return String.format("ParametrizedType for %s<%s>", rawType.getSimpleName(), typeArgumentNames);
+    }
+}

--- a/archaius2-api/src/main/java/com/netflix/archaius/api/Config.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/api/Config.java
@@ -153,8 +153,6 @@ public interface Config extends PropertySource {
      * @return
      */
     <T> T get(Class<T> type, String key);
-    <T> T get(Class<T> type, String key, T defaultValue);
-
     /**
      * Get the property from the Decoder.  All basic data types as well any type
      * will a valueOf or String constructor will be supported.
@@ -162,7 +160,27 @@ public interface Config extends PropertySource {
      * @param key
      * @return
      */
+    <T> T get(Class<T> type, String key, T defaultValue);
+
+    /**
+     * Get the property from the Decoder.  Use this method for polymorphic types such as collections.
+     * <p>
+     * Use the utility methods in {@link ArchaiusType} to get the types for lists, sets and maps.
+     *
+     * @see ArchaiusType#forListOf(Class)
+     * @see ArchaiusType#forSetOf(Class)
+     * @see ArchaiusType#forMapOf(Class, Class)
+     */
     <T> T get(Type type, String key);
+    /**
+     * Get the property from the Decoder.  Use this method for polymorphic types such as collections.
+     * <p>
+     * Use the utility methods in {@link ArchaiusType} to get the types for lists, sets and maps.
+     *
+     * @see ArchaiusType#forListOf(Class)
+     * @see ArchaiusType#forSetOf(Class)
+     * @see ArchaiusType#forMapOf(Class, Class)
+     */
     <T> T get(Type type, String key, T defaultValue);
 
     /**

--- a/archaius2-api/src/main/java/com/netflix/archaius/api/PropertyRepository.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/api/PropertyRepository.java
@@ -1,6 +1,9 @@
 package com.netflix.archaius.api;
 
 import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public interface PropertyRepository {
     /**
@@ -9,12 +12,55 @@ public interface PropertyRepository {
      * to a dynamic configuration system and will have its value automatically updated
      * whenever the backing configuration is updated.  Fallback properties and default values
      * may be specified through the {@link Property} API.
+     * <p>
+     * This method does not handle polymorphic return types such as collections. Use {@link #get(String, Type)} or one
+     * of the specialized utility methods in the interface for that case.
      * 
      * @param key   Property name
-     * @param type  Type of property value
-     * @return
+     * @param type  The type for the property value. This *can* be an array type, but not a primitive array
+     *              (ie, you can use {@code Integer[].class} but not {@code int[].class})
      */
     <T> Property<T> get(String key, Class<T> type);
 
+    /**
+     * Fetch a property of a specific type.  A {@link Property} object is returned regardless of
+     * whether a key for it exists in the backing configuration.  The {@link Property} is attached
+     * to a dynamic configuration system and will have its value automatically updated
+     * whenever the backing configuration is updated.  Fallback properties and default values
+     * may be specified through the {@link Property} API.
+     * <p>
+     * Use this method to request polymorphic return types such as collections. See the utility methods in
+     * {@link ArchaiusType} to get types for lists, sets and maps, or call the utility methods in this interface directly.
+     *
+     * @see ArchaiusType#forListOf(Class)
+     * @see ArchaiusType#forSetOf(Class)
+     * @see ArchaiusType#forMapOf(Class, Class)
+     * @param key   Property name
+     * @param type  Type of property value.
+     */
     <T> Property<T> get(String key, Type type);
+
+    /**
+     * Fetch a property with a {@link List} value. This is just an utility wrapper around {@link #get(String, Type)}.
+     * See that method's documentation for more details.
+     */
+    default <V> Property<List<V>> getList(String key, Class<V> listElementType) {
+        return get(key, ArchaiusType.forListOf(listElementType));
+    }
+
+    /**
+     * Fetch a property with a {@link Set} value. This is just an utility wrapper around {@link #get(String, Type)}.
+     * See that method's documentation for more details.
+     */
+    default <V> Property<Set<V>> getSet(String key, Class<V> setElementType) {
+        return get(key, ArchaiusType.forSetOf(setElementType));
+    }
+
+    /**
+     * Fetch a property with a {@link Map} value. This is just an utility wrapper around {@link #get(String, Type)}.
+     * See that method's documentation for more details.
+     */
+    default <K, V> Property<Map<K, V>> getMap(String key, Class<K> mapKeyType, Class<V> mapValueType) {
+        return get(key, ArchaiusType.forMapOf(mapKeyType, mapValueType));
+    }
 }


### PR DESCRIPTION
Although Archaius has supported decoding of collection-valued properties such as list, sets and maps since at least 2019, the syntax to use them was never properly documented and required users to provide their own implementation of the ParametrizedType interface.

This commit adds some syntactic sugar to simplify usage.

Closes: #654