### PR TITLE
Allow conversion for interface types

### DIFF
--- a/archaius2-core/src/main/java/com/netflix/archaius/ConfigProxyFactory.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/ConfigProxyFactory.java
@@ -300,8 +300,8 @@ public class ConfigProxyFactory {
             if (!knownCollections.containsKey(returnType)
                     && returnType.isInterface()
                     && !(decoder instanceof TypeConverter.Registry && ((TypeConverter.Registry) decoder).get(m.getGenericReturnType()).isPresent())) {
-                // Our return type is an interface but not a known collection. We treat it as a nested Config proxy
-                // interface and create a proxy with it, with the current property name as the initial prefix for nesting.
+                // Our return type is an interface but not a known collection and is also not a type our decoder can handle.
+                // We treat it as a nested Config proxy interface and create a proxy with it, with the current property name as the initial prefix for nesting.
                 propertyValueGetter = createInterfaceProperty(propName, newProxy(returnType, propName, immutable));
 
             } else if (m.getParameterCount() > 0) {

--- a/archaius2-core/src/main/java/com/netflix/archaius/ConfigProxyFactory.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/ConfigProxyFactory.java
@@ -5,6 +5,7 @@ import com.netflix.archaius.api.Decoder;
 import com.netflix.archaius.api.Property;
 import com.netflix.archaius.api.PropertyFactory;
 import com.netflix.archaius.api.PropertyRepository;
+import com.netflix.archaius.api.TypeConverter;
 import com.netflix.archaius.api.annotations.Configuration;
 import com.netflix.archaius.api.annotations.DefaultValue;
 import com.netflix.archaius.api.annotations.PropertyName;
@@ -296,7 +297,9 @@ public class ConfigProxyFactory {
             // This object encapsulates the way to get the value for the current property.
             final PropertyValueGetter propertyValueGetter;
 
-            if (!knownCollections.containsKey(returnType) && returnType.isInterface()) {
+            if (!knownCollections.containsKey(returnType)
+                    && returnType.isInterface()
+                    && !(decoder instanceof TypeConverter.Registry && ((TypeConverter.Registry) decoder).get(m.getGenericReturnType()).isPresent())) {
                 // Our return type is an interface but not a known collection. We treat it as a nested Config proxy
                 // interface and create a proxy with it, with the current property name as the initial prefix for nesting.
                 propertyValueGetter = createInterfaceProperty(propName, newProxy(returnType, propName, immutable));

--- a/archaius2-core/src/main/java/com/netflix/archaius/DefaultDecoder.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/DefaultDecoder.java
@@ -60,7 +60,12 @@ public class DefaultDecoder implements Decoder, TypeConverter.Registry {
             if (encoded == null) {
                 return null;
             }
-            return (T)getOrCreateConverter(type).convert(encoded);
+            @SuppressWarnings("unchecked")
+            TypeConverter<T> converter = (TypeConverter<T>) getOrCreateConverter(type);
+            if (converter == null) {
+                throw new RuntimeException("No converter found for type '" + type + "'");
+            }
+            return converter.convert(encoded);
         } catch (Exception e) {
             throw new ParseException("Error decoding type `" + type.getTypeName() + "`", e);
         }
@@ -76,7 +81,7 @@ public class DefaultDecoder implements Decoder, TypeConverter.Registry {
         if (converter == null) {
             converter = resolve(type);
             if (converter == null) {
-                throw new RuntimeException("No converter found for type '" + type + "'");
+                return null;
             }
             cache.put(type, converter);
         }

--- a/archaius2-core/src/test/java/com/netflix/archaius/DefaultDecoderTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/DefaultDecoderTest.java
@@ -85,4 +85,12 @@ public class DefaultDecoderTest {
         Assert.assertEquals(BitSet.valueOf(Hex.decodeHex("DEADBEEF00DEADBEEF")), decoder.decode(BitSet.class, "DEADBEEF00DEADBEEF"));
         Assert.assertEquals("testString", decoder.decode(String.class, "testString"));
     }
+
+    @Test
+    public void testTypeConverterRegistry() {
+        Assert.assertTrue(DefaultDecoder.INSTANCE.get(Instant.class).isPresent());
+
+        class Foo {}
+        Assert.assertFalse(DefaultDecoder.INSTANCE.get(Foo.class).isPresent());
+    }
 }


### PR DESCRIPTION
Change the behavior of ConfigProxyFactory to check the Decoder for the existence of a TypeConverter before assuming that an interface type should be a nested archaius proxy.