### PR TITLE
Avoid unconditionally casting a Consumer as a PropertyListener

### DIFF
--- a/archaius2-api/src/main/java/com/netflix/archaius/api/Property.java
+++ b/archaius2-api/src/main/java/com/netflix/archaius/api/Property.java
@@ -99,7 +99,7 @@ public interface Property<T> extends Supplier<T> {
      * @return Subscription that may be unsubscribed to no longer get change notifications
      */
     default Subscription subscribe(Consumer<T> consumer) {
-        PropertyListener<T> listener = (PropertyListener<T>) consumer;
+        PropertyListener<T> listener = consumer::accept;
         
         addListener(listener);
         return () -> removeListener(listener);

--- a/archaius2-core/src/test/java/com/netflix/archaius/property/PropertyTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/property/PropertyTest.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -664,6 +665,40 @@ public class PropertyTest {
         assertEquals(expectedMap, secondReference.get());
 
         ensureReferencesMatch(firstReference, secondReference);
+    }
+
+    @Test
+    public void testDefaultInterfaceSubscription() {
+        List<PropertyListener<?>> listeners = new CopyOnWriteArrayList<>();
+
+        Property<Integer> prop = new Property<Integer>() {
+            @Override
+            public Integer get() {
+                return 0;
+            }
+
+            @Override
+            public String getKey() {
+                return "";
+            }
+
+            @Override
+            public void addListener(PropertyListener<Integer> listener) {
+                listeners.add(listener);
+            }
+
+            @Override
+            public void removeListener(PropertyListener<Integer> listener) {
+                listeners.remove(listener);
+            }
+        };
+
+
+        Subscription s = prop.subscribe((ignore) -> {});
+        assertEquals(1, listeners.size(), "We expected to see a listener after subscribing");
+
+        s.unsubscribe();
+        assertEquals(0, listeners.size(), "We expected to see no listeners after unsubscribing");
     }
 
     @Test


### PR DESCRIPTION
Fixes #745