### PR TITLE
Avoid class cast exceptions in array and enum converters

### DIFF
--- a/archaius2-core/src/main/java/com/netflix/archaius/converters/ArrayTypeConverterFactory.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/converters/ArrayTypeConverterFactory.java
@@ -5,6 +5,7 @@ import com.netflix.archaius.api.TypeConverter;
 import java.lang.reflect.Array;
 import java.lang.reflect.Type;
 import java.util.Optional;
+import java.util.function.ObjIntConsumer;
 
 public final class ArrayTypeConverterFactory implements TypeConverter.Factory {
     public static final ArrayTypeConverterFactory INSTANCE = new ArrayTypeConverterFactory();
@@ -13,29 +14,56 @@ public final class ArrayTypeConverterFactory implements TypeConverter.Factory {
 
     @Override
     public Optional<TypeConverter<?>> get(Type type, TypeConverter.Registry registry) {
-        Class clsType = (Class) type;
-
-        if (clsType.isArray()) {
-            TypeConverter elementConverter = registry.get(clsType.getComponentType()).orElseThrow(() -> new RuntimeException());
+        if (type instanceof Class<?> && ((Class<?>) type).isArray()) {
+            Class<?> clsType = (Class<?>) type;
+            Class<?> elementType = clsType.getComponentType();
+            @SuppressWarnings("unchecked")
+            TypeConverter<Object> elementConverter = (TypeConverter<Object>) registry.get(elementType)
+                    .orElseThrow(() -> new RuntimeException("No converter found for array element type '" + elementType + "'"));
             return Optional.of(create(elementConverter, clsType.getComponentType()));
         }
 
         return Optional.empty();
     }
 
-    private static TypeConverter<?> create(TypeConverter elementConverter, Class type) {
+    private static TypeConverter<?> create(TypeConverter<Object> elementConverter, Class<?> type) {
         return value -> {
             value = value.trim();
             if (value.isEmpty()) {
                 return Array.newInstance(type, 0);
             }
             String[] elements = value.split(",");
-            Object[] ar = (Object[]) Array.newInstance(type, elements.length);
+            Object resultArray = Array.newInstance(type, elements.length);
+
+            final ObjIntConsumer<String> elementHandler;
+            if (type.isPrimitive()) {
+                if (type.equals(int.class)) {
+                    elementHandler = (s, idx) -> Array.setInt(resultArray, idx, (int) elementConverter.convert(s));
+                } else if (type.equals(long.class)) {
+                    elementHandler = (s, idx) -> Array.setLong(resultArray, idx, (long) elementConverter.convert(s));
+                } else if (type.equals(short.class)) {
+                    elementHandler = (s, idx) -> Array.setShort(resultArray, idx, (short) elementConverter.convert(s));
+                } else if (type.equals(byte.class)) {
+                    elementHandler = (s, idx) -> Array.setByte(resultArray, idx, (byte) elementConverter.convert(s));
+                } else if (type.equals(char.class)) {
+                    elementHandler = (s, idx) -> Array.setChar(resultArray, idx, (char) elementConverter.convert(s));
+                } else if (type.equals(boolean.class)) {
+                    elementHandler = (s, idx) -> Array.setBoolean(resultArray, idx, (boolean) elementConverter.convert(s));
+                } else if (type.equals(float.class)) {
+                    elementHandler = (s, idx) -> Array.setFloat(resultArray, idx, (float) elementConverter.convert(s));
+                } else if (type.equals(double.class)) {
+                    elementHandler = (s, idx) -> Array.setDouble(resultArray, idx, (double) elementConverter.convert(s));
+                } else {
+                    throw new UnsupportedOperationException("Unknown primitive type: " + type);
+                }
+            } else {
+                elementHandler = (s, idx) -> Array.set(resultArray, idx, elementConverter.convert(s));
+            }
 
             for (int i = 0; i < elements.length; i++) {
-                ar[i] = elementConverter.convert(elements[i]);
+                elementHandler.accept(elements[i], i);
             }
-            return ar;
+            return resultArray;
         };
     }
 }

--- a/archaius2-core/src/main/java/com/netflix/archaius/converters/DefaultCollectionsTypeConverterFactory.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/converters/DefaultCollectionsTypeConverterFactory.java
@@ -48,7 +48,7 @@ public final class DefaultCollectionsTypeConverterFactory implements TypeConvert
                         TreeSet::new,
                         Collections::emptySortedSet,
                         Collections::unmodifiableSortedSet));
-            } else if (parameterizedType.getRawType().equals(List.class)) {
+            } else if (parameterizedType.getRawType().equals(List.class) || parameterizedType.getRawType().equals(Collection.class)) {
                 return Optional.of(createCollectionTypeConverter(
                         parameterizedType.getActualTypeArguments()[0],
                         registry,

--- a/archaius2-core/src/main/java/com/netflix/archaius/converters/EnumTypeConverterFactory.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/converters/EnumTypeConverterFactory.java
@@ -10,18 +10,17 @@ public final class EnumTypeConverterFactory implements TypeConverter.Factory {
 
     private EnumTypeConverterFactory() {}
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     public Optional<TypeConverter<?>> get(Type type, TypeConverter.Registry registry) {
-        Class clsType = (Class) type;
-
-        if (clsType.isEnum()) {
-            return Optional.of(create(clsType));
+        if (type instanceof Class<?> && ((Class<?>) type).isEnum()) {
+            Class enumClass = (Class<?>) type;
+            return Optional.of(create(enumClass));
         }
-
         return Optional.empty();
     }
 
-    private static TypeConverter<?> create(Class clsType) {
+    private static <T extends Enum<T>> TypeConverter<T> create(Class<T> clsType) {
         return value -> Enum.valueOf(clsType, value);
     }
 }


### PR DESCRIPTION
If a ParameterizedType was passed to ArrayTypeConverterFactory or EnumTypeConverterFactory, a ClassCastException would be thrown when it attempted to unconditionally cast it to Class; update the factories to handle this more gracefully by just returning Optional.empty().

Additionally, update ArrayTypeConverterFactory to handle arrays of primitives, and add unit tests for Enums, arrays, and collections.