### PR TITLE
Add support for tracking individual properties' stack traces

### DIFF
--- a/archaius2-core/src/main/java/com/netflix/archaius/instrumentation/AccessMonitorUtil.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/instrumentation/AccessMonitorUtil.java
@@ -140,6 +140,15 @@ public class AccessMonitorUtil implements AutoCloseable {
         for (Map.Entry<String, Integer> entry : accessMonitorUtil.stackTrace.entrySet()) {
             stackTrace.merge(entry.getKey(), entry.getValue(), Integer::sum);
         }
+        for (Map.Entry<String, Set<String>> entry : accessMonitorUtil.trackedPropertyStackTraces.entrySet()) {
+            trackedPropertyStackTraces.merge(
+                    entry.getKey(),
+                    entry.getValue(),
+                    (oldSet, newSet) -> {
+                         oldSet.addAll(newSet);
+                         return oldSet;
+                    });
+        }
     }
 
     public void registerUsage(PropertyDetails propertyDetails) {

--- a/archaius2-core/src/main/java/com/netflix/archaius/instrumentation/AccessMonitorUtil.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/instrumentation/AccessMonitorUtil.java
@@ -9,7 +9,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -31,7 +30,7 @@ public class AccessMonitorUtil implements AutoCloseable {
     // Map from stack trace to how many times that stack trace appeared
     private final ConcurrentHashMap<String, Integer> stackTrace;
     // Property keys that we will keep the stack traces for
-    private Set<String> propertiesToTrack;
+    private volatile Set<String> propertiesToTrack;
     // Map from property key to stack traces map for tracked properties
     private final ConcurrentHashMap<String, Set<String>> trackedPropertyStackTraces;
 


### PR DESCRIPTION
Surface builder handle `setPropertiesToTrack`, AccessMonitorUtil handle `setPropertiesToTrack`, and `getTrackedPropertyTraces` to allow for tracking stack traces of specific properties and also pulling of the data when necessary.

We allow updating this on the fly for better fast property support