### PR TITLE
Readability refactor

### DIFF
--- a/archaius2-api/src/main/java/com/netflix/archaius/api/ArchaiusType.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/api/ArchaiusType.java
@@ -23,19 +23,19 @@ import java.util.stream.Collectors;
  */
 public class ArchaiusType implements ParameterizedType {
 
-    /** Return a ParametrizedType to represent a {@code List<listValuesType>} */
+    /** Return a parameterizedType to represent a {@code List<listValuesType>} */
     public static ParameterizedType forListOf(Class<?> listValuesType) {
         Class<?> maybeWrappedType = PRIMITIVE_WRAPPERS.getOrDefault(listValuesType, listValuesType);
         return new ArchaiusType(List.class, new Class<?>[] { maybeWrappedType });
     }
 
-    /** Return a ParametrizedType to represent a {@code Set<setValuesType>} */
+    /** Return a parameterizedType to represent a {@code Set<setValuesType>} */
     public static ParameterizedType forSetOf(Class<?> setValuesType) {
         Class<?> maybeWrappedType = PRIMITIVE_WRAPPERS.getOrDefault(setValuesType, setValuesType);
         return new ArchaiusType(Set.class, new Class<?>[] { maybeWrappedType });
     }
 
-    /** Return a ParametrizedType to represent a {@code Map<mapKeysType, mapValuesType>} */
+    /** Return a parameterizedType to represent a {@code Map<mapKeysType, mapValuesType>} */
     public static ParameterizedType forMapOf(Class<?> mapKeysTpe, Class<?> mapValuesType) {
         Class<?> maybeWrappedKeyType = PRIMITIVE_WRAPPERS.getOrDefault(mapKeysTpe, mapKeysTpe);
         Class<?> maybeWrappedValuesType = PRIMITIVE_WRAPPERS.getOrDefault(mapValuesType, mapValuesType);
@@ -68,7 +68,7 @@ public class ArchaiusType implements ParameterizedType {
         if (rawType.isArray()
             || rawType.isPrimitive()
             || rawType.getTypeParameters().length != typeArguments.length) {
-            throw new IllegalArgumentException("The provided rawType and arguments don't look like a supported parametrized type");
+            throw new IllegalArgumentException("The provided rawType and arguments don't look like a supported parameterized type");
         }
     }
 
@@ -90,6 +90,6 @@ public class ArchaiusType implements ParameterizedType {
     @Override
     public String toString() {
         String typeArgumentNames = Arrays.stream(typeArguments).map(Class::getSimpleName).collect(Collectors.joining(","));
-        return String.format("ParametrizedType for %s<%s>", rawType.getSimpleName(), typeArgumentNames);
+        return String.format("parameterizedType for %s<%s>", rawType.getSimpleName(), typeArgumentNames);
     }
 }

--- a/archaius2-core/src/main/java/com/netflix/archaius/ConfigProxyFactory.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/ConfigProxyFactory.java
@@ -206,7 +206,7 @@ public class ConfigProxyFactory {
 
             if (immutable) {
                 // Cache the current value of the property and always return that.
-                // Note that this will fail for parametrized properties!
+                // Note that this will fail for parameterized properties!
                 Object value = methodInvokerHolder.invoker.invoke(new Object[]{});
                 invokers.put(method, (args) -> value);
             } else {
@@ -246,7 +246,7 @@ public class ConfigProxyFactory {
                 propertyValueGetter = createInterfaceProperty(propName, newProxy(returnType, propName, immutable));
 
             } else if (m.getParameterCount() > 0) {
-                // A parametrized property. Note that this requires a @PropertyName annotation to extract the interpolation positions!
+                // A parameterized property. Note that this requires a @PropertyName annotation to extract the interpolation positions!
                 if (nameAnnot == null) {
                     throw new IllegalArgumentException("Missing @PropertyName annotation on " + m.getDeclaringClass().getName() + "#" + m.getName());
                 }
@@ -354,7 +354,7 @@ public class ConfigProxyFactory {
                     return (T) methodHandle.invokeWithArguments(args);
                 } else {
                     // This is a handle to a method WITH arguments, being called with none. This happens when toString()
-                    // is trying to build a representation of a proxy that has a parametrized property AND the interface
+                    // is trying to build a representation of a proxy that has a parameterized property AND the interface
                     // provides a default method for it. There's no good default to return here, so we'll just use null
                     return null;
                 }
@@ -385,7 +385,7 @@ public class ConfigProxyFactory {
     }
 
     /**
-     * A value getter for a parametrized property. Takes the arguments passed to the method call and interpolates them
+     * A value getter for a parameterized property. Takes the arguments passed to the method call and interpolates them
      * into the property name from the method's @PropertyName annotation, then returns the value set in config for the
      * computed property name. If not set, it forwards the call with the same parameters to the defaultValueSupplier.
      */
@@ -394,7 +394,7 @@ public class ConfigProxyFactory {
 
         return args -> {
             if (args == null) {
-                // Why would args be null if this is a parametrized property? Because toString() abuses its
+                // Why would args be null if this is a parameterized property? Because toString() abuses its
                 // access to this internal representation :-/
                 // We'll fall back to trying to call the provider for the default value. That works properly if
                 // it comes from an annotation or the known collections. Our wrapper for default interface methods
@@ -465,7 +465,7 @@ public class ConfigProxyFactory {
 
         /**
          * Create a reasonable string representation of the proxy object: "InterfaceName[propName=currentValue, ...]".
-         * For the case of parametrized properties, fudges it and just uses "null" as the value.
+         * For the case of parameterized properties, fudges it and just uses "null" as the value.
          */
         private String proxyToString() {
             String propertyNamesAndValues = invokers.entrySet().stream()
@@ -480,7 +480,7 @@ public class ConfigProxyFactory {
             String propertyName = propertyNames.get(entry.getKey()).substring(prefix.length());
             Object propertyValue;
             try {
-                // This call should fail for parametrized properties, because the PropertyValueGetter has a non-empty
+                // This call should fail for parameterized properties, because the PropertyValueGetter has a non-empty
                 // argument list. Fortunately, the implementation there cooperates with us and returns a null instead :-)
                 propertyValue = entry.getValue().invoke(null);
             } catch (Exception e) {

--- a/archaius2-core/src/test/java/com/netflix/archaius/ProxyFactoryTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/ProxyFactoryTest.java
@@ -28,6 +28,7 @@ import com.netflix.archaius.api.config.SettableConfig;
 import com.netflix.archaius.config.DefaultSettableConfig;
 import com.netflix.archaius.config.EmptyConfig;
 
+@SuppressWarnings("deprecation")
 public class ProxyFactoryTest {
     public enum TestEnum {
         NONE,
@@ -46,6 +47,7 @@ public class ProxyFactoryTest {
         String getValueWithoutDefault2();
     }
     
+    @SuppressWarnings("unused")
     public interface BaseConfig {
         @DefaultValue("basedefault")
         String getStr();
@@ -60,6 +62,7 @@ public class ProxyFactoryTest {
         }
     }
     
+    @SuppressWarnings("UnusedReturnValue")
     public interface RootConfig extends BaseConfig {
         @DefaultValue("default")
         @Override
@@ -92,7 +95,7 @@ public class ProxyFactoryTest {
     }
     
     public static class SubConfigFromString {
-        private String[] parts;
+        private final String[] parts;
 
         public SubConfigFromString(String value) {
             this.parts = value.split(":");
@@ -203,11 +206,11 @@ public class ProxyFactoryTest {
             a.getRequiredValue();
             Assert.fail("should have failed with no value for requiredValue");
         }
-        catch (Exception e) {
+        catch (Exception expected) {
         }
     }
     
-    static interface WithArguments {
+    interface WithArguments {
         @PropertyName(name="${0}.abc.${1}")
         @DefaultValue("default")
         String getProperty(String part0, int part1);
@@ -229,7 +232,7 @@ public class ProxyFactoryTest {
     }
 
     @Configuration(prefix = "foo.bar")
-    static interface WithArgumentsAndPrefix {
+    interface WithArgumentsAndPrefix {
         @PropertyName(name="baz.${0}.abc.${1}")
         @DefaultValue("default")
         String getPropertyWithoutPrefix(String part0, int part1);
@@ -259,10 +262,16 @@ public class ProxyFactoryTest {
     }
 
 
+    @SuppressWarnings("unused")
     public interface WithArgumentsAndDefaultMethod {
         @PropertyName(name="${0}.abc.${1}")
-        default String getProperty(String part0, int part1) {
-            return "default";
+        default String getPropertyWith2Placeholders(String part0, int part1) {
+            return "defaultFor2";
+        }
+
+        @PropertyName(name="${0}.def")
+        default String getPropertyWith1Placeholder(String part0) {
+            return "defaultFor1";
         }
     }
 
@@ -271,14 +280,18 @@ public class ProxyFactoryTest {
         SettableConfig config = new DefaultSettableConfig();
         config.setProperty("a.abc.1", "value1");
         config.setProperty("b.abc.2", "value2");
+        config.setProperty("c.def",   "value_c");
 
         PropertyFactory factory = DefaultPropertyFactory.from(config);
         ConfigProxyFactory proxy = new ConfigProxyFactory(config, config.getDecoder(), factory);
         WithArgumentsAndDefaultMethod withArgsAndDefM = proxy.newProxy(WithArgumentsAndDefaultMethod.class);
 
-        Assert.assertEquals("value1",  withArgsAndDefM.getProperty("a", 1));
-        Assert.assertEquals("value2",  withArgsAndDefM.getProperty("b", 2));
-        Assert.assertEquals("default", withArgsAndDefM.getProperty("a", 2));
+        Assert.assertEquals("value1",  withArgsAndDefM.getPropertyWith2Placeholders("a", 1));
+        Assert.assertEquals("value2",  withArgsAndDefM.getPropertyWith2Placeholders("b", 2));
+        Assert.assertEquals("defaultFor2", withArgsAndDefM.getPropertyWith2Placeholders("a", 2));
+
+        Assert.assertEquals("value_c", withArgsAndDefM.getPropertyWith1Placeholder("c"));
+        Assert.assertEquals("defaultFor1", withArgsAndDefM.getPropertyWith1Placeholder("q"));
     }
 
     public interface ConfigWithMaps {
@@ -398,7 +411,7 @@ public class ProxyFactoryTest {
         Assert.assertEquals(Arrays.asList(1,2,4), new ArrayList<>(withCollections.getSortedSet()));
     }
     
-    public static interface ConfigWithStringCollections {
+    public interface ConfigWithStringCollections {
         List<String> getList();
         
         Set<String> getSet();
@@ -455,6 +468,7 @@ public class ProxyFactoryTest {
         Assert.assertTrue(withCollections.getSortedSet().isEmpty());
     }
     
+    @SuppressWarnings("unused")
     public interface ConfigWithCollectionsWithDefaultValueAnnotation {
         @DefaultValue("")
         LinkedList<Integer> getLinkedList();
@@ -485,12 +499,13 @@ public class ProxyFactoryTest {
         ConfigProxyFactory proxy = new ConfigProxyFactory(config, config.getDecoder(), factory);
         ConfigWithDefaultStringCollections withCollections = proxy.newProxy(ConfigWithDefaultStringCollections.class);
         
-        Assert.assertEquals(Arrays.asList("default"), new ArrayList<>(withCollections.getList()));
-        Assert.assertEquals(Arrays.asList("default"), new ArrayList<>(withCollections.getSet()));
-        Assert.assertEquals(Arrays.asList("default"), new ArrayList<>(withCollections.getSortedSet()));
+        Assert.assertEquals(Collections.singletonList("default"), new ArrayList<>(withCollections.getList()));
+        Assert.assertEquals(Collections.singletonList("default"), new ArrayList<>(withCollections.getSet()));
+        Assert.assertEquals(Collections.singletonList("default"), new ArrayList<>(withCollections.getSortedSet()));
     }
 
-    public static interface FailingError {
+    @SuppressWarnings("UnusedReturnValue")
+    public interface FailingError {
         default String getValue() { throw new IllegalStateException("error"); }
     }
     
@@ -506,18 +521,22 @@ public class ProxyFactoryTest {
     
     @Test
     public void testObjectMethods() {
+        // These tests just ensure that toString, equals and hashCode have implementations that don't fail.
         SettableConfig config = new DefaultSettableConfig();
         PropertyFactory factory = DefaultPropertyFactory.from(config);
         ConfigProxyFactory proxy = new ConfigProxyFactory(config, config.getDecoder(), factory);
         WithArguments withArgs = proxy.newProxy(WithArguments.class);
         
         Assert.assertEquals("WithArguments[${0}.abc.${1}='default']", withArgs.toString());
+        //noinspection ObviousNullCheck
         Assert.assertNotNull(withArgs.hashCode());
-        Assert.assertTrue(withArgs.equals(withArgs));
+        //noinspection EqualsWithItself
+        Assert.assertEquals(withArgs, withArgs);
     }
 
     @Test
     public void testObjectMethods_ClassWithArgumentsAndDefaultMethod() {
+        // These tests just ensure that toString, equals and hashCode have implementations that don't fail.
         SettableConfig config = new DefaultSettableConfig();
         PropertyFactory factory = DefaultPropertyFactory.from(config);
         ConfigProxyFactory proxy = new ConfigProxyFactory(config, config.getDecoder(), factory);
@@ -525,8 +544,11 @@ public class ProxyFactoryTest {
 
         // Printing 'null' here is a compromise. The default method in the interface is being called with a bad signature.
         // There's nothing the proxy could return here that isn't a lie, but at least this is a mostly harmless lie.
-        Assert.assertEquals("WithArgumentsAndDefaultMethod[${0}.abc.${1}='null']", withArgs.toString());
+        // This test depends implicitly on the iteration order for HashMap, which could change on future Java releases.
+        Assert.assertEquals("WithArgumentsAndDefaultMethod[${0}.def='null',${0}.abc.${1}='null']", withArgs.toString());
+        //noinspection ObviousNullCheck
         Assert.assertNotNull(withArgs.hashCode());
-        Assert.assertTrue(withArgs.equals(withArgs));
+        //noinspection EqualsWithItself
+        Assert.assertEquals(withArgs, withArgs);
     }
 }


### PR DESCRIPTION
Refactored code for readability. Split out most sections into self-contained methods with a single objective. Code is now longer, but less convoluted and with less anonymous nested things.

Cleaned up compiler warnings in main class and in the corresponding unit tests.