### PR TITLE
Update instrumentation with more call sites and instrumentation clearing endpoint

### DIFF
--- a/archaius-core/src/main/java/com/netflix/config/ConcurrentCompositeConfiguration.java
+++ b/archaius-core/src/main/java/com/netflix/config/ConcurrentCompositeConfiguration.java
@@ -546,6 +546,9 @@ public class ConcurrentCompositeConfiguration extends ConcurrentMapConfiguration
     private Object getProperty(String key, boolean instrument)
     {
         if (overrideProperties.containsKey(key)) {
+            if (instrument) {
+                recordUsage(key);
+            }
             return overrideProperties.getProperty(key);
         }
         Configuration firstMatchingConfiguration = null;
@@ -922,12 +925,13 @@ public class ConcurrentCompositeConfiguration extends ConcurrentMapConfiguration
      * @param config the configuration to query
      * @param key the key of the property
      */
-    private static void appendListProperty(List<Object> dest, Configuration config,
+    private void appendListProperty(List<Object> dest, Configuration config,
             String key)
     {
         Object value = config.getProperty(key);
         if (value != null)
         {
+            recordUsage(key);
             if (value instanceof Collection)
             {
                 Collection<?> col = (Collection<?>) value;

--- a/archaius-core/src/main/java/com/netflix/config/ConcurrentCompositeConfiguration.java
+++ b/archaius-core/src/main/java/com/netflix/config/ConcurrentCompositeConfiguration.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.HashSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.commons.configuration.AbstractConfiguration;
 import org.apache.commons.configuration.Configuration;
@@ -109,21 +110,18 @@ public class ConcurrentCompositeConfiguration extends ConcurrentMapConfiguration
     private final boolean enableStackTrace = Boolean.parseBoolean(System.getProperty(ENABLE_STACK_TRACE));
     private final boolean enableInstrumentation = Boolean.parseBoolean(System.getProperty(ENABLE_INSTRUMENTATION));
 
-    private Map<String, AbstractConfiguration> namedConfigurations = new ConcurrentHashMap<String, AbstractConfiguration>();
+    private Map<String, AbstractConfiguration> namedConfigurations = new ConcurrentHashMap<>();
 
     private final Map<String, Integer> stackTraces = new ConcurrentHashMap<>();
-    private final Set<String> usedProperties = ConcurrentHashMap.newKeySet();
+    private final AtomicReference<Set<String>> usedPropertiesRef = new AtomicReference<>(ConcurrentHashMap.newKeySet());
 
     public Set<String> getUsedProperties() {
-        return Collections.unmodifiableSet(new HashSet<>(usedProperties));
+        return Collections.unmodifiableSet(new HashSet<>(usedPropertiesRef.get()));
     }
 
     public Set<String> getAndClearUsedProperties() {
-        synchronized (usedProperties) {
-            Set<String> ret = getUsedProperties();
-            usedProperties.clear();
-            return ret;
-        }
+        Set<String> ret = usedPropertiesRef.getAndSet(ConcurrentHashMap.newKeySet());
+        return Collections.unmodifiableSet(new HashSet<>(ret));
     }
 
     private List<AbstractConfiguration> configList = new CopyOnWriteArrayList<AbstractConfiguration>();
@@ -590,7 +588,7 @@ public class ConcurrentCompositeConfiguration extends ConcurrentMapConfiguration
      */
     public void recordUsage(String key) {
         if (enableInstrumentation) {
-            usedProperties.add(key);
+            usedPropertiesRef.get().add(key);
             if (enableStackTrace) {
                 String trace = Arrays.toString(Thread.currentThread().getStackTrace());
                 stackTraces.merge(trace, 1, (v1, v2) -> v1 + 1);

--- a/archaius-core/src/main/java/com/netflix/config/ConcurrentCompositeConfiguration.java
+++ b/archaius-core/src/main/java/com/netflix/config/ConcurrentCompositeConfiguration.java
@@ -115,9 +115,16 @@ public class ConcurrentCompositeConfiguration extends ConcurrentMapConfiguration
     private final Set<String> usedProperties = ConcurrentHashMap.newKeySet();
 
     public Set<String> getUsedProperties() {
-        return usedProperties;
+        return Collections.unmodifiableSet(new HashSet<>(usedProperties));
     }
 
+    public Set<String> getAndClearUsedProperties() {
+        synchronized (usedProperties) {
+            Set<String> ret = getUsedProperties();
+            usedProperties.clear();
+            return ret;
+        }
+    }
 
     private List<AbstractConfiguration> configList = new CopyOnWriteArrayList<AbstractConfiguration>();
     

--- a/archaius-core/src/main/java/com/netflix/config/ConcurrentCompositeConfiguration.java
+++ b/archaius-core/src/main/java/com/netflix/config/ConcurrentCompositeConfiguration.java
@@ -121,7 +121,7 @@ public class ConcurrentCompositeConfiguration extends ConcurrentMapConfiguration
 
     public Set<String> getAndClearUsedProperties() {
         Set<String> ret = usedPropertiesRef.getAndSet(ConcurrentHashMap.newKeySet());
-        return Collections.unmodifiableSet(new HashSet<>(ret));
+        return Collections.unmodifiableSet(ret);
     }
 
     private List<AbstractConfiguration> configList = new CopyOnWriteArrayList<AbstractConfiguration>();

--- a/archaius-core/src/test/java/com/netflix/config/ConcurrentCompositeConfigurationTest.java
+++ b/archaius-core/src/test/java/com/netflix/config/ConcurrentCompositeConfigurationTest.java
@@ -18,6 +18,7 @@ package com.netflix.config;
 import static org.junit.Assert.*;
 
 import java.util.List;
+import java.util.Set;
 
 import org.apache.commons.configuration.AbstractConfiguration;
 import org.apache.commons.configuration.BaseConfiguration;
@@ -80,11 +81,24 @@ public class ConcurrentCompositeConfigurationTest {
         config.addProperty("prop1", "val1");
         config.addProperty("prop2", "val2");
         assertEquals(config.getProperty("prop1"), "val1");
-        assertEquals(config.getUsedProperties().size(), 1);
-        assertEquals(config.getUsedProperties().iterator().next(), "prop1");
+
+        // Confirm that the usage is captured
+        Set<String> usedProperties = config.getUsedProperties();
+        assertEquals(usedProperties.size(), 1);
+        assertEquals(usedProperties.iterator().next(), "prop1");
+
+        // Confirm that an uninstrumented call is ignored
         assertEquals(config.getPropertyUninstrumented("prop2"), "val2");
-        assertEquals(config.getUsedProperties().size(), 1);
-        assertEquals(config.getUsedProperties().iterator().next(), "prop1");
+        usedProperties = config.getAndClearUsedProperties();
+        assertEquals(usedProperties.size(), 1);
+        assertEquals(usedProperties.iterator().next(), "prop1");
+
+        // Confirm that both usedProperties endpoints respect when the properties have been cleared
+        usedProperties = config.getUsedProperties();
+        assertTrue(usedProperties.isEmpty());
+
+        usedProperties = config.getAndClearUsedProperties();
+        assertTrue(usedProperties.isEmpty());
 
         System.clearProperty(ConcurrentCompositeConfiguration.ENABLE_INSTRUMENTATION);
     }


### PR DESCRIPTION
The instrumentation currently is missing a few cases that are addressed here:

- OverrideProperties were not instrumented
- Calls through getStringArray (which for NetflixConfiguration came via the getString call on for both DynamicProperty wrappers [updateValue] and direct NetflixConfiguration calls, covering a large portion of calls [basically anything not calling getProperty])

We also add the ability to clear used instrumentation to avoid repeatedly sending the same instrumentation data over the course of an application's lifetime.