### PR TITLE
Skip static methods on config interfaces

### DIFF
--- a/archaius2-core/src/main/java/com/netflix/archaius/ConfigProxyFactory.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/ConfigProxyFactory.java
@@ -23,6 +23,7 @@ import java.lang.invoke.MethodType;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.Proxy;
 import java.lang.reflect.Type;
 import java.util.Collections;
@@ -232,6 +233,9 @@ public class ConfigProxyFactory {
         // Each setter will be mapped to a Property<T> for the property name:
         //      prefix + lowerCamelCaseDerivedPropertyName
         for (Method method : type.getMethods()) {
+            if (Modifier.isStatic(method.getModifiers())) {
+                continue;
+            }
             MethodInvokerHolder methodInvokerHolder = buildInvokerForMethod(type, prefix, method, proxyObject, immutable);
 
             propertyNames.put(method, methodInvokerHolder.propertyName);

--- a/archaius2-core/src/test/java/com/netflix/archaius/ProxyFactoryTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/ProxyFactoryTest.java
@@ -650,4 +650,28 @@ public class ProxyFactoryTest {
         assertEquals(5, proxy.intValue());
         assertEquals("BLAH", proxy.customValue().value());
     }
+
+    @Configuration(prefix = "config")
+    public interface ConfigWithStaticMethods {
+        @PropertyName(name = "foo")
+        @DefaultValue("foo-value")
+        String foo();
+
+        static String bar() {
+            return "bar-value";
+        }
+
+        static int baz(int x) {
+            return x + 1;
+        }
+    }
+
+    @Test
+    public void testInterfaceWithStaticMethods() {
+        SettableConfig config = new DefaultSettableConfig();
+        config.setProperty("config.foo", "foo-value-updated");
+        ConfigProxyFactory proxyFactory = new ConfigProxyFactory(config, config.getDecoder(), DefaultPropertyFactory.from(config));
+        ConfigWithStaticMethods configWithStaticMethods = proxyFactory.newProxy(ConfigWithStaticMethods.class);
+        assertEquals("foo-value-updated", configWithStaticMethods.foo());
+    }
 }


### PR DESCRIPTION
Skip over static methods declared on config interfaces when constructing the proxy in ConfigProxyFactory.