### PR TITLE
Swallow exceptions when calling toString on ConfigProxy objects

### DIFF
--- a/archaius2-api/src/main/java/com/netflix/archaius/api/Property.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/api/Property.java
@@ -60,15 +60,6 @@ public interface Property<T> extends Supplier<T> {
     T get();
 
     /**
-     * Return the most recent value of the property, swallowing any exceptions that occur.
-     *
-     * @return  Most recent value for the property
-     */
-    default T getSwallowErrors() {
-        return get();
-    }
-
-    /**
      * Add a listener that will be called whenever the property value changes.
      * @implNote Implementors of this interface MUST override this method or {@link #subscribe(Consumer)}.
      * @deprecated Use {@link Property#subscribe(Consumer)} instead

--- a/archaius2-api/src/main/java/com/netflix/archaius/api/Property.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/api/Property.java
@@ -60,6 +60,15 @@ public interface Property<T> extends Supplier<T> {
     T get();
 
     /**
+     * Return the most recent value of the property, swallowing any exceptions that occur.
+     *
+     * @return  Most recent value for the property
+     */
+    default T getSwallowErrors() {
+        return get();
+    }
+
+    /**
      * Add a listener that will be called whenever the property value changes.
      * @implNote Implementors of this interface MUST override this method or {@link #subscribe(Consumer)}.
      * @deprecated Use {@link Property#subscribe(Consumer)} instead

--- a/archaius2-core/src/main/java/com/netflix/archaius/ConfigProxyFactory.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/ConfigProxyFactory.java
@@ -499,9 +499,15 @@ public class ConfigProxyFactory {
                 return value != null ? value : defaultValueSupplier.apply(null);
             }
 
+            @SuppressWarnings({"unchecked"})
             @Override
             public T invokeSwallowErrors(Object[] args) {
-                T value = prop.getSwallowErrors();
+                T value;
+                if (prop instanceof DefaultPropertyFactory.ErrorSwallowingProperty) {
+                    value = ((DefaultPropertyFactory.ErrorSwallowingProperty<T>) prop).getSwallowErrors();
+                } else {
+                    value = prop.get();
+                }
                 return value != null ? value : defaultValueSupplier.apply(null);
             }
         };

--- a/archaius2-core/src/main/java/com/netflix/archaius/ConfigProxyFactory.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/ConfigProxyFactory.java
@@ -203,7 +203,7 @@ public class ConfigProxyFactory {
          */
         T invoke(Object[] args);
 
-        default T invokeSwallowErrors(Object[] args) {
+        default T invokeIgnoreErrors(Object[] args) {
             return invoke(args);
         }
     }
@@ -501,10 +501,10 @@ public class ConfigProxyFactory {
 
             @SuppressWarnings({"unchecked"})
             @Override
-            public T invokeSwallowErrors(Object[] args) {
+            public T invokeIgnoreErrors(Object[] args) {
                 T value;
-                if (prop instanceof DefaultPropertyFactory.ErrorSwallowingProperty) {
-                    value = ((DefaultPropertyFactory.ErrorSwallowingProperty<T>) prop).getSwallowErrors();
+                if (prop instanceof DefaultPropertyFactory.ErrorIgnoringProperty) {
+                    value = ((DefaultPropertyFactory.ErrorIgnoringProperty<T>) prop).getIgnoreErrors();
                 } else {
                     value = prop.get();
                 }
@@ -630,7 +630,7 @@ public class ConfigProxyFactory {
             try {
                 // This call should fail for parameterized properties, because the PropertyValueGetter has a non-empty
                 // argument list. Fortunately, the implementation there cooperates with us and returns a null instead :-)
-                propertyValue = entry.getValue().invokeSwallowErrors(null);
+                propertyValue = entry.getValue().invokeIgnoreErrors(null);
             } catch (Exception e) {
                 // Just in case
                 propertyValue = e.getMessage();

--- a/archaius2-core/src/main/java/com/netflix/archaius/ConfigProxyFactory.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/ConfigProxyFactory.java
@@ -202,6 +202,10 @@ public class ConfigProxyFactory {
          * Invoke the method with the provided arguments
          */
         T invoke(Object[] args);
+
+        default T invokeSwallowErrors(Object[] args) {
+            return invoke(args);
+        }
     }
 
     /**
@@ -488,9 +492,18 @@ public class ConfigProxyFactory {
     protected <T> PropertyValueGetter<T> createScalarProperty(final Type type, final String propName, Function<Object[], T> defaultValueSupplier) {
         LOG.debug("Creating scalar property `{}` for type `{}`", propName, type.getClass());
         final Property<T> prop = propertyRepository.get(propName, type);
-        return args -> {
-            T value = prop.get();
-            return value != null ? value : defaultValueSupplier.apply(null);
+        return new PropertyValueGetter<T>() {
+            @Override
+            public T invoke(Object[] args) {
+                T value = prop.get();
+                return value != null ? value : defaultValueSupplier.apply(null);
+            }
+
+            @Override
+            public T invokeSwallowErrors(Object[] args) {
+                T value = prop.getSwallowErrors();
+                return value != null ? value : defaultValueSupplier.apply(null);
+            }
         };
     }
 
@@ -611,7 +624,7 @@ public class ConfigProxyFactory {
             try {
                 // This call should fail for parameterized properties, because the PropertyValueGetter has a non-empty
                 // argument list. Fortunately, the implementation there cooperates with us and returns a null instead :-)
-                propertyValue = entry.getValue().invoke(null);
+                propertyValue = entry.getValue().invokeSwallowErrors(null);
             } catch (Exception e) {
                 // Just in case
                 propertyValue = e.getMessage();

--- a/archaius2-core/src/main/java/com/netflix/archaius/DefaultPropertyFactory.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/DefaultPropertyFactory.java
@@ -131,11 +131,15 @@ public class DefaultPropertyFactory implements PropertyFactory, ConfigListener {
         return (Property<T>) properties.computeIfAbsent(keyAndType, (ignore) -> new PropertyImpl<>(keyAndType, supplier));
     }
 
+    interface ErrorSwallowingProperty<T> {
+        T getSwallowErrors();
+    }
+
     /**
      * Implementation of the Property interface. This class looks at the factory's masterVersion on each read to
      * determine if the cached parsed values is stale.
      */
-    private final class PropertyImpl<T> implements Property<T> {
+    private final class PropertyImpl<T> implements Property<T>, ErrorSwallowingProperty<T> {
 
         private final KeyAndType<T> keyAndType;
         private final Supplier<T> supplier;


### PR DESCRIPTION
We are currently running into an issue where a user has extended the ConfigProxy interface in a custom manner, adding support for, effectively, Map<String, JSONObject>. We do not support this kind of map (as our decoders assume that a single value is decoded into values, instead of collapsing a tree into a single object).

We want to avoid unnecessary logging for this case, so specifically for the toString call on ConfigProxy objects, we choose to swallow exceptions.