### PR TITLE
Make ArchaiusType equals / hashCode compatible with ParameterizedTypeImpl

### DIFF
--- a/archaius2-api/build.gradle
+++ b/archaius2-api/build.gradle
@@ -19,6 +19,7 @@ apply plugin: 'java-library'
 dependencies {
     api     'javax.inject:javax.inject:1'
     implementation     'org.slf4j:slf4j-api:1.7.36'
+    testImplementation 'junit:junit:4.13.2'
 }
 
 eclipse {

--- a/archaius2-api/src/test/java/com/netflix/archaius/api/ArchaiusTypeTest.java
+++ b/archaius2-api/src/test/java/com/netflix/archaius/api/ArchaiusTypeTest.java
@@ -1,0 +1,70 @@
+package com.netflix.archaius.api;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class ArchaiusTypeTest {
+    @Test
+    public void testEquals() {
+        ParameterizedType archaiusType = ArchaiusType.forListOf(String.class);
+        Assert.assertEquals(archaiusType, listOfString);
+        Assert.assertEquals(listOfString, archaiusType);
+        Assert.assertEquals(archaiusType, ArchaiusType.forListOf(String.class));
+        Assert.assertNotEquals(archaiusType, ArchaiusType.forListOf(Integer.class));
+        Assert.assertNotEquals(archaiusType, setOfLong);
+    }
+
+    @Test
+    public void testHashCode() {
+        Assert.assertEquals(listOfString.hashCode(), ArchaiusType.forListOf(String.class).hashCode());
+        Assert.assertEquals(ArchaiusType.forListOf(String.class).hashCode(), ArchaiusType.forListOf(String.class).hashCode());
+        Assert.assertEquals(setOfLong.hashCode(), ArchaiusType.forSetOf(Long.class).hashCode());
+        Assert.assertEquals(ArchaiusType.forMapOf(Integer.class, CharSequence.class).hashCode(), mapOfIntToCharSequence.hashCode());
+    }
+
+    @Test
+    public void testToString() {
+        Assert.assertEquals("java.util.List<java.lang.String>", ArchaiusType.forListOf(String.class).toString());
+        Assert.assertEquals(listOfString.toString(), ArchaiusType.forListOf(String.class).toString());
+        Assert.assertEquals(setOfLong.toString(), ArchaiusType.forSetOf(Long.class).toString());
+        Assert.assertEquals(mapOfIntToCharSequence.toString(), ArchaiusType.forMapOf(Integer.class, CharSequence.class).toString());
+    }
+
+    @Test
+    public void testPrimitiveType() {
+        Assert.assertEquals(setOfLong, ArchaiusType.forSetOf(long.class));
+    }
+
+    @Test
+    public void testGetTypeParameters() {
+        ParameterizedType archaiusType = ArchaiusType.forSetOf(Long.class);
+        Type[] typeArguments = archaiusType.getActualTypeArguments();
+        // check that returned array is defensively copied
+        Assert.assertNotSame(typeArguments, archaiusType.getActualTypeArguments());
+        Assert.assertEquals(1, typeArguments.length);
+        Assert.assertEquals(Long.class, typeArguments[0]);
+    }
+
+    private static List<String> listOfString() { throw new AssertionError(); }
+    private static Set<Long> setOfLong() { throw new AssertionError(); }
+    private static Map<Integer, CharSequence> mapOfIntToCharSequence() { throw new AssertionError(); }
+    private static final ParameterizedType listOfString;
+    private static final ParameterizedType setOfLong;
+    private static final ParameterizedType mapOfIntToCharSequence;
+
+    static {
+        try {
+            listOfString = (ParameterizedType) ArchaiusTypeTest.class.getDeclaredMethod("listOfString").getGenericReturnType();
+            setOfLong = (ParameterizedType) ArchaiusTypeTest.class.getDeclaredMethod("setOfLong").getGenericReturnType();
+            mapOfIntToCharSequence = (ParameterizedType) ArchaiusTypeTest.class.getDeclaredMethod("mapOfIntToCharSequence").getGenericReturnType();
+        } catch (NoSuchMethodException exc) {
+            throw new AssertionError("Method not found", exc);
+        }
+    }
+}


### PR DESCRIPTION
Make ArchaiusType's equals / hashCode / toString match what JDK's ParameterizedTypeImpl does, so that equivalent ParameterizedType instances hash and compare equal with ArchaiusType. Update toString to match what ParameterizedTypeImpl does as well.

Additionally, add do a defensive copy of the returned array in getActualTypeArguments, and add basic unit tests.