### PR TITLE
Add getPropertiesUninstrumented endpoint for ConfigurationUtils

### DIFF
--- a/archaius-core/src/main/java/com/netflix/config/util/ConfigurationUtils.java
+++ b/archaius-core/src/main/java/com/netflix/config/util/ConfigurationUtils.java
@@ -123,19 +123,36 @@ public class ConfigurationUtils {
      * @return properties extracted from the configuration
      */
     public static Properties getProperties(Configuration config) {
- 	   Properties p = new Properties();
- 	   if (config != null){
-	 	   Iterator<String> it = config.getKeys();	 	   
-	 	   while (it.hasNext()){
-	 		   String key = it.next();
-	 		   if (key != null) {
-	 		      Object value = config.getProperty(key);
-                  if (value != null) {
-                      p.put(key, value);
-                  }	 		   }
-	 	   }
- 	   }
-  	   return p;
+        return getPropertiesInternal(config, true);
+    }
+
+    /**
+     * If possible, returns the Properties while avoiding instrumented fast property usage endpoints.
+     * @param config Configuration to get the properties
+     * @return properties extracted from the configuration
+     */
+    public static Properties getPropertiesUninstrumented(Configuration config) {
+        return getPropertiesInternal(config, false);
+    }
+
+    private static Properties getPropertiesInternal(Configuration config, boolean instrumented) {
+        Properties p = new Properties();
+        if (config != null){
+            Iterator<String> it = config.getKeys();
+            while (it.hasNext()){
+                String key = it.next();
+                if (key != null) {
+                    Object value =
+                            !instrumented && config instanceof InstrumentationAware
+                                    ? ((InstrumentationAware) config).getPropertyUninstrumented(key)
+                                    : config.getProperty(key);
+                    if (value != null) {
+                        p.put(key, value);
+                    }
+                }
+            }
+        }
+        return p;
     }
     
     public static void loadProperties(Properties props, Configuration config) {

--- a/archaius-core/src/main/java/com/netflix/config/util/InstrumentationAware.java
+++ b/archaius-core/src/main/java/com/netflix/config/util/InstrumentationAware.java
@@ -1,0 +1,6 @@
+package com.netflix.config.util;
+
+// Interface which surfaces instrumentation-related endpoints for configurations
+public interface InstrumentationAware {
+    Object getPropertyUninstrumented(String key);
+}


### PR DESCRIPTION
Add the ability for the Archaius2-Archaius1 bridge to go through an uninstrumented endpoint.

We create a separate endpoint here instead of changing the existing behavior so that we continue to be aware of cases that are iterating-over-all-properties and can respond accordingly, instead of blindly turning instrumentation off for all these cases.