### PR TITLE
Implement hashCode for PropertyDetails

### DIFF
--- a/archaius2-api/src/main/java/com/netflix/archaius/api/PropertyDetails.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/api/PropertyDetails.java
@@ -27,6 +27,11 @@ public class PropertyDetails {
         return value;
     }
 
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, id, value);
+    }
+
     public boolean equals(Object o) {
         if (!(o instanceof PropertyDetails)) {
             return false;


### PR DESCRIPTION
Implement hashCode for PropertyDetails since it already overrides equals.

See: https://errorprone.info/bugpattern/EqualsHashCode