### PR TITLE
Add uninstrumented endpoint for the Archaius2-Archaius1 bridge

### DIFF
--- a/archaius2-archaius1-bridge/build.gradle
+++ b/archaius2-archaius1-bridge/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     api  project(':archaius2-core')
     compileOnly  project(':archaius2-guice')
     api  project(':archaius2-commons-configuration')
-    api  'com.netflix.archaius:archaius-core:0.7.8'
+    api  'com.netflix.archaius:archaius-core:0.7.12'
 	
     testImplementation project(':archaius2-guice')
 }

--- a/archaius2-archaius1-bridge/src/main/java/com/netflix/archaius/bridge/AbstractConfigurationBridge.java
+++ b/archaius2-archaius1-bridge/src/main/java/com/netflix/archaius/bridge/AbstractConfigurationBridge.java
@@ -2,6 +2,8 @@ package com.netflix.archaius.bridge;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+
+import com.netflix.config.util.InstrumentationAware;
 import org.apache.commons.configuration.AbstractConfiguration;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.HierarchicalConfiguration;
@@ -32,7 +34,7 @@ import javax.inject.Singleton;
  * @see StaticArchaiusBridgeModule
  */
 @Singleton
-class AbstractConfigurationBridge extends AbstractConfiguration implements AggregatedConfiguration, DynamicPropertySupport {
+class AbstractConfigurationBridge extends AbstractConfiguration implements AggregatedConfiguration, DynamicPropertySupport, InstrumentationAware {
 
     private final Config config;
     private final SettableConfig settable;
@@ -92,6 +94,11 @@ class AbstractConfigurationBridge extends AbstractConfiguration implements Aggre
     @Override
     public Object getProperty(String key) {
         return config.getRawProperty(key);  // Should interpolate
+    }
+
+    @Override
+    public Object getPropertyUninstrumented(String key) {
+        return config.getRawPropertyUninstrumented(key);
     }
 
     @Override

--- a/archaius2-archaius1-bridge/src/main/java/com/netflix/archaius/bridge/StaticAbstractConfiguration.java
+++ b/archaius2-archaius1-bridge/src/main/java/com/netflix/archaius/bridge/StaticAbstractConfiguration.java
@@ -11,6 +11,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import com.netflix.config.util.InstrumentationAware;
 import org.apache.commons.configuration.AbstractConfiguration;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.event.ConfigurationEvent;
@@ -27,7 +28,7 @@ import com.netflix.config.PropertyListener;
  * @see StaticArchaiusBridgeModule
  */
 @Singleton
-public class StaticAbstractConfiguration extends AbstractConfiguration implements AggregatedConfiguration, DynamicPropertySupport {
+public class StaticAbstractConfiguration extends AbstractConfiguration implements AggregatedConfiguration, DynamicPropertySupport, InstrumentationAware {
     
     private static volatile AbstractConfigurationBridge delegate;
     
@@ -141,6 +142,16 @@ public class StaticAbstractConfiguration extends AbstractConfiguration implement
             return null;
         }
         return delegate.getProperty(key);
+    }
+
+    @Override
+    public Object getPropertyUninstrumented(String key) {
+        if (delegate == null) {
+            System.out.println(
+                    "[getPropertyUninstrumented(" + key + ")] StaticAbstractConfiguration not initialized yet.");
+            return null;
+        }
+        return delegate.getPropertyUninstrumented(key);
     }
 
     @Override


### PR DESCRIPTION
Implement InstrumentationAware from Archaius1 to allow Archaius1 calls to ConfigurationUtils that go through the bridge be uninstrumented when requested (per ConfigurationUtils.getPropertiesUninstrumented)