### PR TITLE
Refactor ConfigManagerTest to Include Assertions for Automated Validation

### DIFF
--- a/archaius2-core/src/test/java/com/netflix/archaius/ConfigManagerTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/ConfigManagerTest.java
@@ -15,6 +15,10 @@
  */
 package com.netflix.archaius;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.atomic.AtomicReference;
+
 import com.netflix.archaius.api.Property;
 import com.netflix.archaius.api.PropertyFactory;
 import com.netflix.archaius.config.DefaultCompositeConfig;
@@ -39,19 +43,26 @@ public class ConfigManagerTest {
                         .put("region", "us-east")
                         .put("c",      123)
                         .build()));
-        
-        
+
+
         PropertyFactory factory = DefaultPropertyFactory.from(config);
         
         Property<String> prop = factory.getProperty("abc").asString("defaultValue");
-        
+
+        // Use an AtomicReference to capture the property value change
+        AtomicReference<String> capturedValue = new AtomicReference<>("");
         prop.addListener(new DefaultPropertyListener<String>() {
             @Override
             public void onChange(String next) {
-                System.out.println("Configuration changed : " + next);
+                capturedValue.set(next);
             }
         });
-        
+
+        // Set property which should trigger the listener
         dyn.setProperty("abc", "${c}");
+
+        // Assert that the capturedValue was updated correctly
+        assertEquals("123", capturedValue.get(), "Configuration change did not occur as expected");
+
     }
 }


### PR DESCRIPTION
Fix #710 

Description:

This pull request introduces an enhancement to the ConfigManagerTest, specifically the testBasicReplacement method. Previously, this test method relied on manual verification of test outcomes through console output, which is not in line with automated testing best practices. To address this, the proposed changes refactor the test to utilize AtomicReference for capturing changes in property values and assert these changes using JUnit Jupiter's Assertions.assertEquals. This modification ensures that the test outcomes can be automatically and precisely validated, thus improving the overall reliability and efficiency of our testing process.

Key Changes:

* Utilized AtomicReference<String> to capture changes in property values within the test.
* Replaced manual console output verification with Assertions.assertEquals to automatically verify the expected behavior.
