### PR TITLE
archaius2-core: fix 'occured' -> 'occurred' typos in JDCConfigReader close-error logs

### DIFF
--- a/archaius2-core/src/main/java/com/netflix/archaius/readers/JDCConfigReader.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/readers/JDCConfigReader.java
@@ -135,7 +135,7 @@ public class JDCConfigReader implements Callable<Map<String, Object>> {
                 rs.close();
             }
         } catch (SQLException e) {
-            log.error("An error occured on closing the ResultSet", e);
+            log.error("An error occurred on closing the ResultSet", e);
         }
 
         try {
@@ -143,7 +143,7 @@ public class JDCConfigReader implements Callable<Map<String, Object>> {
                 stmt.close();
             }
         } catch (SQLException e) {
-            log.error("An error occured on closing the statement", e);
+            log.error("An error occurred on closing the statement", e);
         }
 
         try {
@@ -151,7 +151,7 @@ public class JDCConfigReader implements Callable<Map<String, Object>> {
                 conn.close();
             }
         } catch (SQLException e) {
-            log.error("An error occured on closing the connection", e);
+            log.error("An error occurred on closing the connection", e);
         }
     }
 }


### PR DESCRIPTION
Three `log.error` messages in `archaius2-core/src/main/java/com/netflix/archaius/readers/JDCConfigReader.java` (lines 138, 146, 154) read `An error occured on closing the ResultSet / statement / connection`. String-literal-only change.