### PR TITLE
Small performance and memory usage tweaks

### DIFF
--- a/archaius2-api/src/main/java/com/netflix/archaius/api/Decoder.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/api/Decoder.java
@@ -20,6 +20,9 @@ import java.lang.reflect.Type;
 /**
  * API for decoding properties to arbitrary types.
  *
+ * @implSpec Implementations of this interface MUST be idempotent. Failing to do so will result in correctness errors.
+ *    Implementations of this interface SHOULD also be cheap to execute. Expensive or blocking operations are to be
+ *    avoided since they can potentially cause large delays in property resolution.
  * @author spencergibb
  */
 public interface Decoder {

--- a/archaius2-api/src/main/java/com/netflix/archaius/api/StrInterpolator.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/api/StrInterpolator.java
@@ -26,7 +26,11 @@ package com.netflix.archaius.api;
  *  interpolator.create(lookup).resolve("123-${foo}") -> 123-abc
  * }
  * </pre>
- * 
+ *
+ * @implSpec Implementations of this interface MUST be idempotent (as long as the backing Config remains unchanged).
+ *    Failing to do so will result in correctness errors.
+ *    Implementations of this interface SHOULD also be cheap to execute. Expensive or blocking operations are to be
+ *    avoided since they can potentially cause large delays in property resolution.
  * @author elandau
  *
  */
@@ -38,7 +42,7 @@ public interface StrInterpolator {
      * 
      * @author elandau
      */
-    public interface Lookup {
+     interface Lookup {
         String lookup(String key);
     }
 
@@ -47,14 +51,11 @@ public interface StrInterpolator {
      * @author elandau
      *
      */
-    public interface Context {
+     interface Context {
         /**
          * Resolve a string with replaceable variables using the provided map to lookup replacement
          * values.  The implementation should deal with nested replacements and throw an exception
          * for infinite recursion. 
-         * 
-         * @param value
-         * @return
          */
         String resolve(String value);
     }

--- a/archaius2-core/src/main/java/com/netflix/archaius/AbstractProperty.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/AbstractProperty.java
@@ -3,6 +3,11 @@ package com.netflix.archaius;
 import com.netflix.archaius.api.Property;
 import com.netflix.archaius.api.PropertyListener;
 
+/** @deprecated This class has no known users and doesn't offer any actual advantage over implementing {@link Property}
+ * directly. Scheduled to be removed by the end of 2025.
+ **/
+@Deprecated
+// TODO Remove by the end of 2025
 public abstract class AbstractProperty<T> implements Property<T> {
 
     private final String key;

--- a/archaius2-core/src/main/java/com/netflix/archaius/DelegatingProperty.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/DelegatingProperty.java
@@ -3,6 +3,12 @@ package com.netflix.archaius;
 import com.netflix.archaius.api.Property;
 import com.netflix.archaius.api.PropertyListener;
 
+/**
+ * Base class for Property implementations that delegate to another Property.
+ * @deprecated There are no known implementations of this class. To be removed by the end of 2025
+ */
+@Deprecated
+// TODO Remove by the end of 2025
 public abstract class DelegatingProperty<T> implements Property<T> {
 
     protected Property<T> delegate;


### PR DESCRIPTION
Refactor PropertyImpl#get() to avoid an allocation on each call. The new implementation should be marginally faster.

Removed a few unnecessary objects from each instance of Property objects returned from the DefaultPropertyFactory. This will remove a few dozen bytes from each Property instance.