### PR TITLE
Update DefaultCompositeConfig to send the correct object when updating listeners

### DIFF
--- a/archaius2-core/src/main/java/com/netflix/archaius/config/AbstractConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/AbstractConfig.java
@@ -198,6 +198,7 @@ public abstract class AbstractConfig implements Config {
         }
 
         if (value instanceof String) {
+            // todo: inconsistent with above
             return resolve(value.toString());
         } else {
             return value.toString();

--- a/archaius2-core/src/main/java/com/netflix/archaius/config/DefaultCompositeConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/DefaultCompositeConfig.java
@@ -247,7 +247,7 @@ public class DefaultCompositeConfig extends AbstractDependentConfig implements c
     protected void postConfigAdded(Config child) {
         child.setStrInterpolator(getStrInterpolator());
         child.setDecoder(getDecoder());
-        notifyConfigAdded(child);
+        notifyConfigAdded(this);
         child.addListener(listener);
     }
 
@@ -267,7 +267,7 @@ public class DefaultCompositeConfig extends AbstractDependentConfig implements c
         if (child != null) {
             state = state.removeConfig(name);
             child.removeListener(listener);
-            this.notifyConfigRemoved(child);
+            this.notifyConfigRemoved(this);
         }
         return child;
     }    


### PR DESCRIPTION
Dependent views (e.g. PrefixedViewConfig and the PrivateViewConfig) look at the object being passed when there is a new config added or updated. However, currently the DefaultCompositeConfig passes the config being added/removed instead of itself. That means the PrefixedViewConfig/PrivateViewConfig will be updated to JUST the values of the added/removed config (which is either wrong, or very wrong). 

This PR updates DefaultCompositeConfig to correctly pass itself.

Interestingly enough, the DefaultLayeredConfig actually just calls configUpdated (with itself) when there are equivalent such adds/removes.