### PR TITLE
Enhancing Clarity with assume API in Precondition Checks for `validatePropertyUpdates` and `validateApiWhenRemovingChild`

### DIFF
--- a/archaius2-core/src/test/java/com/netflix/archaius/config/DefaultLayeredConfigTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/DefaultLayeredConfigTest.java
@@ -29,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.spy;
@@ -76,9 +77,11 @@ public class DefaultLayeredConfigTest {
         config.addConfig(Layers.APPLICATION, child);
         
         // Validate initial state
-        assertEquals("propvalue", config.getProperty("propname").get());
-        assertEquals("propvalue", config.getRawProperty("propname"));
-        
+        assumeTrue("propvalue".equals(config.getProperty("propname").orElse(null)),
+                "Property 'propname' does not have the expected value 'propvalue', test assumptions not met.");
+        assumeTrue("propvalue".equals(config.getRawProperty("propname")),
+                "Raw property 'propname' does not have the expected value 'propvalue', test assumptions not met.");
+
         // Update the property value
         child.setProperty("propname", "propvalue2");
         
@@ -103,8 +106,10 @@ public class DefaultLayeredConfigTest {
         Mockito.verify(listener, Mockito.times(1)).onConfigUpdated(any());
         
         // Validate initial state
-        assertEquals("propvalue", config.getProperty("propname").get());
-        assertEquals("propvalue", config.getRawProperty("propname"));
+        assumeTrue("propvalue".equals(config.getProperty("propname").orElse(null)),
+                "Property 'propname' does not have the expected value 'propvalue', test assumptions not met.");
+        assumeTrue("propvalue".equals(config.getRawProperty("propname")),
+                "Raw property 'propname' does not have the expected value 'propvalue', test assumptions not met.");
         
         // Remove the child
         config.removeConfig(Layers.APPLICATION, child.getName());


### PR DESCRIPTION
Fix #712 

### Description
This PR introduces a minor enhancement to the test cases `validatePropertyUpdates` and `validateApiWhenRemovingChild` in the codebase. By replacing assert statements used for initial state validation with JUnit5's assumeTrue, we aim to improve the clarity and robustness of our tests. This approach helps in clearly distinguishing between precondition checks and the actual test assertions, thereby ensuring that tests proceed only when their preconditions are met. 

### Key Changes

* **Introduction of assumeTrue for Precondition Checks**:
Replaced assert statements with assumeTrue in the initial state validation sections of validatePropertyUpdates and validateApiWhenRemovingChild.
This ensures that tests are skipped rather than failed when initial conditions are not met, making test outcomes more accurate and meaningful.

* **Enhanced Test Clarity**:
By using assumeTrue, we make our test preconditions explicit. This clarity helps developers understand test intentions and preconditions at a glance.