### PR TITLE
Handle numeric conversions for non-string raw values.

### DIFF
--- a/archaius2-core/src/test/java/com/netflix/archaius/config/AbstractConfigTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/AbstractConfigTest.java
@@ -16,7 +16,9 @@
 package com.netflix.archaius.config;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.function.BiConsumer;
 
 import org.junit.jupiter.api.Test;
@@ -27,9 +29,20 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 public class AbstractConfigTest {
 
     private final AbstractConfig config = new AbstractConfig() {
+        private final Map<String, Object> entries = new HashMap<>();
+
+        {
+            entries.put("foo", "bar");
+            entries.put("byte", (byte) 42);
+            entries.put("int", 42);
+            entries.put("long", 42L);
+            entries.put("float", 42.0f);
+            entries.put("double", 42.0d);
+        }
+
         @Override
         public boolean containsKey(String key) {
-            return "foo".equals(key);
+            return entries.containsKey(key);
         }
 
         @Override
@@ -39,35 +52,90 @@ public class AbstractConfigTest {
 
         @Override
         public Iterator<String> getKeys() {
-            return Collections.singletonList("foo").iterator();
+            return Collections.unmodifiableSet(entries.keySet()).iterator();
         }
 
         @Override
         public Object getRawProperty(String key) {
-            if ("foo".equals(key)) {
-                return "bar";
-            }
-            return null;
+            return entries.get(key);
         }
 
         @Override
         public void forEachProperty(BiConsumer<String, Object> consumer) {
-            consumer.accept("foo",  "bar");
+            entries.forEach(consumer);
         }
     };
 
     @Test
-    public void testGet() throws Exception {
+    public void testGet() {
         assertEquals("bar", config.get(String.class, "foo"));
     }
     
     @Test
     public void getExistingProperty() {
+        //noinspection OptionalGetWithoutIsPresent
         assertEquals("bar", config.getProperty("foo").get());
     }
     
     @Test
     public void getNonExistentProperty() {
         assertFalse(config.getProperty("non_existent").isPresent());
+    }
+
+    @Test
+    public void testGetRawNumerics() {
+        // First, get each entry as its expected type and the corresponding wrapper.
+        assertEquals(42, config.get(int.class, "int"));
+        assertEquals(42, config.get(Integer.class, "int"));
+        assertEquals(42L, config.get(long.class, "long"));
+        assertEquals(42L, config.get(Long.class, "long"));
+        assertEquals((byte) 42, config.get(byte.class, "byte"));
+        assertEquals((byte) 42, config.get(Byte.class, "byte"));
+        assertEquals(42.0f, config.get(float.class, "float"));
+        assertEquals(42.0f, config.get(Float.class, "float"));
+        assertEquals(42.0d, config.get(double.class, "double"));
+        assertEquals(42.0d, config.get(Double.class, "double"));
+
+        // Then, get each entry as a string
+        assertEquals("42", config.get(String.class, "int"));
+        assertEquals("42", config.get(String.class, "long"));
+        assertEquals("42", config.get(String.class, "byte"));
+        assertEquals("42.0", config.get(String.class, "float"));
+        assertEquals("42.0", config.get(String.class, "double"));
+
+        // Then, narrowed types
+        assertEquals((byte) 42, config.get(byte.class, "int"));
+        assertEquals((byte) 42, config.get(byte.class, "long"));
+        assertEquals((byte) 42, config.get(byte.class, "float"));
+        assertEquals((byte) 42, config.get(byte.class, "double"));
+        assertEquals(42.0f, config.get(double.class, "double"));
+
+        // Then, widened
+        assertEquals(42L, config.get(long.class, "int"));
+        assertEquals(42L, config.get(long.class, "byte"));
+        assertEquals(42L, config.get(long.class, "float"));
+        assertEquals(42L, config.get(long.class, "double"));
+        assertEquals(42.0d, config.get(double.class, "float"));
+
+        // On floating point
+        assertEquals(42.0f, config.get(float.class, "int"));
+        assertEquals(42.0f, config.get(float.class, "byte"));
+        assertEquals(42.0f, config.get(float.class, "long"));
+        assertEquals(42.0f, config.get(float.class, "double"));
+
+        // As doubles
+        assertEquals(42.0d, config.get(double.class, "int"));
+        assertEquals(42.0d, config.get(double.class, "byte"));
+        assertEquals(42.0d, config.get(double.class, "long"));
+        assertEquals(42.0d, config.get(double.class, "float"));
+
+        // Narrowed types in wrapper classes
+        assertEquals((byte) 42, config.get(Byte.class, "int"));
+        assertEquals((byte) 42, config.get(Byte.class, "long"));
+        assertEquals((byte) 42, config.get(Byte.class, "float"));
+
+        // Widened types in wrappers
+        assertEquals(42L, config.get(Long.class, "int"));
+        assertEquals(42L, config.get(Long.class, "byte"));
     }
 }

--- a/archaius2-core/src/test/java/com/netflix/archaius/config/MapConfigTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/MapConfigTest.java
@@ -184,6 +184,15 @@ public class MapConfigTest {
     }
 
     @Test
+    public void numericInterpolationShouldWork_withNonStringValues() {
+        Config config = MapConfig.builder()
+                .put("default",     123)
+                .put("value",       "${default}")
+                .build();
+        assertEquals(123L, (long) config.getLong("value"));
+    }
+
+    @Test
     public void getKeys() {
         Map<String, String> props = new HashMap<>();
         props.put("key1", "value1");


### PR DESCRIPTION
For implementations of AbstractConfig that return non-string values from getRawProperty(), be smarter about doing numeric conversions. Without this, users are forced to guess if the property source will interpret a given number as an integer or a long and code to that, instead of to the types that make sense for their own use case.

Fixes: #653