### PR TITLE
Update jackson deps

### DIFF
--- a/archaius2-persisted2/build.gradle
+++ b/archaius2-persisted2/build.gradle
@@ -18,8 +18,8 @@ apply plugin: 'java-library'
 
 dependencies {
     api  project(':archaius2-core')
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.4.3'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.4.3'
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.12.7'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.7'
     implementation 'javax.annotation:javax.annotation-api:1.3.2'
     implementation 'org.apache.commons:commons-lang3:3.3.2'
     implementation 'org.slf4j:slf4j-api:1.7.36'


### PR DESCRIPTION
There are some known issues with Jackson <2.8.11.5, so we update to a known safe version of Jackson