### PR TITLE
Add support for parsing Collections and Maps from the Spring YML format

### DIFF
--- a/archaius2-api/src/main/java/com/netflix/archaius/api/ArchaiusType.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/api/ArchaiusType.java
@@ -3,6 +3,7 @@ package com.netflix.archaius.api;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -79,6 +80,14 @@ public final class ArchaiusType implements ParameterizedType {
     @Override
     public Type getRawType() {
         return rawType;
+    }
+
+    public boolean isMap() {
+        return Map.class.isAssignableFrom(rawType);
+    }
+
+    public boolean isCollection() {
+        return Collection.class.isAssignableFrom(rawType);
     }
 
     @Override

--- a/archaius2-api/src/main/java/com/netflix/archaius/api/ArchaiusType.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/api/ArchaiusType.java
@@ -3,7 +3,6 @@ package com.netflix.archaius.api;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -81,15 +80,6 @@ public final class ArchaiusType implements ParameterizedType {
     public Type getRawType() {
         return rawType;
     }
-
-    public boolean isMap() {
-        return Map.class.isAssignableFrom(rawType);
-    }
-
-    public boolean isCollection() {
-        return Collection.class.isAssignableFrom(rawType);
-    }
-
     @Override
     public Type getOwnerType() {
         return null;

--- a/archaius2-api/src/main/java/com/netflix/archaius/api/ArchaiusType.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/api/ArchaiusType.java
@@ -80,6 +80,7 @@ public final class ArchaiusType implements ParameterizedType {
     public Type getRawType() {
         return rawType;
     }
+
     @Override
     public Type getOwnerType() {
         return null;

--- a/archaius2-core/src/test/java/com/netflix/archaius/ProxyFactoryTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/ProxyFactoryTest.java
@@ -438,6 +438,37 @@ public class ProxyFactoryTest {
                     containsString("getAnIntWithParam")));
     }
 
+    @Test
+    public void testSpringYmlCollections() {
+        config.setProperty("list[0]", "1");
+        config.setProperty("list[1]", 2);
+        config.setProperty("list[2]", "3");
+
+        config.setProperty("set[0]", "1");
+        config.setProperty("set[1]", "2");
+        config.setProperty("set[2]", 3);
+        config.setProperty("set[3]", "3");
+
+        config.setProperty("map.key1", "1");
+        config.setProperty("map.key2", 2);
+        config.setProperty("map.key3", "3");
+
+        ConfigWithSpringCollections configWithSpringCollections = proxyFactory.newProxy(ConfigWithSpringCollections.class);
+        assertEquals(Arrays.asList("1", "2", "3"), configWithSpringCollections.getList());
+
+        Set<Integer> set = configWithSpringCollections.getSet();
+        assertEquals(3, set.size());
+        assertTrue(set.contains(1));
+        assertTrue(set.contains(2));
+        assertTrue(set.contains(3));
+
+        Map<String, Integer> map = configWithSpringCollections.getMap();
+        assertEquals(3, map.size());
+        assertEquals(1, map.get("key1"));
+        assertEquals(2, map.get("key2"));
+        assertEquals(3, map.get("key3"));
+    }
+
 
     //////////////////////////////////////////////////////////////////
     /// Test Interfaces
@@ -665,5 +696,11 @@ public class ProxyFactoryTest {
 
         // A parametrized method requires a @PropertyName annotation
         int getAnIntWithParam(String param);
+    }
+
+    public interface ConfigWithSpringCollections {
+        List<String> getList();
+        Set<Integer> getSet();
+        Map<String, Integer> getMap();
     }
 }

--- a/archaius2-core/src/test/java/com/netflix/archaius/config/AbstractConfigTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/AbstractConfigTest.java
@@ -61,6 +61,8 @@ public class AbstractConfigTest {
             entries.put("springYmlList[0]", "1");
             entries.put("springYmlList[1]", "2");
             entries.put("springYmlList[2]", "3");
+            // Repeated entry to distinguish set and list
+            entries.put("springYmlList[3]", "3");
             entries.put("springYmlMap.key1", "1");
             entries.put("springYmlMap.key2", "2");
             entries.put("springYmlMap.key3", "3");
@@ -242,7 +244,7 @@ public class AbstractConfigTest {
 
         List<Integer> list =
                 config.get(ArchaiusType.forListOf(Integer.class), "springYmlList", Arrays.asList(1));
-        assertEquals(Arrays.asList(1, 2, 3), list);
+        assertEquals(Arrays.asList(1, 2, 3, 3), list);
 
         Map<String, Integer> map =
                 config.get(ArchaiusType.forMapOf(String.class, Integer.class),
@@ -257,6 +259,11 @@ public class AbstractConfigTest {
                 config.get(ArchaiusType.forListOf(Integer.class), "springYmlMap", Arrays.asList(1));
         assertEquals(invalidList, Arrays.asList(1));
 
+        // Not a proper set, so we have the default value returned
+        Set<Integer> invalidSet =
+                config.get(ArchaiusType.forSetOf(Integer.class), "springYmlMap", Collections.singleton(1));
+        assertEquals(invalidSet, Collections.singleton(1));
+
         // Not a proper map, so we have the default value returned
         Map<String, String> invalidMap =
                 config.get(
@@ -265,18 +272,5 @@ public class AbstractConfigTest {
                         Collections.singletonMap("default", "default"));
         assertEquals(1, invalidMap.size());
         assertEquals("default", invalidMap.get("default"));
-
-        // Some illegal values, so we return with those filtered
-        List<String> listWithSomeInvalid =
-                config.get(ArchaiusType.forListOf(String.class), "springYmlWithSomeInvalidList", Arrays.asList("bad"));
-        assertEquals(listWithSomeInvalid, Arrays.asList("abc", "a=b"));
-
-        Map<String, String> mapWithSomeInvalid =
-                config.get(
-                        ArchaiusType.forMapOf(String.class, String.class),
-                        "springYmlWithSomeInvalidMap",
-                        Collections.emptyMap());
-        assertEquals(1, mapWithSomeInvalid.size());
-        assertEquals("c", mapWithSomeInvalid.get("key2"));
     }
 }

--- a/archaius2-core/src/test/java/com/netflix/archaius/config/AbstractConfigTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/AbstractConfigTest.java
@@ -21,9 +21,12 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.BiConsumer;
 
+import com.netflix.archaius.api.ArchaiusType;
 import com.netflix.archaius.api.Config;
 import com.netflix.archaius.api.ConfigListener;
 import com.netflix.archaius.exceptions.ParseException;
@@ -35,6 +38,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -54,6 +58,18 @@ public class AbstractConfigTest {
             entries.put("stringList", "a,b,c");
             entries.put("uriList", "http://example.com,http://example.org");
             entries.put("underlyingList", Arrays.asList("a", "b", "c"));
+            entries.put("springYmlList[0]", "1");
+            entries.put("springYmlList[1]", "2");
+            entries.put("springYmlList[2]", "3");
+            entries.put("springYmlMap.key1", "1");
+            entries.put("springYmlMap.key2", "2");
+            entries.put("springYmlMap.key3", "3");
+            entries.put("springYmlWithSomeInvalidList[0]", "abc,def");
+            entries.put("springYmlWithSomeInvalidList[1]", "abc");
+            entries.put("springYmlWithSomeInvalidList[2]", "a=b");
+            entries.put("springYmlWithSomeInvalidMap.key1", "a=b");
+            entries.put("springYmlWithSomeInvalidMap.key2", "c");
+            entries.put("springYmlWithSomeInvalidMap.key3", "d,e");
         }
 
         @Override
@@ -212,5 +228,55 @@ public class AbstractConfigTest {
             verify(listener).onConfigRemoved(mockChildConfig);
             verify(listener).onError(mockError, mockChildConfig);
         }
+    }
+
+    @Test
+    public void testSpringYml() {
+        // Working cases for set, list, and map
+        Set<Integer> set =
+                config.get(ArchaiusType.forSetOf(Integer.class), "springYmlList", Collections.singleton(1));
+        assertEquals(set.size(), 3);
+        assertTrue(set.contains(1));
+        assertTrue(set.contains(2));
+        assertTrue(set.contains(3));
+
+        List<Integer> list =
+                config.get(ArchaiusType.forListOf(Integer.class), "springYmlList", Arrays.asList(1));
+        assertEquals(Arrays.asList(1, 2, 3), list);
+
+        Map<String, Integer> map =
+                config.get(ArchaiusType.forMapOf(String.class, Integer.class),
+                        "springYmlMap", Collections.emptyMap());
+        assertEquals(map.size(), 3);
+        assertEquals(1, map.get("key1"));
+        assertEquals(2, map.get("key2"));
+        assertEquals(3, map.get("key3"));
+
+        // Not a proper list, so we have the default value returned
+        List<Integer> invalidList =
+                config.get(ArchaiusType.forListOf(Integer.class), "springYmlMap", Arrays.asList(1));
+        assertEquals(invalidList, Arrays.asList(1));
+
+        // Not a proper map, so we have the default value returned
+        Map<String, String> invalidMap =
+                config.get(
+                        ArchaiusType.forMapOf(String.class, String.class),
+                        "springYmlList",
+                        Collections.singletonMap("default", "default"));
+        assertEquals(1, invalidMap.size());
+        assertEquals("default", invalidMap.get("default"));
+
+        // Some illegal values, so we return with those filtered
+        List<String> listWithSomeInvalid =
+                config.get(ArchaiusType.forListOf(String.class), "springYmlWithSomeInvalidList", Arrays.asList("bad"));
+        assertEquals(listWithSomeInvalid, Arrays.asList("abc", "a=b"));
+
+        Map<String, String> mapWithSomeInvalid =
+                config.get(
+                        ArchaiusType.forMapOf(String.class, String.class),
+                        "springYmlWithSomeInvalidMap",
+                        Collections.emptyMap());
+        assertEquals(1, mapWithSomeInvalid.size());
+        assertEquals("c", mapWithSomeInvalid.get("key2"));
     }
 }

--- a/archaius2-core/src/test/java/com/netflix/archaius/config/AbstractConfigTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/config/AbstractConfigTest.java
@@ -61,6 +61,9 @@ public class AbstractConfigTest {
             entries.put("springYmlList[0]", "1");
             entries.put("springYmlList[1]", "2");
             entries.put("springYmlList[2]", "3");
+            entries.put("springYmlIntList[0]", 1);
+            entries.put("springYmlIntList[1]", 2);
+            entries.put("springYmlIntList[2]", 3);
             // Repeated entry to distinguish set and list
             entries.put("springYmlList[3]", "3");
             entries.put("springYmlMap.key1", "1");
@@ -246,6 +249,10 @@ public class AbstractConfigTest {
                 config.get(ArchaiusType.forListOf(Integer.class), "springYmlList", Arrays.asList(1));
         assertEquals(Arrays.asList(1, 2, 3, 3), list);
 
+        List<Integer> intList =
+                config.get(ArchaiusType.forListOf(Integer.class), "springYmlIntList", Arrays.asList(1));
+        assertEquals(Arrays.asList(1, 2, 3), intList);
+
         Map<String, Integer> map =
                 config.get(ArchaiusType.forMapOf(String.class, Integer.class),
                         "springYmlMap", Collections.emptyMap());
@@ -272,5 +279,14 @@ public class AbstractConfigTest {
                         Collections.singletonMap("default", "default"));
         assertEquals(1, invalidMap.size());
         assertEquals("default", invalidMap.get("default"));
+    }
+
+    @Test
+    public void testSpringYamlAsNormalValue() {
+        // Confirm that values that are intended to be read as a Spring YML Map can still be read normally
+        // and also do not return values when read at the top level as anything other than a map.
+        assertEquals("1", config.get(String.class, "springYmlMap.key1"));
+        assertEquals(2, config.get(Integer.class, "springYmlMap.key2"));
+        assertEquals(false, config.containsKey("springYmlMap"));
     }
 }


### PR DESCRIPTION
Add support for understanding the Spring YML (YamlPropertiesFactoryBean) way of parsing YML files via the Archaius endpoints. This supports the ConfigProxy and PropertyRepository as these all are eventually backed by AbstractConfig. 

This enables all existing Archaius read methods to read multi-line/multi-property maps and arrays as specified by Spring.

Spring YML files are converted to configs from this yml file
```yml
test:
    map:
        key1: 1
        key2: 2
        key3: 3
    stringList:
        - a
        - b
        - c
```

To these configs:
```
test.map.key1=1
test.map.key2=2
test.map.key3=3
test.stringList[0]=a
test.stringList[1]=b
test.stringList[2]=c
```