### PR TITLE
Fix instrumentation propagation of PrefixedViewConfigs

### DIFF
--- a/archaius2-core/src/main/java/com/netflix/archaius/config/AbstractDependentConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/AbstractDependentConfig.java
@@ -78,7 +78,7 @@ public abstract class AbstractDependentConfig extends AbstractConfig {
     @Override
     public void recordUsage(PropertyDetails propertyDetails) {
         if (getState().getInstrumentedKeys().containsKey(propertyDetails.getKey())) {
-            getState().getInstrumentedKeys().get(propertyDetails.getKey()).recordUsage(propertyDetails);
+            getState().getInstrumentedKeys().get(propertyDetails.getKey()).recordUsage(createPropertyDetails(propertyDetails.getKey(), propertyDetails.getValue()));
         }
     }
 

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/PrefixedViewConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/PrefixedViewConfig.java
@@ -48,19 +48,16 @@ public class PrefixedViewConfig extends AbstractDependentConfig {
         @Override
         public void onSourceConfigAdded(PrefixedViewConfig pvc, Config config) {
             pvc.updateState(config);
-            pvc.notifyConfigAdded(pvc);
         }
 
         @Override
         public void onSourceConfigRemoved(PrefixedViewConfig pvc, Config config) {
             pvc.updateState(config);
-            pvc.notifyConfigRemoved(pvc);
         }
 
         @Override
         public void onSourceConfigUpdated(PrefixedViewConfig pvc, Config config) {
             pvc.updateState(config);
-            pvc.notifyConfigUpdated(pvc);
         }
 
         @Override

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/PrefixedViewConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/PrefixedViewConfig.java
@@ -48,16 +48,19 @@ public class PrefixedViewConfig extends AbstractDependentConfig {
         @Override
         public void onSourceConfigAdded(PrefixedViewConfig pvc, Config config) {
             pvc.updateState(config);
+            pvc.notifyConfigAdded(pvc);
         }
 
         @Override
         public void onSourceConfigRemoved(PrefixedViewConfig pvc, Config config) {
             pvc.updateState(config);
+            pvc.notifyConfigRemoved(pvc);
         }
 
         @Override
         public void onSourceConfigUpdated(PrefixedViewConfig pvc, Config config) {
             pvc.updateState(config);
+            pvc.notifyConfigUpdated(pvc);
         }
 
         @Override


### PR DESCRIPTION
PrefixedViewConfigs, on updates from configs that it depends on, did not propagate updates to configs that depend on it, meaning any fast property updates for example would be lost. 

Example: For the situation of a CompositeConfig over a PrefixedViewConfig over an instrumented config, any accesses on the overarching CompositeConfig would not be properly re-prefixed with the PrefixedViewConfig when propagating instrumentation data to the instrumented config.

Consider CompositeConfig.getRawProperty("prop") for PrefixedViewConfig with prefix "prefix"

Previous behavior: Instrumented config tries to record usage for "prop", but that's not actually the property being accessed.
Fixed behavior: PrefixedViewConfig when passed through prepends "prefix." resulting in the expected "prefix.prop" being reported as accessed.