### PR TITLE
Remove final flush of instrumentation data from the AccessMonitorUtil

### DIFF
--- a/archaius2-core/src/main/java/com/netflix/archaius/instrumentation/AccessMonitorUtil.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/instrumentation/AccessMonitorUtil.java
@@ -202,6 +202,5 @@ public class AccessMonitorUtil implements AutoCloseable {
     @Override
     public void close() {
         executor.shutdown();
-        flushUsageData();
     }
 }


### PR DESCRIPTION
The instrumentation flushing feature in the AccessMonitorUtil is meant to be as non-invasive as possible. However, we currently have calls outside the dedicated threadpool when shutting down the AccessMonitorUtil. The intention here was to make sure we aren't missing any instrumentation data that accrued at the end, but this also puts a call on the main thread (which could have issues such as blocking JVM shutdown on hangs).

So, we choose to be non-invasive over completeness of information. To be clear, it's quite unlikely that we will actually be losing data in any meaningful way (since property usage is generally either at startup, or just throughout the uptime of an application, meaning that any instrumentation dropped in the last window is very likely to have been seen already).