### PR TITLE
make setter fields volatile for concurrent decoder modification

### DIFF
--- a/archaius2-core/src/main/java/com/netflix/archaius/config/AbstractConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/AbstractConfig.java
@@ -51,8 +51,8 @@ public abstract class AbstractConfig implements Config {
     private static final Logger log = LoggerFactory.getLogger(AbstractConfig.class);
     private final CopyOnWriteArrayList<ConfigListener> listeners = new CopyOnWriteArrayList<>();
     private final Lookup lookup;
-    private Decoder decoder;
-    private StrInterpolator interpolator;
+    private volatile Decoder decoder;
+    private volatile StrInterpolator interpolator;
     private String listDelimiter = ",";
     private final String name;
     


### PR DESCRIPTION
 ## Summary
  
* decoder and interpolator in AbstractConfig can be updated at runtime via setDecoder() / setStrInterpolator(). Without volatile, the JVM is not required to flush a write on one thread to main memory, so other threads may observe stale values indefinitely.
* Marking both fields volatile establishes the necessary happens-before relationship: any write is immediately visible to all subsequent reads across threads.
* volatile is the right level of synchronization here — both setters are simple unconditional single-field assignments with no compound read-modify-write, so no additional atomicity guarantee is needed.