### PR TITLE
reject malformed map entries in collections type converter

### DIFF
--- a/archaius2-core/src/main/java/com/netflix/archaius/converters/DefaultCollectionsTypeConverterFactory.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/converters/DefaultCollectionsTypeConverterFactory.java
@@ -2,6 +2,7 @@ package com.netflix.archaius.converters;
 
 import com.netflix.archaius.api.TypeConverter;
 import com.netflix.archaius.exceptions.ConverterNotFoundException;
+import com.netflix.archaius.exceptions.ParseException;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -106,9 +107,13 @@ public final class DefaultCollectionsTypeConverterFactory implements TypeConvert
                     .stream(s.split("\\s*,\\s*"))
                     .filter(pair -> !pair.isEmpty())
                     .map(pair -> pair.split("\\s*=\\s*"))
-                    .forEach(kv -> result.put(
-                            keyConverter.convert(kv[0]),
-                            valueConverter.convert(kv[1])));
+                    .forEach(kv -> {
+                        if (kv.length != 2) {
+                            throw new ParseException("Error parsing map entry '" + String.join("=", kv) + "'",
+                                    new Exception("Expected 'key=value'"));
+                        }
+                        result.put(keyConverter.convert(kv[0]), valueConverter.convert(kv[1]));
+                    });
             return Collections.unmodifiableMap(result);
         };
     }

--- a/archaius2-core/src/test/java/com/netflix/archaius/DefaultDecoderTest.java
+++ b/archaius2-core/src/test/java/com/netflix/archaius/DefaultDecoderTest.java
@@ -51,9 +51,12 @@ import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
 import org.junit.jupiter.api.Test;
 
+import com.netflix.archaius.exceptions.ParseException;
+
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
@@ -132,6 +135,8 @@ public class DefaultDecoderTest {
         assertEquals(Collections.singleton(2L), decoder.decode(setOfLongType, "2,2,2,2"));
         assertEquals(Collections.emptyMap(), decoder.decode(mapofStringToIntegerType, ""));
         assertEquals(Collections.singletonMap("key", 12345), decoder.decode(mapofStringToIntegerType, "key=12345"));
+        // A map entry without a '=' separator is rejected with a clear error instead of crashing
+        assertThrows(ParseException.class, () -> decoder.decode(mapofStringToIntegerType, "key=12345,bogus"));
     }
 
     @Test


### PR DESCRIPTION
createMapTypeConverter in DefaultCollectionsTypeConverterFactory splits each comma-separated pair on '=' and reads kv[1] without checking the split produced two parts, so a Map property value like `key=12345,bogus` throws ArrayIndexOutOfBoundsException from inside the converter. Reject the malformed entry with a ParseException instead, matching how convertBoolean already rejects unparseable input.