### PR TITLE
Improve Stack Trace tracking for Instrumentation

### DIFF
--- a/archaius-core/src/main/java/com/netflix/config/ConcurrentCompositeConfiguration.java
+++ b/archaius-core/src/main/java/com/netflix/config/ConcurrentCompositeConfiguration.java
@@ -107,8 +107,8 @@ public class ConcurrentCompositeConfiguration extends ConcurrentMapConfiguration
         implements AggregatedConfiguration, ConfigurationListener, Cloneable {
 
     public static final String ENABLE_STACK_TRACE = "archaius_enable_stack_trace";
-    public static final String STACK_TRACE_ENABLED_PROPERTIES = "archaius_stack_trace_enabled_properties";
     public static final String ENABLE_INSTRUMENTATION = "archaius_enable_instrumentation";
+    public static final String STACK_TRACE_ENABLED_PROPERTIES = "archaius_stack_trace_enabled_properties";
     private final boolean enableStackTrace = Boolean.parseBoolean(System.getProperty(ENABLE_STACK_TRACE));
     private final boolean enableInstrumentation = Boolean.parseBoolean(System.getProperty(ENABLE_INSTRUMENTATION));
     private final Set<String> stackTraceEnabledProperties = convertStringFlag(System.getProperty(STACK_TRACE_ENABLED_PROPERTIES));
@@ -611,13 +611,13 @@ public class ConcurrentCompositeConfiguration extends ConcurrentMapConfiguration
     public void recordUsage(String key) {
         if (enableInstrumentation) {
             usedPropertiesRef.get().add(key);
-            if (enableStackTrace
-                    || (!stackTraceEnabledProperties.isEmpty() && stackTraceEnabledProperties.contains(key))) {
+            boolean isTrackedProperty = !stackTraceEnabledProperties.isEmpty() && stackTraceEnabledProperties.contains(key);
+            if (enableStackTrace || isTrackedProperty) {
                 String trace = Arrays.toString(Thread.currentThread().getStackTrace());
                 if (enableStackTrace) {
                     stackTraces.merge(trace, 1, (v1, v2) -> v1 + 1);
                 }
-                if (!stackTraceEnabledProperties.isEmpty() && stackTraceEnabledProperties.contains(key)) {
+                if (isTrackedProperty) {
                     stackTracesAndProperties.merge(trace, createSet(key), this::union);
                 }
             }

--- a/archaius-core/src/main/java/com/netflix/config/ConcurrentCompositeConfiguration.java
+++ b/archaius-core/src/main/java/com/netflix/config/ConcurrentCompositeConfiguration.java
@@ -33,6 +33,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
 
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableSet;
 import org.apache.commons.configuration.AbstractConfiguration;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationRuntimeException;
@@ -123,9 +125,8 @@ public class ConcurrentCompositeConfiguration extends ConcurrentMapConfiguration
         if (properties == null) {
             return Collections.emptySet();
         }
-        Set<String> ret = new HashSet<>();
-        Collections.addAll(ret, properties.split(","));
-        return ret;
+
+        return ImmutableSet.copyOf(Splitter.on(',').trimResults().omitEmptyStrings().split(properties));
     }
 
     public Set<String> getUsedProperties() {
@@ -611,7 +612,7 @@ public class ConcurrentCompositeConfiguration extends ConcurrentMapConfiguration
     public void recordUsage(String key) {
         if (enableInstrumentation) {
             usedPropertiesRef.get().add(key);
-            boolean isTrackedProperty = !stackTraceEnabledProperties.isEmpty() && stackTraceEnabledProperties.contains(key);
+            boolean isTrackedProperty = stackTraceEnabledProperties.contains(key);
             if (enableStackTrace || isTrackedProperty) {
                 String trace = Arrays.toString(Thread.currentThread().getStackTrace());
                 if (enableStackTrace) {


### PR DESCRIPTION
Add archaius_stack_trace_enabled_properties which allows tracking of individual properties (instead of all of them) so we can reduce runtime impact of calculating stack traces. We can use this to only track some unused global fast properties.

This new set will also maintain all the properties associated with specific call sites, in case we are calling several.

Also surfaces these Maps as they were only accessible via the debugger before