### PR TITLE
Add equality comparison for ArchaiusType

### DIFF
--- a/archaius2-api/src/main/java/com/netflix/archaius/api/ArchaiusType.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/api/ArchaiusType.java
@@ -92,4 +92,38 @@ public class ArchaiusType implements ParameterizedType {
         String typeArgumentNames = Arrays.stream(typeArguments).map(Class::getSimpleName).collect(Collectors.joining(","));
         return String.format("parameterizedType for %s<%s>", rawType.getSimpleName(), typeArgumentNames);
     }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = 31 * result + (this.rawType == null ? 0 : this.rawType.hashCode());
+        result = 31 * result + Arrays.hashCode(this.typeArguments);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (obj == null) {
+            return false;
+        } else if (this.getClass() != obj.getClass()) {
+            return false;
+        }
+
+        ArchaiusType other = (ArchaiusType) obj;
+        if ((this.rawType == null) && (other.rawType != null)) {
+            return false;
+        } else if (this.rawType != null && !this.rawType.equals(other.rawType)) {
+            return false;
+        }
+
+        if ((this.typeArguments == null) && (other.typeArguments != null)) {
+            return false;
+        } else if (this.typeArguments != null && !Arrays.equals(this.typeArguments, other.typeArguments)) {
+            return false;
+        }
+
+        return true;
+    }
 }


### PR DESCRIPTION
This PR adds equality methods for the `ArchaiusType` class to ensure `keyAndType` references are reused correctly within the `DefaultPropertyFactory`.

The [`computeIfAbsent`](https://github.com/Netflix/archaius/blob/2.x/archaius2-core/src/main/java/com/netflix/archaius/DefaultPropertyFactory.java#L194) check for existing property references uses the [`type` equality](https://github.com/Netflix/archaius/blob/2.x/archaius2-core/src/main/java/com/netflix/archaius/DefaultPropertyFactory.java#L358-L362) within `keyAndType` to see if a reference to a property already exists, otherwise it adds it to the property ref map.

This can cause an explosion of allocations where the same property key and type are supplied, but as the type itself is constructed on every fetch (`new ArchaiusType`), the default java object equals methods always return false, so a new reference is added to the property factory.