### PR TITLE
make listDelimiter volatile

### DIFF
--- a/archaius2-core/src/main/java/com/netflix/archaius/config/AbstractConfig.java
+++ b/archaius2-core/src/main/java/com/netflix/archaius/config/AbstractConfig.java
@@ -53,7 +53,7 @@ public abstract class AbstractConfig implements Config {
     private final Lookup lookup;
     private volatile Decoder decoder;
     private volatile StrInterpolator interpolator;
-    private String listDelimiter = ",";
+    private volatile String listDelimiter = ",";
     private final String name;
     
     private static final AtomicInteger idCounter = new AtomicInteger();


### PR DESCRIPTION
reading the change that made decoder and interpolator volatile, listDelimiter is the third setter-backed field in AbstractConfig with the same shape: setListDelimiter writes it and getListDelimiter reads it (CommonsToConfig joins on it from the read path). it was missed, so a write still has no happens-before with reads on other threads and a stale delimiter can be observed indefinitely. same single-assignment setter, so volatile is the right level here too.